### PR TITLE
Backport of #327 onto 1.3.x

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -1306,6 +1306,17 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 logger.warn("Error calling ExecutionHook.onRunError", hookException);
             }
 
+            try {
+                Exception decorated = executionHook.onError(this, FailureType.BAD_REQUEST_EXCEPTION, e);
+                if (decorated instanceof HystrixBadRequestException) {
+                    e = (HystrixBadRequestException) decorated;
+                } else {
+                    logger.warn("ExecutionHook.onError returned an exception that was not an instance of HystrixBadRequestException so will be ignored.", decorated);
+                }
+            } catch (Exception hookException) {
+                logger.warn("Error calling ExecutionHook.onError", hookException);
+            }
+
             /*
              * HystrixBadRequestException is treated differently and allowed to propagate without any stats tracking or fallback logic
              */

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -1044,8 +1044,6 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                                 originalCommand.recordTotalExecutionTime(originalCommand.invocationStartTime);
 
                                 timeoutRunnable.run();
-
-
                             }
 
                             observer.unsubscribe();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -1632,6 +1632,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                     metrics.markFallbackSuccess();
                     // record the executionResult
                     executionResult = executionResult.addEvents(HystrixEventType.FALLBACK_SUCCESS);
+
                     return executionHook.onComplete(this, fallback);
                 } catch (UnsupportedOperationException fe) {
                     logger.debug("No fallback for HystrixCommand. ", fe); // debug only since we're throwing the exception and someone higher will do something with it
@@ -5346,7 +5347,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
             /* test with queue() */
             command = new SuccessfulTestCommand();
@@ -5382,7 +5383,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -5437,7 +5438,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -5486,7 +5487,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -5531,7 +5532,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
             /* test with queue() */
             command = new UnknownFailureTestCommandWithoutFallback();
@@ -5570,7 +5571,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
         }
 
@@ -5609,7 +5610,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackSuccess - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
             /* test with queue() */
             command = new KnownFailureTestCommandWithFallback(new TestCircuitBreaker());
@@ -5690,7 +5691,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
             /* test with queue() */
             command = new KnownFailureTestCommandWithFallbackFailure();
@@ -5729,7 +5730,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -5780,7 +5781,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - onRunSuccess - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onRunSuccess - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -5828,7 +5829,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackSuccess - onRunSuccess - onThreadComplete - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackSuccess - onComplete - onRunSuccess - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -5931,7 +5932,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(0, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onFallbackStart - onFallbackError - onError - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -5979,7 +5980,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(0, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onFallbackStart - onFallbackError - onError - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -6108,7 +6109,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(0, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onFallbackStart - onFallbackError - onError - onComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
@@ -6146,7 +6147,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             // we should not have a response from execute()
             assertNull(command.builder.executionHook.endExecuteSuccessResponse);
             // we should not have an exception since run() succeeded
-            assertNull(command.builder.executionHook.endExecuteFailureException);
+            assertNotNull(command.builder.executionHook.endExecuteFailureException);
 
             // thread execution
             assertEquals(0, command.builder.executionHook.threadStart.get());

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -842,7 +842,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
         if (properties.executionIsolationStrategy().get().equals(ExecutionIsolationStrategy.THREAD)) {
             // wrap for timeout support
-            o = new TimeoutObservable<R>(o, _this, performAsyncTimeout, executionHook);
+            o = new TimeoutObservable<R>(o, _this, performAsyncTimeout);
         }
 
         // error handling
@@ -1003,7 +1003,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
     private static class TimeoutObservable<R> extends Observable<R> {
 
-        public TimeoutObservable(final Observable<R> o, final HystrixCommand<R> originalCommand, final boolean isNonBlocking, final HystrixCommandExecutionHook executionHook) {
+        public TimeoutObservable(final Observable<R> o, final HystrixCommand<R> originalCommand, final boolean isNonBlocking) {
             super(new OnSubscribe<R>() {
 
                 @Override

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -5792,7 +5792,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             assertEquals(1, command.builder.executionHook.threadComplete.get());
 
             // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onRunSuccess - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - onRunSuccess - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**

--- a/hystrix-core/src/main/java/com/netflix/hystrix/exception/HystrixRuntimeException.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/exception/HystrixRuntimeException.java
@@ -31,7 +31,7 @@ public class HystrixRuntimeException extends RuntimeException {
     private final FailureType failureCause;
 
     public static enum FailureType {
-        COMMAND_EXCEPTION, TIMEOUT, SHORTCIRCUIT, REJECTED_THREAD_EXECUTION, REJECTED_SEMAPHORE_EXECUTION, REJECTED_SEMAPHORE_FALLBACK
+        COMMAND_EXCEPTION, TIMEOUT, SHORTCIRCUIT, REJECTED_THREAD_EXECUTION, REJECTED_SEMAPHORE_EXECUTION, BAD_REQUEST_EXCEPTION, REJECTED_SEMAPHORE_FALLBACK
     }
 
     public HystrixRuntimeException(FailureType failureCause, Class<? extends HystrixCommand> commandClass, String message, Exception cause, Throwable fallbackException) {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/exception/HystrixRuntimeException.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/exception/HystrixRuntimeException.java
@@ -31,7 +31,7 @@ public class HystrixRuntimeException extends RuntimeException {
     private final FailureType failureCause;
 
     public static enum FailureType {
-        COMMAND_EXCEPTION, TIMEOUT, SHORTCIRCUIT, REJECTED_THREAD_EXECUTION, REJECTED_SEMAPHORE_EXECUTION, BAD_REQUEST_EXCEPTION, REJECTED_SEMAPHORE_FALLBACK
+        BAD_REQUEST_EXCEPTION, COMMAND_EXCEPTION, TIMEOUT, SHORTCIRCUIT, REJECTED_THREAD_EXECUTION, REJECTED_SEMAPHORE_EXECUTION, REJECTED_SEMAPHORE_FALLBACK
     }
 
     public HystrixRuntimeException(FailureType failureCause, Class<? extends HystrixCommand> commandClass, String message, Exception cause, Throwable fallbackException) {


### PR DESCRIPTION
This pull request asserts that the proper calls on HystrixCommandExecutionHook are made.  The bugfixes identified by these assertions are:

* HystrixBadRequestException flow was not invoking ```onError()```
* run() throwing an Exception with a successful fallback was invoking ```onComplete()``` twice