### PR TITLE
RxJava 0.13

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
+++ b/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
@@ -174,7 +174,7 @@
 
 (defn ^:private wait-for-observable
   [^rx.Observable o]
-  (rx.observables.BlockingObservable/single o))
+  (-> o .toBlockingObservable .single))
 
 (deftest test-observe
   (let [base-def {:type :command

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixRequestCache.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixRequestCache.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import rx.Observable;
+import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
 import rx.subscriptions.Subscriptions;
@@ -334,10 +335,10 @@ public class HystrixRequestCache {
 
         private static class TestObservable extends Observable<String> {
             public TestObservable(final String value) {
-                super(new Func1<Observer<String>, Subscription>() {
+                super(new OnSubscribeFunc<String>() {
 
                     @Override
-                    public Subscription call(Observer<String> observer) {
+                    public Subscription onSubscribe(Observer<? super String> observer) {
                         observer.onNext(value);
                         observer.onCompleted();
                         return Subscriptions.empty();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestObservableFunction.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestObservableFunction.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 import rx.Observable;
+import rx.Observable.OnSubscribeFunc;
 import rx.Observer;
 import rx.Subscription;
 import rx.subscriptions.BooleanSubscription;
@@ -27,7 +28,7 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
  * 
  * @param <R>
  */
-/* package */class CollapsedRequestObservableFunction<T, R> implements CollapsedRequest<T, R>, Func1<Observer<T>, Subscription> {
+/* package */class CollapsedRequestObservableFunction<T, R> implements CollapsedRequest<T, R>, OnSubscribeFunc<T> {
     private final R argument;
     private final AtomicReference<CollapsedRequestObservableFunction.ResponseHolder<T>> rh = new AtomicReference<CollapsedRequestObservableFunction.ResponseHolder<T>>(new CollapsedRequestObservableFunction.ResponseHolder<T>());
     private final BooleanSubscription subscription = new BooleanSubscription();
@@ -139,7 +140,7 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
     }
 
     @Override
-    public Subscription call(Observer<T> observer) {
+    public Subscription onSubscribe(Observer<? super T> observer) {
         while (true) {
             CollapsedRequestObservableFunction.ResponseHolder<T> r = rh.get();
             if (r.getObserver() != null) {
@@ -159,7 +160,7 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
 
     private static <T> void sendResponseIfRequired(BooleanSubscription subscription, CollapsedRequestObservableFunction.ResponseHolder<T> r) {
         if (!subscription.isUnsubscribed()) {
-            Observer<T> o = r.getObserver();
+            Observer<? super T> o = r.getObserver();
             if (o == null || (r.getException() == null && !r.isResponseSet())) {
                 // not ready to send
                 return;
@@ -183,13 +184,13 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
         // even if the value set is null
         private final AtomicReference<T> r;
         private final Exception e;
-        private final Observer<T> o;
+        private final Observer<? super T> o;
 
         public ResponseHolder() {
             this(null, null, null);
         }
 
-        private ResponseHolder(AtomicReference<T> response, Exception exception, Observer<T> observer) {
+        private ResponseHolder(AtomicReference<T> response, Exception exception, Observer<? super T> observer) {
             this.o = observer;
             this.r = response;
             this.e = exception;
@@ -199,7 +200,7 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
             return new ResponseHolder<T>(new AtomicReference<T>(response), e, o);
         }
 
-        public ResponseHolder<T> setObserver(Observer<T> observer) {
+        public ResponseHolder<T> setObserver(Observer<? super T> observer) {
             return new ResponseHolder<T>(r, e, observer);
         }
 
@@ -207,7 +208,7 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
             return new ResponseHolder<T>(r, exception, o);
         }
 
-        public Observer<T> getObserver() {
+        public Observer<? super T> getObserver() {
             return o;
         }
 


### PR DESCRIPTION
Upgrade to RxJava 0.13 (https://github.com/Netflix/RxJava/releases/tag/0.13.0) which includes breaking changes from 0.12 (https://github.com/Netflix/RxJava/releases/tag/0.12.0).
