### PR TITLE
Allow for @HystrixCommand to be used on parameterized return type

### DIFF
--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/command/ExecutionType.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/command/ExecutionType.java
@@ -39,16 +39,15 @@ public enum ExecutionType {
      */
     OBSERVABLE;
 
-
     /**
      * Gets execution type for specified class type.
      * @param type the type
      * @return the execution type {@link ExecutionType}
      */
     public static ExecutionType getExecutionType(Class<?> type) {
-        if (type.isAssignableFrom(Future.class)) {
+        if (Future.class.isAssignableFrom(type)) {
             return ExecutionType.ASYNCHRONOUS;
-        } else if (type.isAssignableFrom(Observable.class)) {
+        } else if (Observable.class.isAssignableFrom(type)) {
             return ExecutionType.OBSERVABLE;
         } else {
             return ExecutionType.SYNCHRONOUS;

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/command/ExecutionTypeTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/command/ExecutionTypeTest.java
@@ -1,0 +1,60 @@
+package com.netflix.hystrix.contrib.javanica.command;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import rx.Observable;
+import rx.internal.operators.OperatorMulticast;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.RunnableFuture;
+
+import static com.netflix.hystrix.contrib.javanica.command.ExecutionType.ASYNCHRONOUS;
+import static com.netflix.hystrix.contrib.javanica.command.ExecutionType.OBSERVABLE;
+import static com.netflix.hystrix.contrib.javanica.command.ExecutionType.SYNCHRONOUS;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class ExecutionTypeTest {
+
+    @Parameterized.Parameters
+    public static List<Object[]> data() {
+        return asList(new Object[][]{
+                {returnType(Integer.class), shouldHaveExecutionType(SYNCHRONOUS)},
+                {returnType(List.class), shouldHaveExecutionType(SYNCHRONOUS)},
+                {returnType(Object.class), shouldHaveExecutionType(SYNCHRONOUS)},
+                {returnType(Class.class), shouldHaveExecutionType(SYNCHRONOUS)},
+                {returnType(Future.class), shouldHaveExecutionType(ASYNCHRONOUS)},
+                {returnType(AsyncResult.class), shouldHaveExecutionType(ASYNCHRONOUS)},
+                {returnType(RunnableFuture.class), shouldHaveExecutionType(ASYNCHRONOUS)},
+                {returnType(CompletableFuture.class), shouldHaveExecutionType(ASYNCHRONOUS)},
+                {returnType(Observable.class), shouldHaveExecutionType(OBSERVABLE)},
+                {returnType(OperatorMulticast.class), shouldHaveExecutionType(OBSERVABLE)},
+        });
+    }
+
+    @Test
+    public void should_return_correct_execution_type() throws Exception {
+        assertEquals("Unexpected execution type for method return type: " + methodReturnType, expectedType, ExecutionType.getExecutionType(methodReturnType));
+
+    }
+
+    private static ExecutionType shouldHaveExecutionType(final ExecutionType type) {
+        return type;
+    }
+
+    private static Class<?> returnType(final Class<?> aClass) {
+        return aClass;
+    }
+
+    private final Class<?> methodReturnType;
+    private final ExecutionType expectedType;
+
+    public ExecutionTypeTest(final Class<?> methodReturnType, final ExecutionType expectedType) {
+        this.methodReturnType = methodReturnType;
+        this.expectedType = expectedType;
+    }
+}

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/command/CommandTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/command/CommandTest.java
@@ -77,6 +77,14 @@ public class CommandTest {
         assertTrue(command.getExecutionEvents().contains(HystrixEventType.SUCCESS));
     }
 
+    @Test
+    public void should_work_with_parameterized_method() throws Exception {
+        assertEquals(Integer.valueOf(1), userService.echo(1));
+
+        assertEquals(1, HystrixRequestLog.getCurrentRequest().getExecutedCommands().size());
+        assertTrue(getCommand().getExecutionEvents().contains(HystrixEventType.SUCCESS));
+    }
+
     private com.netflix.hystrix.HystrixCommand<?> getCommand() {
         return HystrixRequestLog.getCurrentRequest().getExecutedCommands().iterator().next();
     }
@@ -96,6 +104,11 @@ public class CommandTest {
         @HystrixCommand(groupKey = "UserGroup")
         public User getUserSync(String id, String name) {
             return new User(id, name + id); // it should be network call
+        }
+
+        @HystrixCommand
+        public <T> T echo(T value) {
+            return value;
         }
 
     }


### PR DESCRIPTION
The current implementation of hystrix-javanica doesn't work with methods that have a parameterized method return type. I.e. the following (somewhat silly example) would not work:

``` java
@HystrixCommand
public <T> T echo(T value) {
    return value;
}
```

This is because the code that determines the execution type from the method return type incorrectly matches `Object` to `Future` and then marks it for asynchronous execution. This leads to an exception at runtime. E.g.:

``` java
final String answer = echo("hello");
```

would cause a class cast exception.

Correcting the logic for determining the execution type fixes this issue.
