### PR TITLE
deploying hystrix dashboard on tomcat, SLF4J complains about a missing implementation

### DIFF
--- a/hystrix-dashboard/build.gradle
+++ b/hystrix-dashboard/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     provided 'javax.servlet:servlet-api:2.5'
     compile 'org.apache.httpcomponents:httpclient:4.2.1'
     compile 'log4j:log4j:1.2.17'
-    compile 'org.slf4j:slf4j-api:1.7.0'
+    compile 'org.slf4j:slf4j-log4j12:1.7.0'
 }
 
 jettyRun {


### PR DESCRIPTION
this change fixes it by exchanging the API for the implemenation (like it has been before the upgrade of slf4j 1.7.0), see f29321cffd01c76fdca88dea2e70890796fc4207
