### PR TITLE
Javadocs and Comments

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPool.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPool.java
@@ -38,8 +38,8 @@ import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
  * will derive a {@link HystrixThreadPoolKey} from the injected {@link HystrixCommandGroupKey}.
  * <p>
  * The pool should be sized large enough to handle normal healthy traffic but small enough that it will constrain concurrent execution if backend calls become latent.
- * 
- * // TODO put link to wiki for docs on how to tune the threadpool
+ * <p>
+ * For more information see the Github Wiki: https://github.com/Netflix/Hystrix/wiki/Configuration#wiki-ThreadPool and https://github.com/Netflix/Hystrix/wiki/How-it-Works#wiki-Isolation
  */
 public interface HystrixThreadPool {
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixRollingPercentile.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixRollingPercentile.java
@@ -59,8 +59,6 @@ public class HystrixRollingPercentile {
     private final HystrixProperty<Integer> numberOfBuckets;
     private final HystrixProperty<Integer> bucketDataLength;
 
-    // TODO add property overrides in constructor and set defaults using HystrixProperties with strategy pattern
-
     /*
      * This will get flipped each time a new bucket is created.
      */


### PR DESCRIPTION
Javadoc link to Wiki
Removed unnecessary comment since the constructor how accepts HystrixProperty objects
