### PR TITLE
Update clojuresque and remove test shutdown hack.

### DIFF
--- a/hystrix-contrib/hystrix-clj/build.gradle
+++ b/hystrix-contrib/hystrix-clj/build.gradle
@@ -3,7 +3,7 @@
             mavenRepo name: 'clojars', url: 'http://clojars.org/repo'
         }
         dependencies {
-            classpath 'clojuresque:clojuresque:1.5.4'
+            classpath 'clojuresque:clojuresque:1.5.8'
         }
     }
     apply plugin: 'clojure'

--- a/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
+++ b/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
@@ -16,16 +16,6 @@
 
 (use-fixtures :each request-context-fixture)
 
-; In the end, reset Hystrix so that Clojuresque will exit after running tests.
-(defn hystrix-reset-fixture
-  [f]
-  (try
-    (f)
-    (finally
-      (com.netflix.hystrix.Hystrix/reset))))
-
-(use-fixtures :once hystrix-reset-fixture)
-
 (deftest test-command-key
   (testing "returns nil when input is nil"
     (is (nil? (command-key nil))))


### PR DESCRIPTION
Clojuresque 1.5.8 addresses the issue with Clojure tests never
finishing. Now it does an explicit System.exit() to ensure the tests
finish even if there are threads hanging around.
