### PR TITLE
Make javax.servlet-api a 'provided' dependency not 'compile'

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/build.gradle
+++ b/hystrix-contrib/hystrix-metrics-event-stream/build.gradle
@@ -2,5 +2,5 @@
     dependencies {
         compile project(':hystrix-core')
         compile 'org.codehaus.jackson:jackson-core-asl:1.9.2'
-        provided 'javax.servlet:javax.servlet-api:3.0.1'
+        compile 'javax.servlet:servlet-api:2.5'
     }

--- a/hystrix-contrib/hystrix-request-servlet/build.gradle
+++ b/hystrix-contrib/hystrix-request-servlet/build.gradle
@@ -1,5 +1,5 @@
     apply plugin: 'java'
     dependencies {
         compile project(':hystrix-core')
-        provided 'javax.servlet:javax.servlet-api:3.0.1'
+        compile 'javax.servlet:servlet-api:2.5'
     }


### PR DESCRIPTION
Make javax.servlet-api a 'provided' dependency for compilation but not transitive.

Trying to make it so it doesn't force a servlet version or a specific jar. Nothing about the implementation requires anything higher than Servlet 2.x.
