### PR TITLE
Fixing non-deterministic unit test

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -4398,7 +4398,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             protected Boolean run() {
                 System.out.println("***** running");
                 try {
-                    Thread.sleep(timeout * 2);
+                    Thread.sleep(timeout * 10);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Intermittent failures have been occurring where command executions succeed when they're supposed to timeout.

Increasing the time the thread sleeps so thread scheduling has less chance to affect this.
