### PR TITLE
Force character encoding for event stream to utf-8

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
@@ -102,7 +102,7 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
                 }
 
                 /* initialize response */
-                response.setHeader("Content-Type", "text/event-stream");
+                response.setHeader("Content-Type", "text/event-stream;charset=UTF-8");
                 response.setHeader("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate");
                 response.setHeader("Pragma", "no-cache");
 


### PR DESCRIPTION
Hi,

This change fixed an "EventSource's response has a charset ("iso-8859-1") that is not UTF-8. Aborting the connection." error in Dashboard for me.

Br,
-Mikko
