### PR TITLE
Initialize HealthCounts to non-null value.

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
@@ -25,6 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import org.junit.Test;
 
+import com.netflix.hystrix.HystrixCommandMetrics.HealthCounts;
 import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifierDefault;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
 
@@ -172,14 +173,15 @@ public interface HystrixCircuitBreaker {
             }
 
             // we're closed, so let's see if errors have made us so we should trip the circuit open
-
+            HealthCounts health = metrics.getHealthCounts();
+            
             // check if we are past the statisticalWindowVolumeThreshold
-            if (metrics.getHealthCounts().getTotalRequests() < properties.circuitBreakerRequestVolumeThreshold().get()) {
+            if (health.getTotalRequests() < properties.circuitBreakerRequestVolumeThreshold().get()) {
                 // we are not past the minimum volume threshold for the statisticalWindow so we'll return false immediately and not calculate anything
                 return false;
             }
 
-            if (metrics.getHealthCounts().getErrorPercentage() < properties.circuitBreakerErrorThresholdPercentage().get()) {
+            if (health.getErrorPercentage() < properties.circuitBreakerErrorThresholdPercentage().get()) {
                 return false;
             } else {
                 // our failure rate is too high, trip the circuit

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
@@ -334,7 +334,7 @@ public class HystrixCommandMetrics {
         }
     }
 
-    private volatile HealthCounts healthCountsSnapshot = null;
+    private volatile HealthCounts healthCountsSnapshot = new HealthCounts(0, 0, 0);
     private volatile AtomicLong lastHealthCountsSnapshot = new AtomicLong(System.currentTimeMillis());
 
     /**


### PR DESCRIPTION
In a stress test I was doing that pounds a circuit immediately after creation it would have thread contention on the compareAndSet, one thread would go to create it, the other(s) would go to the else and return null and cause an NPE when trying to use it.
The losing threads should get the originally initialized value set to 0.
