### PR TITLE
Updated a img http link to https in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="http://netflix.github.com/Hystrix/images/hystrix-logo-tagline-850.png">
+<img src="https://netflix.github.com/Hystrix/images/hystrix-logo-tagline-850.png">
 
 # Hystrix: Latency and Fault Tolerance for Distributed Systems
 


### PR DESCRIPTION
This removes a SSL error when viewing the readme on GitHub
