### PR TITLE
Upgrade to RxJava 0.10.0

### DIFF
--- a/hystrix-core/build.gradle
+++ b/hystrix-core/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'idea'
 
 dependencies {
     compile 'com.netflix.archaius:archaius-core:0.4.1'
-    compile 'com.netflix.rxjava:rxjava-core:0.9.0'
+    compile 'com.netflix.rxjava:rxjava-core:0.10.0'
     compile 'org.slf4j:slf4j-api:1.7.0'
     compile 'com.google.code.findbugs:jsr305:2.0.0'
     provided 'junit:junit-dep:4.10'

--- a/hystrix-core/src/main/java/com/netflix/hystrix/collapser/RequestBatch.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/collapser/RequestBatch.java
@@ -185,7 +185,14 @@ public class RequestBatch<BatchReturnType, ResponseType, RequestArgumentType> {
         }
 
         @Override
-        public void onError(Exception e) {
+        public void onError(Throwable t) {
+            Exception e = null;
+            if (t instanceof Exception) {
+                e = (Exception) t;
+            } else {
+                // Hystrix 1.x uses Exception, not Throwable so to prevent a breaking change Throwable will be wrapped in Exception
+                e = new Exception("Throwable caught while executing command with batch.", t);
+            }
             logger.error("Exception while executing command with batch.", e);
             // if a failure occurs we want to pass that exception to all of the Futures that we've returned
             for (CollapsedRequest<ResponseType, RequestArgumentType> request : requests) {


### PR DESCRIPTION
- RxJava 0.10.0 changes from onError(Exception) to onError(Throwable) so I want to get that in before releasing Hystrix 1.3 as I don't want a breaking change like that to affect Hystrix once released.
- Hystrix itself still exposes public methods using Exception so if a Throwable is caught internally it will be wrapped inside an Exception. Changing to Throwable is not worth breaking backwards compatibility and revving to Version 2.0.

NOTE: This won't build against Maven Central quite yet as RxJava 0.10.0 is not yet available there. I'm building against internal Netflix repos while getting Hystrix 1.3 ready for release.
