### PR TITLE
Make servlet-api a provided dependency

### DIFF
--- a/hystrix-dashboard/build.gradle
+++ b/hystrix-dashboard/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'war'
 
     dependencies {
-        compile 'javax.servlet:servlet-api:2.5'
+        provided 'javax.servlet:servlet-api:2.5'
         compile 'org.apache.httpcomponents:httpclient:4.2.1'
         compile 'log4j:log4j:1.2.17'
         compile 'org.slf4j:slf4j-api:1.7.0'


### PR DESCRIPTION
Tomcat is complaining about the included servlet-api-2.5.jar in the Hystrix Dashboard.

```
INFO: validateJarFile(/opt/apache-tomcat-7.0.33/webapps/hystrix-dashboard-1.1.8-SNAPSHOT/WEB-INF/lib/servlet-api-2.5.jar) - jar not loaded. See Servlet Spec 2.3, section 9.7.2. Offending class: javax/servlet/Servlet.class
```

I've changed it to provided as done in https://github.com/Netflix/Hystrix/pull/50 for other subprojects.
