### PR TITLE
BugFix: ConcurrencyStrategy.wrapCallable was not being used on callbacks

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -853,7 +853,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             // don't waste overhead if it's the 'immediate' scheduler
             // otherwise we'll 'observeOn' and wrap with the HystrixContextScheduler
             // to copy state across threads (if threads are involved)
-            o = o.observeOn(new HystrixContextScheduler(observeOn));
+            o = o.observeOn(new HystrixContextScheduler(concurrencyStrategy, observeOn));
         }
 
         o = o.finallyDo(new Action0() {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextFunc2.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextFunc2.java
@@ -15,6 +15,9 @@
  */
 package com.netflix.hystrix.strategy.concurrency;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
 import rx.Scheduler;
 import rx.Subscription;
 import rx.util.functions.Func2;
@@ -31,23 +34,53 @@ public class HystrixContextFunc2<T> implements Func2<Scheduler, T, Subscription>
 
     private final Func2<? super Scheduler, ? super T, ? extends Subscription> actual;
     private final HystrixRequestContext parentThreadState;
+    private final Callable<Subscription> c;
 
-    public HystrixContextFunc2(Func2<? super Scheduler, ? super T, ? extends Subscription> action) {
+    /*
+     * This is a workaround to needing to use Callable<Subscription> but
+     * needing to pass `Scheduler t1, T t2` into it after construction.
+     * 
+     * Think of it like sticking t1 and t2 on the stack and then calling the function
+     * that uses them.
+     * 
+     * This should all be thread-safe without issues despite multi-step execution
+     * because this Func2 is only ever executed once by Hystrix and construction will always
+     * precede `call` being invoked once. 
+     * 
+     */
+    private final AtomicReference<Scheduler> t1Holder = new AtomicReference<Scheduler>();
+    private final AtomicReference<T> t2Holder = new AtomicReference<T>();
+
+    public HystrixContextFunc2(final HystrixConcurrencyStrategy concurrencyStrategy, Func2<? super Scheduler, ? super T, ? extends Subscription> action) {
         this.actual = action;
         this.parentThreadState = HystrixRequestContext.getContextForCurrentThread();
+
+        this.c = concurrencyStrategy.wrapCallable(new Callable<Subscription>() {
+
+            @Override
+            public Subscription call() throws Exception {
+                HystrixRequestContext existingState = HystrixRequestContext.getContextForCurrentThread();
+                try {
+                    // set the state of this thread to that of its parent
+                    HystrixRequestContext.setContextOnCurrentThread(parentThreadState);
+                    // execute actual Func2 with the state of the parent
+                    return actual.call(t1Holder.get(), t2Holder.get());
+                } finally {
+                    // restore this thread back to its original state
+                    HystrixRequestContext.setContextOnCurrentThread(existingState);
+                }
+            }
+        });
     }
 
     @Override
     public Subscription call(Scheduler t1, T t2) {
-        HystrixRequestContext existingState = HystrixRequestContext.getContextForCurrentThread();
         try {
-            // set the state of this thread to that of its parent
-            HystrixRequestContext.setContextOnCurrentThread(parentThreadState);
-            // execute actual Func2 with the state of the parent
-            return actual.call(t1, t2);
-        } finally {
-            // restore this thread back to its original state
-            HystrixRequestContext.setContextOnCurrentThread(existingState);
+            this.t1Holder.set(t1);
+            this.t2Holder.set(t2);
+            return c.call();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed executing wrapped Func2", e);
         }
     }
 


### PR DESCRIPTION
The Rx Scheduler now correctly has state transferred to it with ConcurrencyStrategy.wrapCallable.

Note that if the Rx sequence ever migrates to another thread (such as using observeOn) it is up to the user to deal with this as Hystrix loses control of the flow at that point.

This change does ensure though that the initial threads the callbacks are performed on has the expected thread context.

The design of this code is not very elegant and uses a workaround similar to posting variables on a stack before a method uses them. I have used this approach because I do not want to add a 'wrapFunc2' method to the ConcurrencyStrategy as the use of Func2 is just an implementation detail internally and the users of the library should not have to replicate the effort for both Callable and Func2. Thus the internal code is a little odd but the public API is untouched.
