### PR TITLE
Avoid NPE when 'origin' parameter not present

### DIFF
--- a/hystrix-dashboard/src/main/java/com/netflix/hystrix/dashboard/stream/ProxyStreamServlet.java
+++ b/hystrix-dashboard/src/main/java/com/netflix/hystrix/dashboard/stream/ProxyStreamServlet.java
@@ -42,6 +42,7 @@ public class ProxyStreamServlet extends HttpServlet {
         if (origin == null) {
             response.setStatus(500);
             response.getWriter().println("Required parameter 'origin' missing. Example: 107.20.175.135:7001");
+            return;
         }
         origin = origin.trim();
         


### PR DESCRIPTION
NPE is thrown in `origin.trim()` expression.
