### PR TITLE
Fixing a hystrix-examples compilation failure.

### DIFF
--- a/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandHelloWorld.java
+++ b/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandHelloWorld.java
@@ -76,8 +76,8 @@ public class CommandHelloWorld extends HystrixCommand<String> {
             Observable<String> fBob = new CommandHelloWorld("Bob").observe();
 
             // blocking
-            assertEquals("Hello World!", fWorld.toBlockingObservable().single());
-            assertEquals("Hello Bob!", fBob.toBlockingObservable().single());
+            assertEquals("Hello World!", fWorld.toBlocking().single());
+            assertEquals("Hello Bob!", fBob.toBlocking().single());
 
             // non-blocking 
             // - this is a verbose anonymous inner-class approach and doesn't do assertions


### PR DESCRIPTION
One of the examples still used the now-deprecated toBlockingObservable(). It now uses toBlocking() which allows one to actually compile the examples again.
