### PR TITLE
[hystrix-contrib/hystrix-clj] Making Command keys quantified by namespaces.

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
+++ b/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
@@ -391,7 +391,7 @@
   "
   {:arglists '([name doc-string? attr-map? [params*] & body])}
   [name & opts]
-  (let [command-key         (str name)
+  (let [command-key         (str *ns* "/" name )
         group-key           (str *ns*)
         [m [params & body]] (split-def-meta opts)
         m                   (if-not (contains? m :arglists)

--- a/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
+++ b/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
@@ -306,7 +306,7 @@
     (testing "defines a fn in a var"
       (is (fn? my-fn-command))
       (is (map? hm))
-      (is (= "my-fn-command" (.name (:command-key hm))))
+      (is (= "com.netflix.hystrix.core-test/my-fn-command" (.name (:command-key hm))))
       (is (= "com.netflix.hystrix.core-test" (.name (:group-key hm))))
       (is (= :data (-> #'my-fn-command meta :meta)))
       (= 500 ((:fallback-fn hm))))


### PR DESCRIPTION
This improves the Hystrix dashboard reporting information. 

If you have two fns with the same name in different namespaces,
their command key will be the same. This messes up any monitoring using the Hystrix dashboard (the two conflicting commands were trying to write to the same graph I suspect).

It is also confusing that circuit breakers are only shown by their command key. 
Namespaces provide more useful information in reporting.

My only goal is to improve reporting. If this is better actioned upon in the Hystrix dashboard project, I'm happy to add a patch there.

Thanks,
Joe
