### PR TITLE
Restore HystrixContext* Constructors without ConcurrencyStrategy

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContexSchedulerAction.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContexSchedulerAction.java
@@ -22,6 +22,7 @@ import rx.Scheduler.Inner;
 import rx.functions.Action1;
 import rx.functions.Func2;
 
+import com.netflix.hystrix.strategy.HystrixPlugins;
 import com.netflix.hystrix.strategy.concurrency.HystrixContextScheduler.HystrixContextInnerScheduler;
 
 /**
@@ -50,6 +51,10 @@ public class HystrixContexSchedulerAction implements Action1<Inner> {
      * precede `call` being invoked once.
      */
     private final AtomicReference<Inner> t1Holder = new AtomicReference<Inner>();
+
+    public HystrixContexSchedulerAction(Action1<Inner> action) {
+        this(HystrixPlugins.getInstance().getConcurrencyStrategy(), action);
+    }
 
     public HystrixContexSchedulerAction(final HystrixConcurrencyStrategy concurrencyStrategy, Action1<Inner> action) {
         this.actual = action;

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextCallable.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextCallable.java
@@ -17,6 +17,8 @@ package com.netflix.hystrix.strategy.concurrency;
 
 import java.util.concurrent.Callable;
 
+import com.netflix.hystrix.strategy.HystrixPlugins;
+
 /**
  * Wrapper around {@link Callable} that manages the {@link HystrixRequestContext} initialization and cleanup for the execution of the {@link Callable}
  * 
@@ -29,6 +31,10 @@ public class HystrixContextCallable<K> implements Callable<K> {
 
     private final Callable<K> actual;
     private final HystrixRequestContext parentThreadState;
+
+    public HystrixContextCallable(Callable<K> actual) {
+        this(HystrixPlugins.getInstance().getConcurrencyStrategy(), actual);
+    }
 
     public HystrixContextCallable(HystrixConcurrencyStrategy concurrencyStrategy, Callable<K> actual) {
         this.actual = concurrencyStrategy.wrapCallable(actual);

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextRunnable.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextRunnable.java
@@ -17,6 +17,8 @@ package com.netflix.hystrix.strategy.concurrency;
 
 import java.util.concurrent.Callable;
 
+import com.netflix.hystrix.strategy.HystrixPlugins;
+
 /**
  * Wrapper around {@link Runnable} that manages the {@link HystrixRequestContext} initialization and cleanup for the execution of the {@link Runnable}
  * 
@@ -27,6 +29,10 @@ public class HystrixContextRunnable implements Runnable {
     private final Callable<Void> actual;
     private final HystrixRequestContext parentThreadState;
 
+    public HystrixContextRunnable(Runnable actual) {
+        this(HystrixPlugins.getInstance().getConcurrencyStrategy(), actual);
+    }
+    
     public HystrixContextRunnable(HystrixConcurrencyStrategy concurrencyStrategy, final Runnable actual) {
         this.actual = concurrencyStrategy.wrapCallable(new Callable<Void>() {
 


### PR DESCRIPTION
In fixing the bug in 1.3.10 I accidentally changed the public constructors which would break anyone using them. Restoring them and using the default ConcurrencyStrategy available via plugin.
