### PR TITLE
Add `with-context` macro for conviently wrapping collapsers in thier own context

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
+++ b/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
@@ -227,7 +227,7 @@
 
 ;################################################################################
 
-(defmacro with-context
+(defmacro with-request-context
   "Executes body within a new Hystrix Context"
   [& body]
   `(let [context# (HystrixRequestContext/initializeContext)]

--- a/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
+++ b/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
@@ -104,7 +104,7 @@
         (is (= (- 99 42) (.execute c)))))
 
     (testing "makes a HystrixCommand that implements getCacheKey"
-      (with-context
+      (with-request-context
         (let [call-count (atom 0) ; make sure run-fn is only called once
                test-def (normalize (assoc base-def
                                      :run-fn       (fn [arg] (swap! call-count inc) (str arg "!"))


### PR DESCRIPTION
Closes #132
