### PR TITLE
Failing unit tests for timeouts on HystrixCommands not causing thread interruptions

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -907,7 +907,6 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
                         timeoutRunnable.run();
                     }
-
                 }
 
                 @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -4347,6 +4347,33 @@ public class HystrixCommandTest {
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
+    @Test
+    public void testInterruptFutureOnTimeout() throws InterruptedException, ExecutionException {
+        // given
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker());
+
+        // when
+        Future<Boolean> f = cmd.queue();
+
+        // then
+        Thread.sleep(3000);
+        System.out.println("RESULT : " + f.get());
+        assertTrue(cmd.hasBeenInterrupted());
+    }
+
+    @Test
+    public void testInterruptObservableOnTimeout() throws InterruptedException {
+        // given
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker());
+
+        // when
+        cmd.observe().subscribe();
+
+        // then
+        Thread.sleep(3000);
+        assertTrue(cmd.hasBeenInterrupted());
+    }
+
     /* ******************************************************************************** */
     /* ******************************************************************************** */
     /* private HystrixCommand class implementations for unit testing */
@@ -5243,6 +5270,39 @@ public class HystrixCommandTest {
             throw new IOException("simulated checked exception message");
         }
 
+    }
+
+    private static class InterruptibleCommand extends TestHystrixCommand<Boolean> {
+
+        public InterruptibleCommand(TestCircuitBreaker circuitBreaker) {
+            super(testPropsBuilder()
+                    .setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
+                            .withExecutionIsolationThreadInterruptOnTimeout(true)
+                            .withExecutionIsolationThreadTimeoutInMilliseconds(100)));
+        }
+
+        private volatile boolean hasBeenInterrupted;
+
+        public boolean hasBeenInterrupted()
+        {
+            return hasBeenInterrupted;
+        }
+
+        @Override
+        protected Boolean run() throws Exception
+        {
+            try {
+                Thread.sleep(2000);
+            }
+            catch (InterruptedException e) {
+                System.out.println("Interrupted!");
+                e.printStackTrace();
+                hasBeenInterrupted = true;
+            }
+
+            return hasBeenInterrupted;
+        }
     }
 
     enum CommandKeyForUnitTest implements HystrixCommandKey {


### PR DESCRIPTION
This is a PR slightly modified from #354.  Thanks @aadeon for the contribution, I can replicate your failure.

cc @benjchristensen, it seems like we need a way to explicitly control thread interruption of the Observable underlying a HystrixCommand.  Can you take a look and see if there's a workaround in Hystrix, or if corresponding RxJava changes are needed?