### PR TITLE
Handling InterruptedExceptions in the HystrixMetricsStreamServlet

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
@@ -150,6 +150,10 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
                         // now wait the 'delay' time
                         Thread.sleep(delay);
                     }
+                } catch (InterruptedException e) {
+                    poller.shutdown();
+                    logger.debug("InterruptedException. Will stop polling.");	
+                    Thread.currentThread().interrupt();
                 } catch (IOException e) {
                     poller.shutdown();
                     // debug instead of error as we expect to get these whenever a client disconnects or network issue occurs


### PR DESCRIPTION
Some environments like spring boots embedded Tomcat interrupt the worker threads on shutdown. Interupting a thread is the Java way to politely ask it to gracefully stop doing long running things. Since serving an event stream is a long running thing, we should stop sending the stream and stop polling, whenever an InterruptedException occures.
