### PR TITLE
Add toObservable() to the common HystrixExecutable interface

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapser.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapser.java
@@ -308,6 +308,7 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
      * @return {@code Observable<R>} that executes and calls back with the result of of {@link HystrixCommand}{@code <BatchReturnType>} execution after passing through {@link #mapResponseToRequests}
      *         to transform the {@code <BatchReturnType>} into {@code <ResponseType>}
      */
+    @Override
     public Observable<ResponseType> observe() {
         // us a ReplaySubject to buffer the eagerly subscribed-to Observable
         ReplaySubject<ResponseType> subject = ReplaySubject.create();
@@ -332,6 +333,7 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
      * @return {@code Observable<R>} that lazily executes and calls back with the result of of {@link HystrixCommand}{@code <BatchReturnType>} execution after passing through
      *         {@link #mapResponseToRequests} to transform the {@code <BatchReturnType>} into {@code <ResponseType>}
      */
+    @Override
     public Observable<ResponseType> toObservable() {
         // when we callback with the data we want to do the work
         // on a separate thread than the one giving us the callback
@@ -348,6 +350,7 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
      * @return {@code Observable<R>} that lazily executes and calls back with the result of of {@link HystrixCommand}{@code <BatchReturnType>} execution after passing through
      *         {@link #mapResponseToRequests} to transform the {@code <BatchReturnType>} into {@code <ResponseType>}
      */
+    @Override
     public Observable<ResponseType> toObservable(Scheduler observeOn) {
 
         /* try from cache first */
@@ -397,6 +400,7 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
      * @throws HystrixRuntimeException
      *             if an error occurs and a fallback cannot be retrieved
      */
+    @Override
     public ResponseType execute() {
         try {
             return queue().get();
@@ -427,6 +431,7 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
      * @throws HystrixRuntimeException
      *             within an <code>ExecutionException.getCause()</code> (thrown by {@link Future#get}) if an error occurs and a fallback cannot be retrieved
      */
+    @Override
     public Future<ResponseType> queue() {
         final Observable<ResponseType> o = toObservable();
         return o.toBlockingObservable().toFuture();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -291,6 +291,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R>, Hystrix
      * @throws IllegalStateException
      *             if invoked more than once
      */
+    @Override
     public Observable<R> toObservable() {
         if (observableCommand.properties.executionIsolationStrategy().get().equals(ExecutionIsolationStrategy.THREAD)) {
             return toObservable(Schedulers.computation());
@@ -301,26 +302,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R>, Hystrix
         }
     }
 
-    /**
-     * A lazy {@link Observable} that will execute the command when subscribed to.
-     * <p>
-     * See https://github.com/Netflix/RxJava/wiki for more information.
-     * 
-     * @param observeOn
-     *            The {@link Scheduler} to execute callbacks on.
-     * @return {@code Observable<R>} that lazily executes and calls back with the result of {@link #run()} execution or a fallback from {@link #getFallback()} if the command fails for any reason.
-     * @throws HystrixRuntimeException
-     *             if a fallback does not exist
-     *             <p>
-     *             <ul>
-     *             <li>via {@code Observer#onError} if a failure occurs</li>
-     *             <li>or immediately if the command can not be queued (such as short-circuited, thread-pool/semaphore rejected)</li>
-     *             </ul>
-     * @throws HystrixBadRequestException
-     *             via {@code Observer#onError} if invalid arguments or state were used representing a user failure, not a system failure
-     * @throws IllegalStateException
-     *             if invoked more than once
-     */
+    @Override
     public Observable<R> toObservable(Scheduler observeOn) {
         return toObservable(observeOn, true);
     }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixExecutableBase.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixExecutableBase.java
@@ -291,6 +291,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
      * @throws IllegalStateException
      *             if invoked more than once
      */
+    @Override
     public R execute() {
         try {
             return queue().get();
@@ -321,6 +322,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
      * @throws IllegalStateException
      *             if invoked more than once
      */
+    @Override
     public Future<R> queue() {
         /*
          * --- Schedulers.immediate()
@@ -544,6 +546,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
      * @throws IllegalStateException
      *             if invoked more than once
      */
+    @Override
     public Observable<R> observe() {
         // us a ReplaySubject to buffer the eagerly subscribed-to Observable
         ReplaySubject<R> subject = ReplaySubject.create();
@@ -573,11 +576,10 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
      * @throws IllegalStateException
      *             if invoked more than once
      */
+    @Override
     public Observable<R> toObservable(Scheduler observeOn) {
         return toObservable(observeOn, true);
     }
-
-    public abstract Observable<R> toObservable();
 
     protected abstract ObservableCommand<R> toObservable(final Scheduler observeOn, boolean performAsyncTimeout);
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixObservableCollapser.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixObservableCollapser.java
@@ -319,6 +319,7 @@ public abstract class HystrixObservableCollapser<K, BatchReturnType, ResponseTyp
      * @return {@code Observable<R>} that executes and calls back with the result of of {@link HystrixCommand}{@code <BatchReturnType>} execution after passing through {@link #mapResponseToRequests}
      *         to transform the {@code <BatchReturnType>} into {@code <ResponseType>}
      */
+    @Override
     public Observable<ResponseType> observe() {
         // us a ReplaySubject to buffer the eagerly subscribed-to Observable
         ReplaySubject<ResponseType> subject = ReplaySubject.create();
@@ -343,6 +344,7 @@ public abstract class HystrixObservableCollapser<K, BatchReturnType, ResponseTyp
      * @return {@code Observable<R>} that lazily executes and calls back with the result of of {@link HystrixCommand}{@code <BatchReturnType>} execution after passing through
      *         {@link #mapResponseToRequests} to transform the {@code <BatchReturnType>} into {@code <ResponseType>}
      */
+    @Override
     public Observable<ResponseType> toObservable() {
         // when we callback with the data we want to do the work
         // on a separate thread than the one giving us the callback
@@ -359,6 +361,7 @@ public abstract class HystrixObservableCollapser<K, BatchReturnType, ResponseTyp
      * @return {@code Observable<R>} that lazily executes and calls back with the result of of {@link HystrixCommand}{@code <BatchReturnType>} execution after passing through
      *         {@link #mapResponseToRequests} to transform the {@code <BatchReturnType>} into {@code <ResponseType>}
      */
+    @Override
     public Observable<ResponseType> toObservable(Scheduler observeOn) {
 
         /* try from cache first */
@@ -408,6 +411,7 @@ public abstract class HystrixObservableCollapser<K, BatchReturnType, ResponseTyp
      * @throws HystrixRuntimeException
      *             if an error occurs and a fallback cannot be retrieved
      */
+    @Override
     public ResponseType execute() {
         try {
             return queue().get();
@@ -438,6 +442,7 @@ public abstract class HystrixObservableCollapser<K, BatchReturnType, ResponseTyp
      * @throws HystrixRuntimeException
      *             within an <code>ExecutionException.getCause()</code> (thrown by {@link Future#get}) if an error occurs and a fallback cannot be retrieved
      */
+    @Override
     public Future<ResponseType> queue() {
         final Observable<ResponseType> o = toObservable();
         return o.toBlockingObservable().toFuture();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixObservableCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixObservableCommand.java
@@ -246,10 +246,12 @@ public abstract class HystrixObservableCommand<R> extends HystrixExecutableBase<
      * @throws IllegalStateException
      *             if invoked more than once
      */
+    @Override
     public Observable<R> toObservable() {
         return toObservable(Schedulers.immediate());
     }
 
+    @Override
     protected ObservableCommand<R> toObservable(final Scheduler observeOn, final boolean performAsyncTimeout) {
         /* this is a stateful object so can only be used once */
         if (!started.compareAndSet(false, true)) {


### PR DESCRIPTION
All of the implementers of HystrixExecutable<R> implement toObservable() and toObservable(Scheduler observeOn)

This patch adds those methods to the common interface, and also adds @Override annotations to appropriate places.

Use case is that I have a factory method that may return a HystrixCollapser or a HystrixCommand, and want to be able to call .toObservable on the result. (I'm still doing some designs on this and may not use it that way, but hopefully this technically-breaking change can make 0.40....)
