### PR TITLE
RxJava 0.17.1

### DIFF
--- a/hystrix-core/build.gradle
+++ b/hystrix-core/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'idea'
 
 dependencies {
     compile 'com.netflix.archaius:archaius-core:0.4.1'
-    compile 'com.netflix.rxjava:rxjava-core:0.17.0'
+    compile 'com.netflix.rxjava:rxjava-core:0.17.1'
     compile 'org.slf4j:slf4j-api:1.7.0'
     compile 'com.google.code.findbugs:jsr305:2.0.0'
     testCompile 'junit:junit-dep:4.10'


### PR DESCRIPTION
This version includes a fix needed after testing RxJava 0.17.0 and Hystrix 1.4 on production canaries.
