### PR TITLE
Dashboard: custom authorization header 

### DIFF
--- a/hystrix-dashboard/src/main/java/com/netflix/hystrix/dashboard/stream/ProxyStreamServlet.java
+++ b/hystrix-dashboard/src/main/java/com/netflix/hystrix/dashboard/stream/ProxyStreamServlet.java
@@ -39,13 +39,14 @@ public class ProxyStreamServlet extends HttpServlet {
      */
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String origin = request.getParameter("origin");
+        String authorization = request.getParameter("authorization");
         if (origin == null) {
             response.setStatus(500);
             response.getWriter().println("Required parameter 'origin' missing. Example: 107.20.175.135:7001");
             return;
         }
         origin = origin.trim();
-        
+
         HttpGet httpget = null;
         InputStream is = null;
         boolean hasFirstParameter = false;
@@ -60,7 +61,7 @@ public class ProxyStreamServlet extends HttpServlet {
         @SuppressWarnings("unchecked")
         Map<String, String[]> params = request.getParameterMap();
         for (String key : params.keySet()) {
-            if (!key.equals("origin")) {
+            if (!key.equals("origin") && !key.equals("authorization")) {
                 String[] values = params.get(key);
                 String value = values[0].trim();
                 if (hasFirstParameter) {
@@ -76,6 +77,9 @@ public class ProxyStreamServlet extends HttpServlet {
         logger.info("\n\nProxy opening connection to: " + proxyUrl + "\n\n");
         try {
             httpget = new HttpGet(proxyUrl);
+            if (authorization != null) {
+                httpget.addHeader("Authorization", authorization);
+            }
             HttpClient client = ProxyConnectionManager.httpClient;
             HttpResponse httpResponse = client.execute(httpget);
             int statusCode = httpResponse.getStatusLine().getStatusCode();

--- a/hystrix-dashboard/src/main/webapp/index.html
+++ b/hystrix-dashboard/src/main/webapp/index.html
@@ -18,6 +18,9 @@
 				if($('#title').val().length > 0) {	
 					url += "&title=" + encodeURIComponent($('#title').val());
 				}
+                if($('#authorization').val().length > 0) {
+                    url += "&authorization=" + encodeURIComponent($('#authorization').val());
+                }
 				location.href= url;
 			} else {
 				$('#message').html("The 'stream' value is required.");
@@ -44,7 +47,8 @@
 	<br><br>
 	Delay: <input id="delay" type="textfield" size="10" placeholder="2000"></input>ms 
 	&nbsp;&nbsp;&nbsp;&nbsp; 
-	Title: <input id="title" type="textfield" size="60" placeholder="Example Hystrix App"></input><br>
+	Title: <input id="title" type="textfield" size="60" placeholder="Example Hystrix App"></input><br><br>
+    Authorization: <input id="authorization" type="textfield" size="60" placeholder="Basic Zm9vOmJhcg=="></input><br>
 	<br>
 	<button onclick="sendToMonitor()">Monitor Stream</button>
 	<br><br>

--- a/hystrix-dashboard/src/main/webapp/monitor/monitor.html
+++ b/hystrix-dashboard/src/main/webapp/monitor/monitor.html
@@ -93,15 +93,20 @@
 			if(getUrlVars()["delay"] != undefined) {
 				stream = stream + "&delay=" + getUrlVars()["delay"];
 			}
-			
-			var commandStream = "../proxy.stream?origin=" + stream;
-			var poolStream = "../proxy.stream?origin=" + stream;
-			
+
 			if(getUrlVars()["title"] != undefined) {
 				$('#title_name').html("Hystrix Stream: " + decodeURIComponent(getUrlVars()["title"]))
 			} else {
 				$('#title_name').html("Hystrix Stream: " + decodeURIComponent(stream))
 			}
+
+            //do not show authorization in stream title
+            if(getUrlVars()["authorization"] != undefined) {
+                stream = stream + "&authorization=" + getUrlVars()["authorization"];
+            }
+
+            var commandStream = "../proxy.stream?origin=" + stream;
+            var poolStream = "../proxy.stream?origin=" + stream;
 		}
 				
 		$(window).load(function() { // within load with a setTimeout to prevent the infinite spinner


### PR DESCRIPTION
This adds supports for a custom authorization header to the dashboard. This allows the hystrix stream to be protected by HTTP basic authentication.
