### PR TITLE
Fixed Clojure unit tests

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
+++ b/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
@@ -628,16 +628,13 @@
   "A protocol solely to eliminate reflection warnings because .toObservable
   can be found on both HystrixCommand and HystrixCollapser, but not in their
   common base class HystrixExecutable."
-  (^:private observe-later* [this])
-  (^:private observe-later-on* [this scheduler]))
+  (^:private observe-later* [this]))
 
 (extend-protocol ObserveLater
   HystrixCommand
     (observe-later* [this] (.toObservable this))
-    (observe-later-on* [this scheduler] (.toObservable this scheduler))
   HystrixCollapser
-    (observe-later* [this] (.toObservable this))
-    (observe-later-on* [this scheduler] (.toObservable this scheduler)))
+    (observe-later* [this] (.toObservable this)))
 
 (defn observe-later
   "Same as #'com.netflix.hystrix.core/observe, but command execution does not begin until the
@@ -649,19 +646,6 @@
   "
   [definition & args]
   (observe-later* (apply instantiate definition args)))
-
-(defn observe-later-on
-  "Same as #'com.netflix.hystrix.core/observe-later but an explicit scheduler can be provided
-  for the callback.
-
-  See:
-    com.netflix.hystrix.core/observe-later
-    com.netflix.hystrix.core/observe
-    http://netflix.github.io/Hystrix/javadoc/com/netflix/hystrix/HystrixCommand.html#toObservable(Scheduler)
-    http://netflix.github.io/RxJava/javadoc/rx/Observable.html
-  "
-  [definition scheduler & args]
-  (observe-later-on* (apply instantiate definition args) scheduler))
 
 ;################################################################################
 ; :command impl

--- a/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
+++ b/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
@@ -174,7 +174,7 @@
 
 (defn ^:private wait-for-observable
   [^rx.Observable o]
-  (-> o .toBlockingObservable .single))
+  (-> o .toBlocking .single))
 
 (deftest test-observe
   (let [base-def {:type :command
@@ -210,13 +210,6 @@
                    (observe-later (instantiate (normalize base-def)) 10 23))))
     (testing "instantiates and observes a command"
       (let [o (observe-later (normalize base-def) 75 19 23)]
-        (is (instance? rx.Observable o))
-        (is (= (+ 75 19 23)
-               (wait-for-observable o)))))
-    (testing "observes command with a Scheduler"
-      (let [o (observe-later-on (normalize base-def)
-                                (rx.schedulers.Schedulers/newThread)
-                                75 19 23)]
         (is (instance? rx.Observable o))
         (is (= (+ 75 19 23)
                (wait-for-observable o)))))))
@@ -315,10 +308,7 @@
       (is (= 100 (execute #'my-fn-command 89 11)))
       (is (= 101 (deref (queue #'my-fn-command 89 12))))
       (is (= 103 (wait-for-observable (observe #'my-fn-command 90 13))))
-      (is (= 105 (wait-for-observable (observe-later #'my-fn-command 91 14))))
-      (is (= 107 (wait-for-observable (observe-later-on #'my-fn-command
-                                                        (rx.schedulers.Schedulers/newThread)
-                                                        92 15)))))))
+      (is (= 105 (wait-for-observable (observe-later #'my-fn-command 91 14)))))))
 
 (defcollapser my-collapser
   "a doc string"


### PR DESCRIPTION
- s/toBlockingObservable/toBlocking
- Removed observe(Scheduler) calls
