### PR TITLE
Fixed Clojure unit tests that failed with RxJava 1.0 (Backport from master)

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
+++ b/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
@@ -634,10 +634,10 @@
 (extend-protocol ObserveLater
   HystrixCommand
     (observe-later* [this] (.toObservable this))
-    (observe-later-on* [this scheduler] (.toObservable this scheduler))
+    (observe-later-on* [this scheduler] (.observeOn (.toObservable this) scheduler))
   HystrixCollapser
     (observe-later* [this] (.toObservable this))
-    (observe-later-on* [this scheduler] (.toObservable this scheduler)))
+    (observe-later-on* [this scheduler] (.observeOne (.toObservable this) scheduler)))
 
 (defn observe-later
   "Same as #'com.netflix.hystrix.core/observe, but command execution does not begin until the

--- a/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
+++ b/hystrix-contrib/hystrix-clj/src/test/clojure/com/netflix/hystrix/core_test.clj
@@ -174,7 +174,7 @@
 
 (defn ^:private wait-for-observable
   [^rx.Observable o]
-  (-> o .toBlockingObservable .single))
+  (-> o .toBlocking .single))
 
 (deftest test-observe
   (let [base-def {:type :command


### PR DESCRIPTION
* s/toBlockingObservable/toBlocking
* Changed implementation of observe-later-on to use Observable.observeOn