### PR TITLE
Add unregister methods for Hystrix plugins

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/HystrixPlugins.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/HystrixPlugins.java
@@ -94,6 +94,13 @@ public class HystrixPlugins {
     }
 
     /**
+     * Unregister any globally registered {@link HystrixEventNotifier}.
+     */
+    public void unregisterEventNotifier() {
+        notifier.set(null);
+    }
+
+    /**
      * Retrieve instance of {@link HystrixConcurrencyStrategy} to use based on order of precedence as defined in {@link HystrixPlugins} class header.
      * <p>
      * Override default by using {@link #registerConcurrencyStrategy(HystrixConcurrencyStrategy)} or setting property: <code>hystrix.plugin.HystrixConcurrencyStrategy.implementation</code> with the
@@ -129,6 +136,13 @@ public class HystrixPlugins {
         if (!concurrencyStrategy.compareAndSet(null, impl)) {
             throw new IllegalStateException("Another strategy was already registered.");
         }
+    }
+
+    /**
+     * Unregister any globally registered {@link HystrixConcurrencyStrategy}.
+     */
+    public void unregisterConcurrencyStrategy() {
+        concurrencyStrategy.set(null);
     }
 
     /**
@@ -170,6 +184,13 @@ public class HystrixPlugins {
     }
 
     /**
+     * Unregister any globally registered {@link HystrixMetricsPublisher}.
+     */
+    public void unregisterMetricsPublisher() {
+        metricsPublisher.set(null);
+    }
+
+    /**
      * Retrieve instance of {@link HystrixPropertiesStrategy} to use based on order of precedence as defined in {@link HystrixPlugins} class header.
      * <p>
      * Override default by using {@link #registerPropertiesStrategy(HystrixPropertiesStrategy)} or setting property: <code>hystrix.plugin.HystrixPropertiesStrategy.implementation</code> with the full
@@ -205,6 +226,13 @@ public class HystrixPlugins {
         if (!propertiesFactory.compareAndSet(null, impl)) {
             throw new IllegalStateException("Another strategy was already registered.");
         }
+    }
+
+    /**
+     * Unregister any globally registered {@link HystrixPropertiesStrategy}.
+     */
+    public void unregisterPropertiesStrategy() {
+        propertiesFactory.set(null);
     }
 
     /**
@@ -248,6 +276,13 @@ public class HystrixPlugins {
         if (!commandExecutionHook.compareAndSet(null, impl)) {
             throw new IllegalStateException("Another strategy was already registered.");
         }
+    }
+
+    /**
+     * Unregister any globally registered {@link HystrixCommandExecutionHook}.
+     */
+    public void unregisterCommandExecutionHook() {
+        commandExecutionHook.set(null);
     }
 
     private static Object getPluginImplementationViaProperty(Class<?> pluginClass) {

--- a/hystrix-core/src/test/java/com/netflix/hystrix/strategy/HystrixPluginsTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/strategy/HystrixPluginsTest.java
@@ -28,12 +28,12 @@ import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategyDefault;
 public class HystrixPluginsTest {
     @After
     public void reset() {
-        // use private access to reset so we can test different initializations via the public static flow
-        HystrixPlugins.getInstance().concurrencyStrategy.set(null);
-        HystrixPlugins.getInstance().metricsPublisher.set(null);
-        HystrixPlugins.getInstance().notifier.set(null);
-        HystrixPlugins.getInstance().propertiesFactory.set(null);
-        HystrixPlugins.getInstance().commandExecutionHook.set(null);
+        // reset so we can test different initializations via the public static flow
+        HystrixPlugins.getInstance().unregisterConcurrencyStrategy();
+        HystrixPlugins.getInstance().unregisterMetricsPublisher();
+        HystrixPlugins.getInstance().unregisterEventNotifier();
+        HystrixPlugins.getInstance().unregisterPropertiesStrategy();
+        HystrixPlugins.getInstance().unregisterCommandExecutionHook();
     }
 
     @Test


### PR DESCRIPTION
I need to be able to unregister a previously registered concurrency strategy in my unit tests but there is currently no way to do this.  

I notice in the Hystrix unit tests this can be done because the variables are package scoped.  I have changed these to use the propsed unregsiter methods too.
