### PR TITLE
Added thread pool metrics back to execution flow

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -515,12 +515,14 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                     } else {
                         // not timed out so execute
                         try {
+                            threadPool.markThreadExecution();
                             final Action0 endCurrentThread = Hystrix.startCurrentThreadExecutingCommand(getCommandKey());
                             getExecutionObservable().doOnTerminate(new Action0() {
 
                                 @Override
                                 public void call() {
                                     // TODO is this actually the end of the thread?
+                                    threadPool.markThreadCompletion();
                                     executionHook.onThreadComplete(_self);
                                     endCurrentThread.call();
                                 }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolMetricsTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolMetricsTest.java
@@ -27,7 +27,7 @@ public class HystrixThreadPoolMetricsTest {
 
 	@Before
 	public void resetAll() {
-		HystrixThreadPoolMetrics.resetAll();
+		HystrixThreadPoolMetrics.reset();
 	}
 
 	@Test


### PR DESCRIPTION
Calls to `threadPool.markThreadExecution()` and `threadPool.markThreadCompletion()` got removed in the 1.3 -> 1.4 rewrite.  This adds them back and gets the unit tests contributed by @nurkiewicz working.  Thanks for those, @nurkiewicz!
