### PR TITLE
defer the Creation of ISE, to when an exception needs to be created

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestObservableFunction.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestObservableFunction.java
@@ -102,17 +102,21 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
     /**
      * Set an ISE if a response is not yet received otherwise skip it
      *
+     * @param e A pre-generated exception.  If this is null an ISE will be created and returned
      * @param exceptionMessage The message for the ISE
      */
-    public void setIllegalStateExceptionIfResponseNotReceived(String exceptionMessage) {
+    public Exception setExceptionIfResponseNotReceived(Exception e, String exceptionMessage) {
+        Exception exception = e;
         CollapsedRequestObservableFunction.ResponseHolder<T> r = rh.get();
         // only proceed if neither response is set
         if (!r.isResponseSet() && r.getException() == null) {
-            setExceptionIfResponseNotReceived(new IllegalStateException(exceptionMessage));
-        } else {
-            // return quietly instead of throwing an exception
-            return;
+            if(e==null) {
+                exception = new IllegalStateException(exceptionMessage);
+            }
+            setExceptionIfResponseNotReceived(exception);
         }
+        // return any exception that was generated
+        return exception;
     }
 
     /**

--- a/hystrix-core/src/main/java/com/netflix/hystrix/collapser/RequestBatch.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/collapser/RequestBatch.java
@@ -143,9 +143,10 @@ public class RequestBatch<BatchReturnType, ResponseType, RequestArgumentType> {
                             @Override
                             public void call() {
                                 // check that all requests had setResponse or setException invoked in case 'mapResponseToRequests' was implemented poorly
+                                Exception e = null;
                                 for (CollapsedRequest<ResponseType, RequestArgumentType> request : shardRequests) {
                                     try {
-                                        ((CollapsedRequestObservableFunction<ResponseType, RequestArgumentType>) request).setIllegalStateExceptionIfResponseNotReceived("No response set by " + commandCollapser.getCollapserKey().name() + " 'mapResponseToRequests' implementation.");
+                                       e = ((CollapsedRequestObservableFunction<ResponseType, RequestArgumentType>) request).setExceptionIfResponseNotReceived(e,"No response set by " + commandCollapser.getCollapserKey().name() + " 'mapResponseToRequests' implementation.");
                                     } catch (IllegalStateException e2) {
                                         logger.debug("Partial success of 'mapResponseToRequests' resulted in IllegalStateException while setting 'No response set' Exception. Continuing ... ", e2);
                                     }


### PR DESCRIPTION
Hi there,

I noticed that an ISE is always created in the doOnComplete, even if the exception case does not occur, which incurs a slight performance hit from the Exception construction and it's initialisation of the stack trace (fillInStackTrace()):
- https://github.com/Netflix/Hystrix/blob/master/hystrix-core/src/main/java/com/netflix/hystrix/collapser/RequestBatch.java#L146

The PR moves this to the passing in of a String that represents the ISE Exception Message if/when it occurs.

You could tackle it by having a custom ISE that overloads the fillInStackTrace() method to return null, and have a custom method that calls super.fillInStackTrace() if/when required.

cheers
/dom
