### PR TITLE
Updates HystrixCommand to expose an isCommandTimedOut() method.

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -969,6 +969,15 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         return executionResult.events.contains(HystrixEventType.SUCCESS);
     }
 
+	/**
+	 * Whether the <code>run()</code> resulted in a failure (exception).
+	 *
+	 * @return boolean
+	 */
+	public boolean isFailedExecution() {
+		return executionResult.events.contains(HystrixEventType.FAILURE);
+	}
+
     /**
      * Whether the <code>run()</code> timed out during execution.
      * 


### PR DESCRIPTION
Updates HystrixCommand to expose an isCommandTimedOut() method, which can be helpful when determining what to do inside of getFallback().
