### PR TITLE
escape meta-characters to fix dashboard

### DIFF
--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
@@ -73,7 +73,7 @@
 				
 				if(data && data.type == 'HystrixCommand') {
 					if (data.deleteData == 'true') {
-						deleteCircuit(data.name);
+						deleteCircuit(data.escapedName);
 					} else {
 						displayCircuit(data);
 					}
@@ -87,13 +87,13 @@
 		 */
 		function preProcessData(data) {
 			validateData(data);
-			// clean up the 'name' field so it doesn't have invalid characters
-			data.name = data.name.replace(/[.:-]/g,'_');
+			// escape string used in jQuery & d3 selectors
+			data.escapedName = data.name.replace(/([ !"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g,'\\$1');
 			// do math
 			converAllAvg(data);
 			calcRatePerSecond(data);
 		}
-		
+
 		/**
 		 * Since the stream of data can be aggregated from multiple hosts in a tiered manner
 		 * the aggregation just sums everything together and provides us the denominator (reportingHosts)
@@ -208,7 +208,7 @@
 			
 			var addNew = false;
 			// check if we need to create the container
-			if(!$('#CIRCUIT_' + data.name).length) {
+			if(!$('#CIRCUIT_' + data.escapedName).length) {
 				// args for display
 				if(self.args.includeDetailIcon != undefined && self.args.includeDetailIcon) {
 					data.includeDetailIcon = true;
@@ -224,7 +224,7 @@
 				$('#' + containerId + '').append(html);
 				
 				// add the default sparkline graph
-				d3.selectAll('#graph_CIRCUIT_' + data.name + ' svg').append("svg:path");
+				d3.selectAll('#graph_CIRCUIT_' + data.escapedName + ' svg').append("svg:path");
 				
 				// remember this is new so we can trigger a sort after setting data
 				addNew = true;
@@ -232,7 +232,7 @@
 			
 			
 			// now update/insert the data
-			$('#CIRCUIT_' + data.name + ' div.monitor_data').html(tmpl(hystrixTemplateCircuit, data));
+			$('#CIRCUIT_' + data.escapedName + ' div.monitor_data').html(tmpl(hystrixTemplateCircuit, data));
 			
 			var ratePerSecond = data.ratePerSecond;
 			var ratePerSecondPerHost = data.ratePerSecondPerHost;
@@ -240,19 +240,19 @@
 			var errorThenVolume = (data.errorPercentage * 100000000) +  ratePerSecond;
 			
 			// set the rates on the div element so it's available for sorting
-			$('#CIRCUIT_' + data.name).attr('rate_value', ratePerSecond);
-			$('#CIRCUIT_' + data.name).attr('error_then_volume', errorThenVolume);
+			$('#CIRCUIT_' + data.escapedName).attr('rate_value', ratePerSecond);
+			$('#CIRCUIT_' + data.escapedName).attr('error_then_volume', errorThenVolume);
 			
 			// update errorPercentage color on page
-			$('#CIRCUIT_' + data.name + ' a.errorPercentage').css('color', self.circuitErrorPercentageColorRange(data.errorPercentage));
+			$('#CIRCUIT_' + data.escapedName + ' a.errorPercentage').css('color', self.circuitErrorPercentageColorRange(data.errorPercentage));
 			
-			updateCircle('circuit', '#CIRCUIT_' + data.name + ' circle', ratePerSecondPerHostDisplay, data.errorPercentage);
+			updateCircle('circuit', '#CIRCUIT_' + data.escapedName + ' circle', ratePerSecondPerHostDisplay, data.errorPercentage);
 			
 			if(data.graphValues) {
 				// we have a set of values to initialize with
-				updateSparkline('circuit', '#CIRCUIT_' + data.name + ' path', data.graphValues);
+				updateSparkline('circuit', '#CIRCUIT_' + data.escapedName + ' path', data.graphValues);
 			} else {
-				updateSparkline('circuit', '#CIRCUIT_' + data.name + ' path', ratePerSecond);
+				updateSparkline('circuit', '#CIRCUIT_' + data.escapedName + ' path', ratePerSecond);
 			}
 
 			if(addNew) {

--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/templates/hystrixCircuitContainer.html
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/templates/hystrixCircuitContainer.html
@@ -26,13 +26,15 @@
 
 	<script>
 		var y = 200;
-		var vis = d3.select("#chart_CIRCUIT_<%= name %>").append("svg:svg").attr("width", "100%").attr("height", "100%");
+		/* escape with two backslashes */
+		var vis = d3.select("#chart_CIRCUIT_<%= name.replace(/([ !"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g,'\\\\$1') %>").append("svg:svg").attr("width", "100%").attr("height", "100%");
 		/* add a circle -- we don't use the data point, we set it manually, so just passing in [1] */
 		var circle = vis.selectAll("circle").data([1]).enter().append("svg:circle");
 		/* setup the initial styling and sizing of the circle */
 		circle.style("fill", "green").attr("cx", "30%").attr("cy", "30%").attr("r", 5);
 		
 		/* add the line graph - it will be populated by javascript, no default to show here */
-		var graph = d3.select("#graph_CIRCUIT_<%= name %>").append("svg:svg").attr("width", "100%").attr("height", "100%");
+		/* escape with two backslashes */
+		var graph = d3.select("#graph_CIRCUIT_<%= name.replace(/([ !"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g,'\\\\$1') %>").append("svg:svg").attr("width", "100%").attr("height", "100%");
 	</script>
 </div>

--- a/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/hystrixThreadPool.js
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/hystrixThreadPool.js
@@ -68,7 +68,7 @@
 				
 				if(data && data.type == 'HystrixThreadPool') {
 					if (data.deleteData == 'true') {
-						deleteThreadPool(data.name);
+						deleteThreadPool(data.escapedName);
 					} else {
 						displayThreadPool(data);
 					}
@@ -82,8 +82,8 @@
 		 */
 		function preProcessData(data) {
 			validateData(data);
-			// clean up the 'name' field so it doesn't have invalid characters
-			data.name = data.name.replace(/[.:-]/g,'_');
+			// escape string used in jQuery & d3 selectors
+			data.escapedName = data.name.replace(/([ !"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g,'\\$1');
 			// do math
 			converAllAvg(data);
 			calcRatePerSecond(data);
@@ -167,7 +167,7 @@
 			
 			var addNew = false;
 			// check if we need to create the container
-			if(!$('#THREAD_POOL_' + data.name).length) {
+			if(!$('#THREAD_POOL_' + data.escapedName).length) {
 				// it doesn't exist so add it
 				var html = tmpl(htmlTemplateContainer, data);
 				// remove the loading thing first
@@ -180,17 +180,17 @@
 				$('#' + containerId + ' div.monitor').last().addClass('last');
 				
 				// add the default sparkline graph
-				d3.selectAll('#graph_THREAD_POOL_' + data.name + ' svg').append("svg:path");
+				d3.selectAll('#graph_THREAD_POOL_' + data.escapedName + ' svg').append("svg:path");
 				
 				// remember this is new so we can trigger a sort after setting data
 				addNew = true;
 			}
 			
 			// set the rate on the div element so it's available for sorting
-			$('#THREAD_POOL_' + data.name).attr('rate_value', data.ratePerSecondPerHost);
+			$('#THREAD_POOL_' + data.escapedName).attr('rate_value', data.ratePerSecondPerHost);
 			
 			// now update/insert the data
-			$('#THREAD_POOL_' + data.name + ' div.monitor_data').html(tmpl(htmlTemplate, data));
+			$('#THREAD_POOL_' + data.escapedName + ' div.monitor_data').html(tmpl(htmlTemplate, data));
 
 			// set variables for circle visualization
 			var rate = data.ratePerSecondPerHost;
@@ -198,7 +198,7 @@
 			// ie. 5 threads in queue per instance == 5% error percentage
 			var errorPercentage = data.currentQueueSize / data.reportingHosts; 
 			
-			updateCircle('#THREAD_POOL_' + data.name + ' circle', rate, errorPercentage);
+			updateCircle('#THREAD_POOL_' + data.escapedName + ' circle', rate, errorPercentage);
 			
 			if(addNew) {
 				// sort since we added a new circuit
@@ -244,8 +244,8 @@
 				.style("fill", self.colorRange(errorPercentage));
 		}
 		
-		/* private */ function deleteThreadPool(circuitName) {
-			$('#THREAD_POOL_' + circuitName).remove();
+		/* private */ function deleteThreadPool(poolName) {
+			$('#THREAD_POOL_' + poolName).remove();
 		}
 		
 	}

--- a/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/templates/hystrixThreadPoolContainer.html
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/templates/hystrixThreadPoolContainer.html
@@ -23,7 +23,8 @@
 			var errorPercentageData = [99];
 		<% } %>
 		var y = 200;
-		var vis = d3.select("#chart_THREAD_POOL_<%= name %>").append("svg:svg").attr("width", "100%").attr("height", "100%");
+		/* escape with two backslashes */
+		var vis = d3.select("#chart_THREAD_POOL_<%= name.replace(/([ !"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g,'\\\\$1') %>").append("svg:svg").attr("width", "100%").attr("height", "100%");
 		/* add a circle -- we don't use the data point, we set it manually, so just passing in [1] */
 		var circle = vis.selectAll("circle").data([1]).enter().append("svg:circle");
 		/* setup the initial styling and sizing of the circle */


### PR DESCRIPTION
I want to solve #100 and #125 in a proper way rather than directly replacing 'invalid characters'.

By looking at the code, diagram flooding is caused by:
https://github.com/Netflix/Hystrix/blob/master/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js#L211
https://github.com/Netflix/Hystrix/blob/master/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/hystrixThreadPool.js#L170

The selectors do not work as expected due to [meta-characters](http://api.jquery.com/category/selectors/). Although replacing those meta-characters would work to prevent flooding, it will cause further bug since different meta-characters on the same position of two different commands lead to the same command name (e.g. both my:command and my-command will reduce to my_command).

A clean approach is to escape those meta-characters in command name when used in selectors. Another advantage of this way is that original command/thread pool name can be displayed on the web page.

This patch creates escapedName in data object and replaces occurrences of original name in selectors.
