### PR TITLE
Bypass fallback/circuit breaker for BadRequestExceptions from ExecutionHook

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -624,6 +624,12 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                     } catch (Exception hookException) {
                         logger.warn("Error calling ExecutionHook.endRunFailure", hookException);
                     }
+                    /*
+                     * Treat HystrixBadRequestException from ExecutionHook like a plain HystrixBadRequestException.
+                     */
+                    if (e instanceof HystrixBadRequestException){
+                        return Observable.error(e);
+                    }
 
                     logger.debug("Error executing HystrixCommand.run(). Proceeding to fallback logic ...", e);
 


### PR DESCRIPTION
Hi,

recently introduced Hystrix into an existing codebase and like it a lot. That codebase uses a custom `BusinessException` to signal bad user input etc. We would like to automatically wrap the `BusinessException`s into a `HystrixBadRequestException` to isolate Hystrix-Exception handling and not having to touch all the existing code.
However, turning an `Exception` into a `HystrixBadRequestException` inside `HystrixCommandExecutionHook#onRunError` did not side-step the fallback machinery. This pull request fixes that.

Cheers,
Gerrit