### PR TITLE
Making provided scope transtive

### DIFF
--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -57,8 +57,8 @@ subprojects { project ->
     configurations {
         provided {
             description = 'much like compile, but indicates you expect the JDK or a container to provide it. It is only available on the compilation classpath, and is not transitive.'
-            transitive = false
-            visible = false
+            transitive = true
+            visible = true
         }
     }
 


### PR DESCRIPTION
Internally junit:junit:4.10 actually points to junit:junit-dep:4.10. And that single hop is where things were breaking. This commit will fix all transitive issues related to the provided scope.

I'd actually recommend changing all junit:junit references to junit:junit-dep. The problem with junit:junit is that it bundles hamcrest in it, so you're limited in your ability to include a better hamcrest matching libraries since junit pollutes the classpath.
