### PR TITLE
Unit tests for HystrixCommandExecutionHooks (Manual merge of #327)

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -561,7 +561,6 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
             @Override
             public R call(R t1) {
-                System.out.println("map " + t1);
                 if (!once) {
                     // report success
                     executionResult = executionResult.addEvents(HystrixEventType.SUCCESS);
@@ -617,6 +616,17 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                         logger.warn("Error calling ExecutionHook.onRunError", hookException);
                     }
 
+                    try {
+                        Exception decorated = executionHook.onError(_self, FailureType.BAD_REQUEST_EXCEPTION, (Exception) t);
+
+                        if (decorated instanceof HystrixBadRequestException) {
+                            t = (HystrixBadRequestException) decorated;
+                        } else {
+                            logger.warn("ExecutionHook.onError returned an exception that was not an instance of HystrixBadRequestException so will be ignored.", decorated);
+                        }
+                    } catch (Exception hookException) {
+                        logger.warn("Error calling ExecutionHook.onError", hookException);
+                    }
                     /*
                      * HystrixBadRequestException is treated differently and allowed to propagate without any stats tracking or fallback logic
                      */

--- a/hystrix-core/src/main/java/com/netflix/hystrix/exception/HystrixRuntimeException.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/exception/HystrixRuntimeException.java
@@ -32,7 +32,7 @@ public class HystrixRuntimeException extends RuntimeException {
     private final FailureType failureCause;
 
     public static enum FailureType {
-        COMMAND_EXCEPTION, TIMEOUT, SHORTCIRCUIT, REJECTED_THREAD_EXECUTION, REJECTED_SEMAPHORE_EXECUTION, REJECTED_SEMAPHORE_FALLBACK
+        BAD_REQUEST_EXCEPTION, COMMAND_EXCEPTION, TIMEOUT, SHORTCIRCUIT, REJECTED_THREAD_EXECUTION, REJECTED_SEMAPHORE_EXECUTION, REJECTED_SEMAPHORE_FALLBACK
     }
 
     public HystrixRuntimeException(FailureType failureCause, Class<? extends HystrixInvokable> commandClass, String message, Exception cause, Throwable fallbackException) {

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -4184,12 +4184,12 @@ public class HystrixCommandTest {
 
         // the run() method should run as we're not short-circuited or rejected
         assertEquals(1, command.builder.executionHook.startRun.get());
-        // we expect a successful response from run()
+        // we expect no response from run()
         assertNull(command.builder.executionHook.runSuccessResponse);
         // we expect an exception
         assertNotNull(command.builder.executionHook.runFailureException);
 
-        // the fallback() method should not be run as we were successful
+        // the fallback() method should not be run as BadRequestException is handled by immediate propagation
         assertEquals(0, command.builder.executionHook.startFallback.get());
         // null since it didn't run
         assertNull(command.builder.executionHook.fallbackSuccessResponse);
@@ -4200,8 +4200,8 @@ public class HystrixCommandTest {
         assertEquals(1, command.builder.executionHook.startExecute.get());
         // we should not have a response from execute()
         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-        // we should not have an exception since run() succeeded
-        assertNull(command.builder.executionHook.endExecuteFailureException);
+        // we should have a HystrixBadRequest exception since run() succeeded
+        assertNotNull(command.builder.executionHook.endExecuteFailureException);
 
         // thread execution
         assertEquals(0, command.builder.executionHook.threadStart.get());


### PR DESCRIPTION
This is a manual merge of #327.  Thanks @krutsko for the contribution.  The commits by @krutsko added unit tests demonstrating a number of failures of execution hooks.

1) Unlike 1.3.x, 1.4 was calling `onRunStart` before `onThreadStart`.  This is now switched back to `onThreadStart` before `onRunStart`
2) Some paths called the `onComplete` hook twice
3) 1.4 is calling `onThreadComplete` earlier, as the amount of logic executed on the Hystrix-isolated thread is less is 1.4.  I'm opening issue #377 to check this out.
4) HystrixBadRequestException was not calling the `onError` execution hook.
