### PR TITLE
Adding `observe` to Clojure adapter.

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
+++ b/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
@@ -603,6 +603,21 @@
   (let [^HystrixExecutable instance (apply instantiate definition args)]
     (queued-command instance (.queue instance))))
 
+(defn observe
+  "The same as queue but returns a rx.Observable (http://netflix.github.io/RxJava/javadoc/rx/Observable.html).
+
+  Examples:
+
+    (let [ob (observe my-command 1 2 3)]
+      ... subscribe to observer ...)
+
+  See:
+    http://netflix.github.com/Hystrix/javadoc/com/netflix/hystrix/HystrixCommand.html#observe()
+  "
+  [definition & args]
+  (let [^HystrixExecutable instance (apply instantiate definition args)]
+    (.observe instance)))
+
 ;################################################################################
 ; :command impl
 

--- a/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
+++ b/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
@@ -2,7 +2,8 @@
   (:use com.netflix.hystrix.core)
   (:require [clojure.test :refer [deftest testing is are use-fixtures]])
   (:import [com.netflix.hystrix Hystrix HystrixExecutable]
-           [com.netflix.hystrix.strategy.concurrency HystrixRequestContext]))
+           [com.netflix.hystrix.strategy.concurrency HystrixRequestContext]
+           [rx Observable]))
 
 ; reset hystrix after each execution, for consistency and sanity
 (defn reset-fixture
@@ -171,6 +172,15 @@
         (is (future? qc))
         (is (= "hello-world" (.get qc) @qc))
         (is (.isDone qc))))))
+
+(deftest test-observe
+  (let [base-def {:type :command
+                  :group-key :my-group
+                  :command-key :my-command
+                  :run-fn + }]
+      (testing "returns an observable"
+        (let [ob (observe (normalize (assoc base-def :run-fn str)) "")]
+          (is (instance? Observable ob))))))
 
 (deftest test-this-command-binding
   (let [base-def {:type :command


### PR DESCRIPTION
Adding to the Clojure bindings `observe` which works much like queue but returns an Observable. 

Like `queue` and `execute` it hides having to explicitly instantiate the HystrixExecutable.
