### PR TITLE
HystrixContextScheduler was not wrapping the Inner Scheduler

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextFunc2.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextFunc2.java
@@ -64,7 +64,7 @@ public class HystrixContextFunc2<T> implements Func2<Scheduler, T, Subscription>
                     // set the state of this thread to that of its parent
                     HystrixRequestContext.setContextOnCurrentThread(parentThreadState);
                     // execute actual Func2 with the state of the parent
-                    return actual.call(t1Holder.get(), t2Holder.get());
+                    return actual.call(new HystrixContextScheduler(concurrencyStrategy, t1Holder.get()), t2Holder.get());
                 } finally {
                     // restore this thread back to its original state
                     HystrixRequestContext.setContextOnCurrentThread(existingState);


### PR DESCRIPTION
This caused RequestContext to be broken using RxJava as of https://github.com/Netflix/RxJava/commit/bc6965c5b9fa85b010e97a5f3efbcdc5a3a6490c

/cc @daveray @mattrjacobs
