### PR TITLE
Bugfix to HystrixBadRequestException handling

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -1264,11 +1264,10 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 if (decorated instanceof HystrixBadRequestException) {
                     e = (HystrixBadRequestException) decorated;
                 } else {
-                    logger.warn("ExecutionHook.endRunFailure returned an exception that was not an instance of HystrixBadRequestException so will be ignored.", decorated);
+                    logger.warn("ExecutionHook.onRunError returned an exception that was not an instance of HystrixBadRequestException so will be ignored.", decorated);
                 }
-                throw e;
             } catch (Exception hookException) {
-                logger.warn("Error calling ExecutionHook.endRunFailure", hookException);
+                logger.warn("Error calling ExecutionHook.onRunError", hookException);
             }
 
             /*


### PR DESCRIPTION
Logs were spuriously getting generated by `HystrixBadRequestException`s.

Only functional diff is that the `log.warn` is now not called unless the `HystrixCommandExecutionHook.onRunError` invocation throws an Exception.  I didn't add a mockLogger for testing purposes, but checked that the `HystrixBadRequestException` case was completely handled already - so no regressions here.

Also, changed the log message to match the `HystrixCommandExecutionHook` method name : `onRunError`
