### PR TITLE
Move thread completion to end of chain

### DIFF
--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -3583,7 +3583,7 @@ public class HystrixCommandTest {
         assertEquals(1, command.builder.executionHook.threadComplete.get());
 
         // expected hook execution sequence
-        assertEquals("onStart - onThreadStart - onRunStart - onThreadComplete - onRunError - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+        assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
 
         /* test with queue() */
@@ -3623,7 +3623,7 @@ public class HystrixCommandTest {
         assertEquals(1, command.builder.executionHook.threadComplete.get());
 
         // expected hook execution sequence
-        assertEquals("onStart - onThreadStart - onRunStart - onThreadComplete - onRunError - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+        assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
     }
 
     /**
@@ -3661,7 +3661,7 @@ public class HystrixCommandTest {
         assertEquals(1, command.builder.executionHook.threadComplete.get());
 
         // expected hook execution sequence
-        assertEquals("onStart - onThreadStart - onRunStart - onThreadComplete - onRunError - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+        assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
 
         /* test with queue() */
@@ -3698,7 +3698,7 @@ public class HystrixCommandTest {
         assertEquals(1, command.builder.executionHook.threadComplete.get());
 
         // expected hook execution sequence
-        assertEquals("onStart - onThreadStart - onRunStart - onThreadComplete - onRunError - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+        assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
     }
 
     /**
@@ -3743,7 +3743,7 @@ public class HystrixCommandTest {
         assertEquals(1, command.builder.executionHook.threadComplete.get());
 
         // expected hook execution sequence
-        assertEquals("onStart - onThreadStart - onRunStart - onThreadComplete - onRunError - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+        assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
         /* test with queue() */
         command = new KnownFailureTestCommandWithFallbackFailure();
@@ -3782,7 +3782,7 @@ public class HystrixCommandTest {
         assertEquals(1, command.builder.executionHook.threadComplete.get());
 
         // expected hook execution sequence
-        assertEquals("onStart - onThreadStart - onRunStart - onThreadComplete - onRunError - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+        assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
     }
 
     /**

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -5745,8 +5745,8 @@ public class HystrixObservableCommandTest {
         System.out.println("results.observeOnThread.get(): " + results.observeOnThread.get() + "  " + Thread.currentThread());
         assertTrue(results.observeOnThread.get().equals(Thread.currentThread())); // rejected so we stay on calling thread
 
-        // thread isolated so even though we're rejected we mark that it attempted execution in a thread
-        assertTrue(results.command.isExecutedInThread());
+        // thread isolated, but rejected, so this is false
+        assertFalse(results.command.isExecutedInThread());
     }
 
     /**
@@ -5766,8 +5766,8 @@ public class HystrixObservableCommandTest {
         assertTrue(results.isContextInitializedObserveOn.get()); // we capture and set the context once the user provided Observable emits
         assertTrue(results.observeOnThread.get().getName().startsWith("RxNewThread"));
 
-        // thread isolated so even though we're rejected we mark that it attempted execution in a thread
-        assertTrue(results.command.isExecutedInThread());
+        // thread isolated, but rejected, so this is false
+        assertFalse(results.command.isExecutedInThread());
     }
 
     /**
@@ -5785,8 +5785,8 @@ public class HystrixObservableCommandTest {
         assertTrue(results.isContextInitializedObserveOn.get()); // the user scheduler captures context
         assertTrue(results.observeOnThread.get().getName().startsWith("RxNewThread")); // the user provided thread/scheduler for getFallback
 
-        // thread isolated so even though we're rejected we mark that it attempted execution in a thread
-        assertTrue(results.command.isExecutedInThread());
+        // thread isolated, but rejected, so this is false
+        assertFalse(results.command.isExecutedInThread());
     }
 
     /* *************************************** testShortCircuitedWithFallbackRequestContext *********************************** */


### PR DESCRIPTION
Thread completion events (metrics and hook execution) were firing earlier in 1.4.x, as documented by #377, and discovered via #327.  This PR moves them back to the rightful place at the end of the Observable chain.  Along the way, 2 unrelated bugs were fixed.

1) ```Hystrix.startCurrentThreadExecutingCommand()``` and the corresponding end ```Action0``` were being invoked twice per command.  Now they both invoked once
2) As documented in #448, ```HystrixCommand.isExecutedInThread()``` was documented to only return true when it actually ran in the Hystrix thread.  In practice, it was returning true in the case that it was set up to run in a thread, but got rejected.  Fixing this made the implementation of the thread completion straightforward.