### PR TITLE
Fix Exception vs Throwable typo

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -834,10 +834,10 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         }
 
         // error handling
-        o = o.onErrorResumeNext(new Func1<Exception, Observable<R>>() {
+        o = o.onErrorResumeNext(new Func1<Throwable, Observable<R>>() {
 
             @Override
-            public Observable<R> call(Exception e) {
+            public Observable<R> call(Throwable e) {
                 // count that we are throwing an exception and re-throw it
                 metrics.markExceptionThrown();
                 return Observable.error(e);


### PR DESCRIPTION
This was using the Object overload rather than statically typed Func1<Throwable> method. This was caught when testing RxJava 0.11.0 which restores static type safety.

See https://github.com/Netflix/RxJava/pull/319 for more information.
