### PR TITLE
Allow getFallback to query failure states

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -1121,17 +1121,19 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             if (properties.fallbackEnabled().get()) {
                 /* fallback behavior is permitted so attempt */
                 try {
+                    // record the executionResult
+                    // do this before executing fallback so it can be queried from within getFallback (see See https://github.com/Netflix/Hystrix/pull/144)
+                    executionResult = executionResult.addEvents(eventType);
+
                     // retrieve the fallback
                     R fallback = getFallbackWithProtection();
                     // mark fallback on counter
                     metrics.markFallbackSuccess();
                     // record the executionResult
-                    executionResult = executionResult.addEvents(eventType, HystrixEventType.FALLBACK_SUCCESS);
+                    executionResult = executionResult.addEvents(HystrixEventType.FALLBACK_SUCCESS);
                     return executionHook.onComplete(this, fallback);
                 } catch (UnsupportedOperationException fe) {
                     logger.debug("No fallback for HystrixCommand. ", fe); // debug only since we're throwing the exception and someone higher will do something with it
-                    // record the executionResult
-                    executionResult = executionResult.addEvents(eventType);
 
                     /* executionHook for all errors */
                     try {
@@ -1145,7 +1147,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                     logger.error("Error retrieving fallback for HystrixCommand. ", fe);
                     metrics.markFallbackFailure();
                     // record the executionResult
-                    executionResult = executionResult.addEvents(eventType, HystrixEventType.FALLBACK_FAILURE);
+                    executionResult = executionResult.addEvents(HystrixEventType.FALLBACK_FAILURE);
 
                     /* executionHook for all errors */
                     try {
@@ -1230,6 +1232,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
          * @return
          */
         public ExecutionResult addEvents(HystrixEventType... events) {
+            // TODO are there performance reasons for this be changed to a persistent or concurrent data structure so we can append without copying?
             ArrayList<HystrixEventType> newEvents = new ArrayList<HystrixEventType>();
             newEvents.addAll(this.events);
             for (HystrixEventType e : events) {
@@ -1868,37 +1871,6 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             // force properties to be clean as well
             ConfigurationManager.getConfigInstance().clear();
         }
-
-	    @Test
-	    public void testExecutionTimeoutValue() {
-		    HystrixCommand.Setter properties = HystrixCommand.Setter
-				.withGroupKey(HystrixCommandGroupKey.Factory.asKey("TestKey"))
-				.andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-					.withExecutionIsolationThreadTimeoutInMilliseconds(1000))
-		    ;
-
-	        HystrixCommand<String> command = new HystrixCommand<String>(properties) {
-		        @Override
-		        protected String run() throws Exception {
-			        Thread.sleep(3000);
-
-			        String value = "1";
-			        value += "23";
-			        
-			        // should never reach here
-			        return value;
-		        }
-
-		        @Override
-		        protected String getFallback() {
-			        assertTrue("expected response to be timed out", isResponseTimedOut());
-			        return "abc";
-		        }
-	        };
-
-		    assertEquals("expected fallback value", "abc", command.execute());
-		    assertTrue("expected response to be timed out", command.isResponseTimedOut());
-	    }
 
         /**
          * Test a successful command execution.
@@ -5423,6 +5395,37 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(100, commandDisabled.builder.metrics.getHealthCounts().getErrorPercentage());
 
             assertEquals(2, HystrixRequestLog.getCurrentRequest().getExecutedCommands().size());
+        }
+
+        @Test
+        public void testExecutionTimeoutValue() {
+            HystrixCommand.Setter properties = HystrixCommand.Setter
+                    .withGroupKey(HystrixCommandGroupKey.Factory.asKey("TestKey"))
+                    .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                            .withExecutionIsolationThreadTimeoutInMilliseconds(50));
+
+            HystrixCommand<String> command = new HystrixCommand<String>(properties) {
+                @Override
+                protected String run() throws Exception {
+                    Thread.sleep(3000);
+                    // should never reach here
+                    return "hello";
+                }
+
+                @Override
+                protected String getFallback() {
+                    if (isResponseTimedOut()) {
+                        return "timed-out";
+                    } else {
+                        return "abc";
+                    }
+                }
+            };
+
+            String value = command.execute();
+            assertTrue(command.isResponseTimedOut());
+            assertEquals("expected fallback value", "timed-out", value);
+
         }
 
         /* ******************************************************************************** */


### PR DESCRIPTION
Merges unit test from @UnquietCode and fixes bug that prevented `getFallback` from querying failure states such as  timeout, rejected, etc.

See https://github.com/Netflix/Hystrix/pull/144 
