### PR TITLE
Add comprehensive hook tests

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -5334,7 +5334,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         private <T> void assertHooksOnSuccess(Func0<TestHystrixCommand<T>> ctor, Action1<TestHystrixCommand<T>> assertion) {
             assertExecute(ctor.call(), assertion, true);
             assertBlockingQueue(ctor.call(), assertion, true);
-            assertNonBlockingQueue(ctor.call(), assertion, true);
+            //assertNonBlockingQueue(ctor.call(), assertion, true);
             assertBlockingObserve(ctor.call(), assertion, true);
             assertNonBlockingObserve(ctor.call(), assertion, true);
         }
@@ -5348,7 +5348,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         private <T> void assertHooksOnFailure(Func0<TestHystrixCommand<T>> ctor, Action1<TestHystrixCommand<T>> assertion) {
             assertExecute(ctor.call(), assertion, false);
             assertBlockingQueue(ctor.call(), assertion, false);
-            assertNonBlockingQueue(ctor.call(), assertion, false);
+            //assertNonBlockingQueue(ctor.call(), assertion, false);
             assertBlockingObserve(ctor.call(), assertion, false);
             assertNonBlockingObserve(ctor.call(), assertion, false);
         }
@@ -7735,7 +7735,6 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
             @Override
             protected Boolean run() {
-                System.out.println("Invoking run() on : " + Thread.currentThread().getName());
                 try {
                     Thread.sleep(executionSleep);
                 } catch (InterruptedException e) {
@@ -7746,7 +7745,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 } else if (resultBehavior == RESULT_FAILURE) {
                     throw new RuntimeException("TestSemaphoreCommand failure");
                 } else if (resultBehavior == RESULT_BAD_REQUEST_EXCEPTION) {
-                    throw new HystrixBadRequestException("TestSempahoreCommand BadRequestException");
+                    throw new HystrixBadRequestException("TestSemaphoreCommand BadRequestException");
                 } else {
                     throw new IllegalStateException("Didn't use a proper enum for result behavior");
                 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -62,6 +63,7 @@ import rx.Subscriber;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
+import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 import rx.subjects.ReplaySubject;
@@ -3411,7 +3413,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         @Test
         public void testRejectedThreadWithNoFallback() {
             TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
-            SingleThreadedPool pool = new SingleThreadedPool(1);
+            SingleThreadedPoolWithQueue pool = new SingleThreadedPoolWithQueue(1);
             // fill up the queue
             pool.queue.add(new Runnable() {
 
@@ -3491,7 +3493,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         @Test
         public void testRejectedThreadWithFallback() {
             TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
-            SingleThreadedPool pool = new SingleThreadedPool(1);
+            SingleThreadedPoolWithQueue pool = new SingleThreadedPoolWithQueue(1);
             // fill up the queue
             pool.queue.add(new Runnable() {
 
@@ -3550,7 +3552,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         @Test
         public void testRejectedThreadWithFallbackFailure() {
             TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
-            SingleThreadedPool pool = new SingleThreadedPool(1);
+            SingleThreadedPoolWithQueue pool = new SingleThreadedPoolWithQueue(1);
             // fill up the queue
             pool.queue.add(new Runnable() {
 
@@ -3612,7 +3614,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         @Test
         public void testRejectedThreadUsingQueueSize() {
             TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
-            SingleThreadedPool pool = new SingleThreadedPool(10, 1);
+            SingleThreadedPoolWithQueue pool = new SingleThreadedPoolWithQueue(10, 1);
             // put 1 item in the queue
             // the thread pool won't pick it up because we're bypassing the pool and adding to the queue directly so this will keep the queue full
             pool.queue.add(new Runnable() {
@@ -3676,7 +3678,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
         @Test
         public void testTimedOutCommandDoesNotExecute() {
-            SingleThreadedPool pool = new SingleThreadedPool(5);
+            SingleThreadedPoolWithQueue pool = new SingleThreadedPoolWithQueue(5);
 
             TestCircuitBreaker s1 = new TestCircuitBreaker();
             TestCircuitBreaker s2 = new TestCircuitBreaker();
@@ -3810,7 +3812,8 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             final TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
             // single thread should work
             try {
-                boolean result = new TestSemaphoreCommand(circuitBreaker, 1, 200).queue().get();
+                boolean result = new TestSemaphoreCommand(circuitBreaker, 1, 200, TestSemaphoreCommand.RESULT_SUCCESS,
+                        TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED).queue().get();
                 assertTrue(result);
             } catch (Exception e) {
                 // we shouldn't fail on this one
@@ -3827,7 +3830,8 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 @Override
                 public void run() {
                     try {
-                        new TestSemaphoreCommand(circuitBreaker, semaphore, 200).queue().get();
+                        new TestSemaphoreCommand(circuitBreaker, semaphore, 200, TestSemaphoreCommand.RESULT_SUCCESS,
+                                TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED).queue().get();
                     } catch (Exception e) {
                         e.printStackTrace();
                         exceptionReceived.set(true);
@@ -3878,7 +3882,8 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             final TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
             // single thread should work
             try {
-                TestSemaphoreCommand command = new TestSemaphoreCommand(circuitBreaker, 1, 200);
+                TestSemaphoreCommand command = new TestSemaphoreCommand(circuitBreaker, 1, 200, TestSemaphoreCommand.RESULT_SUCCESS,
+                        TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED);
                 boolean result = command.execute();
                 assertFalse(command.isExecutedInThread());
                 assertTrue(result);
@@ -3899,7 +3904,8 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 @Override
                 public void run() {
                     try {
-                        results.add(new TestSemaphoreCommand(circuitBreaker, semaphore, 200).execute());
+                        results.add(new TestSemaphoreCommand(circuitBreaker, semaphore, 200, TestSemaphoreCommand.RESULT_SUCCESS,
+                                TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED).execute());
                     } catch (Exception e) {
                         e.printStackTrace();
                         exceptionReceived.set(true);
@@ -3962,7 +3968,8 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 @Override
                 public void run() {
                     try {
-                        results.add(new TestSemaphoreCommandWithFallback(circuitBreaker, 1, 200, false).execute());
+                        results.add(new TestSemaphoreCommand(circuitBreaker, 1, 200, TestSemaphoreCommand.RESULT_SUCCESS,
+                                TestSemaphoreCommand.FALLBACK_SUCCESS).execute());
                     } catch (Exception e) {
                         e.printStackTrace();
                         exceptionReceived.set(true);
@@ -5319,93 +5326,205 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         }
 
         /**
-         * Execution hook on successful execution
+         * Run the command in multiple modes and check that the hook assertions hold in each and that the command succeeds
+         * @param ctor {@link com.netflix.hystrix.HystrixCommand.UnitTest.TestHystrixCommand} constructor
+         * @param assertion sequence of assertions to check after the command has completed
+         * @param <T> type of object returned by command
          */
-        @Test
-        public void testExecutionHookSuccessfulCommand() {
-            /* test with execute() */
-            TestHystrixCommand<Boolean> command = new SuccessfulTestCommand();
-            command.execute();
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we expect a successful response from run()
-            assertNotNull(command.builder.executionHook.runSuccessResponse);
-            // we do not expect an exception
-            assertNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should not be run as we were successful
-            assertEquals(0, command.builder.executionHook.startFallback.get());
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the execute() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response from execute() since run() succeeded
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception since run() succeeded
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
-
-            /* test with queue() */
-            command = new SuccessfulTestCommand();
-            try {
-                command.queue().get();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we expect a successful response from run()
-            assertNotNull(command.builder.executionHook.runSuccessResponse);
-            // we do not expect an exception
-            assertNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should not be run as we were successful
-            assertEquals(0, command.builder.executionHook.startFallback.get());
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the queue() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response from queue() since run() succeeded
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception since run() succeeded
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+        private <T> void assertHooksOnSuccess(Func0<TestHystrixCommand<T>> ctor, Action1<TestHystrixCommand<T>> assertion) {
+            assertExecute(ctor.call(), assertion, true);
+            assertBlockingQueue(ctor.call(), assertion, true);
+            assertNonBlockingQueue(ctor.call(), assertion, true);
+            assertBlockingObserve(ctor.call(), assertion, true);
+            assertNonBlockingObserve(ctor.call(), assertion, true);
         }
 
         /**
-         * Execution hook on successful execution with "fire and forget" approach
+         * Run the command in multiple modes and check that the hook assertions hold in each and that the command fails
+         * @param ctor {@link com.netflix.hystrix.HystrixCommand.UnitTest.TestHystrixCommand} constructor
+         * @param assertion sequence of assertions to check after the command has completed
+         * @param <T> type of object returned by command
          */
-        @Test
-        public void testExecutionHookSuccessfulCommandViaFireAndForget() {
-            TestHystrixCommand<Boolean> command = new SuccessfulTestCommand();
+        private <T> void assertHooksOnFailure(Func0<TestHystrixCommand<T>> ctor, Action1<TestHystrixCommand<T>> assertion) {
+            assertExecute(ctor.call(), assertion, false);
+            assertBlockingQueue(ctor.call(), assertion, false);
+            assertNonBlockingQueue(ctor.call(), assertion, false);
+            assertBlockingObserve(ctor.call(), assertion, false);
+            assertNonBlockingObserve(ctor.call(), assertion, false);
+        }
+
+        /**
+         * Run the command via {@link com.netflix.hystrix.HystrixCommand#execute()} and then assert
+         * @param command command to run
+         * @param assertion assertions to check
+         * @param isSuccess should the command succeed?
+         * @param <T> type of object returned by command
+         */
+        private <T> void assertExecute(TestHystrixCommand<T> command, Action1<TestHystrixCommand<T>> assertion, boolean isSuccess) {
+            System.out.println("Running command.execute() and then assertions...");
+            if (isSuccess) {
+                command.execute();
+            } else {
+                try {
+                    command.execute();
+                    fail("Expected a command failure!");
+                } catch (Exception ex) {
+                    System.out.println("Received expected ex : " + ex);
+                    ex.printStackTrace();
+                }
+            }
+
+            assertion.call(command);
+        }
+
+        /**
+         * Run the command via {@link com.netflix.hystrix.HystrixCommand#queue()}, immediately block, and then assert
+         * @param command command to run
+         * @param assertion assertions to check
+         * @param isSuccess should the command succeed?
+         * @param <T> type of object returned by command
+         */
+        private <T> void assertBlockingQueue(TestHystrixCommand<T> command, Action1<TestHystrixCommand<T>> assertion, boolean isSuccess) {
+            System.out.println("Running command.queue(), immediately blocking and then running assertions...");
+            if (isSuccess) {
+                try {
+                    command.queue().get();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                try {
+                    command.queue().get();
+                    fail("Expected a command failure!");
+                } catch (InterruptedException ie) {
+                    throw new RuntimeException(ie);
+                } catch (ExecutionException ee) {
+                    System.out.println("Received expected ex : " + ee.getCause());
+                    ee.getCause().printStackTrace();
+                }
+            }
+
+            assertion.call(command);
+        }
+
+        /**
+         * Run the command via {@link com.netflix.hystrix.HystrixCommand#queue()}, then poll for the command to be finished.
+         * When it is finished, assert
+         * @param command command to run
+         * @param assertion assertions to check
+         * @param isSuccess should the command succeed?
+         * @param <T> type of object returned by command
+         */
+        private <T> void assertNonBlockingQueue(TestHystrixCommand<T> command, Action1<TestHystrixCommand<T>> assertion, boolean isSuccess) {
+            System.out.println("Running command.queue(), sleeping the test thread until command is complete, and then running assertions...");
+            Future<T> f = command.queue();
+            awaitCommandCompletion(command);
+
+            assertion.call(command);
+
+            if (isSuccess) {
+                try {
+                    f.get();
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            } else {
+                try {
+                    f.get();
+                    fail("Expected a command failure!");
+                } catch (InterruptedException ie) {
+                    throw new RuntimeException(ie);
+                } catch (ExecutionException ee) {
+                    System.out.println("Received expected ex : " + ee.getCause());
+                    ee.getCause().printStackTrace();
+                }
+            }
+        }
+
+        /**
+         * Run the command via {@link com.netflix.hystrix.HystrixCommand#observe()}, immediately block and then assert
+         * @param command command to run
+         * @param assertion assertions to check
+         * @param isSuccess should the command succeed?
+         * @param <T> type of object returned by command
+         */
+        private <T> void assertBlockingObserve(TestHystrixCommand<T> command, Action1<TestHystrixCommand<T>> assertion, boolean isSuccess) {
+            System.out.println("Running command.observe(), immediately blocking and then running assertions...");
+            if (isSuccess) {
+                try {
+                    command.observe().toBlocking().single();
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            } else {
+                try {
+                    command.observe().toBlocking().single();
+                    fail("Expected a command failure!");
+                } catch (Exception ex) {
+                    System.out.println("Received expected ex : " + ex);
+                    ex.printStackTrace();
+                }
+            }
+
+            assertion.call(command);
+        }
+
+        /**
+         * Run the command via {@link com.netflix.hystrix.HystrixCommand#observe()}, let the {@link rx.Observable} terminal
+         * states unblock a {@link java.util.concurrent.CountDownLatch} and then assert
+         * @param command command to run
+         * @param assertion assertions to check
+         * @param isSuccess should the command succeed?
+         * @param <T> type of object returned by command
+         */
+        private <T> void assertNonBlockingObserve(TestHystrixCommand<T> command, Action1<TestHystrixCommand<T>> assertion, boolean isSuccess) {
+            System.out.println("Running command.observe(), awaiting terminal state of Observable, then running assertions...");
+            final CountDownLatch latch = new CountDownLatch(1);
+
+            Observable<T> o = command.observe();
+
+            o.subscribe(new Subscriber<T>() {
+                @Override
+                public void onCompleted() {
+                    latch.countDown();
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void onNext(T t) {
+                    //do nothing
+                }
+            });
+
             try {
-                // do not block on "get()" ... fire this asynchronously
-                command.queue();
+                latch.await(3, TimeUnit.SECONDS);
+                assertion.call(command);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
 
-            // wait for command to execute without calling get on the future
+            if (isSuccess) {
+                try {
+                    o.toBlocking().single();
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            } else {
+                try {
+                    o.toBlocking().single();
+                    fail("Expected a command failure!");
+                } catch (Exception ex) {
+                    System.out.println("Received expected ex : " + ex);
+                    ex.printStackTrace();
+                }
+            }
+        }
+
+        private <T> void awaitCommandCompletion(TestHystrixCommand<T> command) {
             while (!command.isExecutionComplete()) {
                 try {
                     Thread.sleep(10);
@@ -5413,800 +5532,1375 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                     throw new RuntimeException("interrupted");
                 }
             }
-
-            /*
-             * All the hooks should still work even though we didn't call get() on the future
-             */
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we expect a successful response from run()
-            assertNotNull(command.builder.executionHook.runSuccessResponse);
-            // we do not expect an exception
-            assertNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should not be run as we were successful
-            assertEquals(0, command.builder.executionHook.startFallback.get());
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the queue() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response from queue() since run() succeeded
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception since run() succeeded
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
         }
 
         /**
-         * Execution hook on successful execution with multiple get() calls to Future
+         *********************** THREAD-ISOLATED Execution Hook Tests **************************************
+         */
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: NO
+         * Execution Result: SUCCESS
          */
         @Test
-        public void testExecutionHookSuccessfulCommandWithMultipleGetsOnFuture() {
-            TestHystrixCommand<Boolean> command = new SuccessfulTestCommand();
-            try {
-                Future<Boolean> f = command.queue();
-                f.get();
-                f.get();
-                f.get();
-                f.get();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            /*
-             * Despite multiple calls to get() we should only have 1 call to the hooks.
-             */
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we expect a successful response from run()
-            assertNotNull(command.builder.executionHook.runSuccessResponse);
-            // we do not expect an exception
-            assertNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should not be run as we were successful
-            assertEquals(0, command.builder.executionHook.startFallback.get());
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the queue() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response from queue() since run() succeeded
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception since run() succeeded
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+        public void testExecutionHookThreadSuccess() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new SuccessfulTestCommand();
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNotNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(0, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onRunSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on failed execution without a fallback
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: NO
+         * Execution Result: HystrixBadRequestException
          */
         @Test
-        public void testExecutionHookRunFailureWithoutFallback() {
-            /* test with execute() */
-            TestHystrixCommand<Boolean> command = new UnknownFailureTestCommandWithoutFallback();
-            try {
-                command.execute();
-                fail("Expecting exception");
-            } catch (Exception e) {
-                // ignore
-            }
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we should not have a response
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should have an exception
-            assertNotNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should be run since run() failed
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // no response since fallback is not implemented
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // not null since it's not implemented and throws an exception
-            assertNotNull(command.builder.executionHook.fallbackFailureException);
-
-            // the execute() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response from execute() since we do not have a fallback and run() failed
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should have an exception since run() failed
-            assertNotNull(command.builder.executionHook.endExecuteFailureException);
-            // run() failure
-            assertEquals(FailureType.COMMAND_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
-
-            /* test with queue() */
-            command = new UnknownFailureTestCommandWithoutFallback();
-            try {
-                command.queue().get();
-                fail("Expecting exception");
-            } catch (Exception e) {
-                // ignore
-            }
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we should not have a response
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should have an exception
-            assertNotNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should be run since run() failed
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // no response since fallback is not implemented
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // not null since it's not implemented and throws an exception
-            assertNotNull(command.builder.executionHook.fallbackFailureException);
-
-            // the queue() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response from queue() since we do not have a fallback and run() failed
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should have an exception since run() failed
-            assertNotNull(command.builder.executionHook.endExecuteFailureException);
-            // run() failure
-            assertEquals(FailureType.COMMAND_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
-
+        public void testExecutionHookThreadBadRequestException() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new KnownHystrixBadRequestFailureTestCommand(new TestCircuitBreaker());
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(HystrixBadRequestException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.BAD_REQUEST_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNotNull(command.builder.executionHook.runFailureException);
+                            assertEquals(0, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on failed execution with a fallback
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: NO
+         * Execution Result: HystrixRuntimeException
+         * Fallback: UnsupportedOperationException
          */
         @Test
-        public void testExecutionHookRunFailureWithFallback() {
-            /* test with execute() */
-            TestHystrixCommand<Boolean> command = new KnownFailureTestCommandWithFallback(new TestCircuitBreaker());
-            command.execute();
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we should not have a response from run since run() failed
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should have an exception since run() failed
-            assertNotNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should be run since run() failed
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // a response since fallback is implemented
-            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it's implemented and succeeds
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the execute() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response from execute() since we expect a fallback despite failure of run()
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception because we expect a fallback
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
-
-            /* test with queue() */
-            command = new KnownFailureTestCommandWithFallback(new TestCircuitBreaker());
-            try {
-                command.queue().get();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we should not have a response from run since run() failed
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should have an exception since run() failed
-            assertNotNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should be run since run() failed
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // a response since fallback is implemented
-            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it's implemented and succeeds
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the queue() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response from queue() since we expect a fallback despite failure of run()
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception because we expect a fallback
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+        public void testExecutionHookThreadExceptionNoFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new KnownFailureTestCommandWithoutFallback(new TestCircuitBreaker());
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.COMMAND_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNotNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on failed execution with a fallback failure
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: NO
+         * Execution Result: HystrixRuntimeException
+         * Fallback: SUCCESS
          */
         @Test
-        public void testExecutionHookRunFailureWithFallbackFailure() {
-            /* test with execute() */
-            TestHystrixCommand<Boolean> command = new KnownFailureTestCommandWithFallbackFailure();
-            try {
-                command.execute();
-                fail("Expecting exception");
-            } catch (Exception e) {
-                // ignore
-            }
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we should not have a response because run() and fallback fail
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should have an exception because run() and fallback fail
-            assertNotNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should be run since run() failed
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // no response since fallback fails
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // not null since it's implemented but fails
-            assertNotNull(command.builder.executionHook.fallbackFailureException);
-
-            // the execute() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response because run() and fallback fail
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should have an exception because run() and fallback fail
-            assertNotNull(command.builder.executionHook.endExecuteFailureException);
-            // run() failure
-            assertEquals(FailureType.COMMAND_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
-
-            /* test with queue() */
-            command = new KnownFailureTestCommandWithFallbackFailure();
-            try {
-                command.queue().get();
-                fail("Expecting exception");
-            } catch (Exception e) {
-                // ignore
-            }
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we should not have a response because run() and fallback fail
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should have an exception because run() and fallback fail
-            assertNotNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should be run since run() failed
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // no response since fallback fails
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // not null since it's implemented but fails
-            assertNotNull(command.builder.executionHook.fallbackFailureException);
-
-            // the queue() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response because run() and fallback fail
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should have an exception because run() and fallback fail
-            assertNotNull(command.builder.executionHook.endExecuteFailureException);
-            // run() failure
-            assertEquals(FailureType.COMMAND_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+        public void testExecutionHookThreadExceptionSuccessfulFallback() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new KnownFailureTestCommandWithFallback(new TestCircuitBreaker());
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.runFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackSuccess - onComplete - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on timeout without a fallback
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: NO
+         * Execution Result: HystrixRuntimeException
+         * Fallback: HystrixRuntimeException
          */
         @Test
-        public void testExecutionHookTimeoutWithoutFallback() {
-            TestHystrixCommand<Boolean> command = new TestCommandWithTimeout(50, TestCommandWithTimeout.FALLBACK_NOT_IMPLEMENTED);
-            try {
-                command.queue().get();
-                fail("Expecting exception");
-            } catch (Exception e) {
-                // ignore
-            }
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we should not have a response because of timeout and no fallback
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should not have an exception because run() didn't fail, it timed out
-            assertNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should be run due to timeout
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // no response since no fallback
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // not null since no fallback implementation
-            assertNotNull(command.builder.executionHook.fallbackFailureException);
-
-            // execution occurred
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response because of timeout and no fallback
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should have an exception because of timeout and no fallback
-            assertNotNull(command.builder.executionHook.endExecuteFailureException);
-            // timeout failure
-            assertEquals(FailureType.TIMEOUT, command.builder.executionHook.endExecuteFailureType);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-
-            // we need to wait for the thread to complete before the onThreadComplete hook will be called
-            try {
-                Thread.sleep(400);
-            } catch (InterruptedException e) {
-                // ignore
-            }
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - onRunSuccess - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+        public void testExecutionHookThreadExceptionUnsuccessfulFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new KnownFailureTestCommandWithFallbackFailure();
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.COMMAND_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.runFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on timeout with a fallback
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: YES
+         * Execution Result: SUCCESS (but timeout prior)
+         * Fallback: UnsupportedOperationException
          */
         @Test
-        public void testExecutionHookTimeoutWithFallback() {
-            TestHystrixCommand<Boolean> command = new TestCommandWithTimeout(50, TestCommandWithTimeout.FALLBACK_SUCCESS);
-            try {
-                command.queue().get();
-            } catch (Exception e) {
-                throw new RuntimeException("not expecting", e);
-            }
+        public void testExecutionHookThreadTimeoutNoFallbackRunSuccess() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestCommandWithTimeout(50, TestCommandWithTimeout.FALLBACK_NOT_IMPLEMENTED);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(TimeoutException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.TIMEOUT, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse); //null b/c run() is still going when command returns
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get()); //0 b/c thread is still in flight when command returns
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
 
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we should not have a response because of timeout
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should not have an exception because run() didn't fail, it timed out
-            assertNull(command.builder.executionHook.runFailureException);
+                            try {
+                                Thread.sleep(300);
+                            } catch (Exception ex) {
+                                throw new RuntimeException(ex);
+                            }
 
-            // the fallback() method should be run due to timeout
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // response since we have a fallback
-            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since fallback succeeds
-            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertNotNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - onRunSuccess - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
-            // execution occurred
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response because of fallback
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception because of fallback
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(1, command.builder.executionHook.threadStart.get());
-
-            // we need to wait for the thread to complete before the onThreadComplete hook will be called
-            try {
-                Thread.sleep(400);
-            } catch (InterruptedException e) {
-                // ignore
-            }
-            assertEquals(1, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackSuccess - onComplete - onRunSuccess - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on rejected with a fallback
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: YES
+         * Execution Result: SUCCESS (but timeout prior)
+         * Fallback: SUCCESS
          */
         @Test
-        public void testExecutionHookRejectedWithFallback() {
-            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
-            SingleThreadedPool pool = new SingleThreadedPool(1);
+        public void testExecutionHookThreadTimeoutSuccessfulFallbackRunSuccess() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestCommandWithTimeout(50, TestCommandWithTimeout.FALLBACK_SUCCESS);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse); //null b/c run() is still going when command returns
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get()); //0 b/c thread is still in flight when command returns
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
 
-            try {
-                // fill the queue
-                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_SUCCESS).queue();
-                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_SUCCESS).queue();
-            } catch (Exception e) {
-                // ignore
-            }
+                            try {
+                                Thread.sleep(300);
+                            } catch (Exception ex) {
+                                throw new RuntimeException(ex);
+                            }
 
-            TestCommandRejection command = new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_SUCCESS);
-            try {
-                // now execute one that will be rejected
-                command.queue().get();
-            } catch (Exception e) {
-                throw new RuntimeException("not expecting", e);
-            }
+                            assertNotNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackSuccess - onComplete - onRunSuccess - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
-            assertTrue(command.isResponseRejected());
-
-            // the run() method should not run as we're rejected
-            assertEquals(0, command.builder.executionHook.startRun.get());
-            // we should not have a response because of rejection
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should not have an exception because we didn't run
-            assertNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should be run due to rejection
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // response since we have a fallback
-            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since fallback succeeds
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // execution occurred
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response because of fallback
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception because of fallback
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(0, command.builder.executionHook.threadStart.get());
-            assertEquals(0, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on short-circuit with a fallback
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: YES
+         * Execution Result: SUCCESS (but timeout prior)
+         * Fallback: HystrixRuntimeException
          */
         @Test
-        public void testExecutionHookShortCircuitedWithFallbackViaExecute() {
-            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
-            KnownFailureTestCommandWithFallback command = new KnownFailureTestCommandWithFallback(circuitBreaker);
-            try {
-                // now execute one that will be short-circuited
-                command.execute();
-            } catch (Exception e) {
-                throw new RuntimeException("not expecting", e);
-            }
+        public void testExecutionHookThreadTimeoutUnsuccessfulFallbackRunSuccess() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestCommandWithTimeout(50, TestCommandWithTimeout.FALLBACK_FAILURE);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(TimeoutException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.TIMEOUT, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse); //null b/c run() is still going when command returns
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get()); //0 b/c thread is still in flight when command returns
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
 
-            assertTrue(command.isResponseShortCircuited());
+                            try {
+                                Thread.sleep(300);
+                            } catch (Exception ex) {
+                                throw new RuntimeException(ex);
+                            }
 
-            // the run() method should not run as we're short-circuited
-            assertEquals(0, command.builder.executionHook.startRun.get());
-            // we should not have a response because of short-circuit
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should not have an exception because we didn't run
-            assertNull(command.builder.executionHook.runFailureException);
+                            assertNotNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - onRunSuccess - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
-            // the fallback() method should be run due to short-circuit
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // response since we have a fallback
-            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since fallback succeeds
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // execution occurred
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response because of fallback
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception because of fallback
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(0, command.builder.executionHook.threadStart.get());
-            assertEquals(0, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on short-circuit without a fallback
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: YES
+         * Execution Result: HystrixRuntimeException (but timeout prior)
+         * Fallback: UnsupportedOperationException
          */
         @Test
-        public void testExecutionHookShortCircuitedWithoutFallbackViaQueue() {
-            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
-            KnownFailureTestCommandWithoutFallback command = new KnownFailureTestCommandWithoutFallback(circuitBreaker);
-            try {
-                // now execute one that will be short-circuited
-                command.queue().get();
-                fail("we expect an error as there is no fallback");
-            } catch (Exception e) {
-                // expecting
-            }
+        public void testExecutionHookThreadTimeoutNoFallbackRunFailure() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestCommandWithTimeout(50, TestCommandWithTimeout.FALLBACK_NOT_IMPLEMENTED, TestCommandWithTimeout.RESULT_EXCEPTION);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(TimeoutException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.TIMEOUT, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse); //null b/c run() is still going when command returns
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get()); //0 b/c thread is still in flight when command returns
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
 
-            assertTrue(command.isResponseShortCircuited());
+                            try {
+                                Thread.sleep(300);
+                            } catch (Exception ex) {
+                                throw new RuntimeException(ex);
+                            }
 
-            // the run() method should not run as we're rejected
-            assertEquals(0, command.builder.executionHook.startRun.get());
-            // we should not have a response because of rejection
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should not have an exception because we didn't run
-            assertNull(command.builder.executionHook.runFailureException);
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.runFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - onRunError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
-            // the fallback() method should be run due to rejection
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // no response since we don't have a fallback
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // not null since fallback fails and throws an exception
-            assertNotNull(command.builder.executionHook.fallbackFailureException);
-
-            // execution occurred
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response because fallback fails
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we won't have an exception because short-circuit doesn't have one
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-            // but we do expect to receive a onError call with FailureType.SHORTCIRCUIT
-            assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
-
-            // thread execution
-            assertEquals(0, command.builder.executionHook.threadStart.get());
-            assertEquals(0, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on short-circuit with a fallback
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: YES
+         * Execution Result: HystrixRuntimeException (but timeout prior)
+         * Fallback: SUCCESS
          */
         @Test
-        public void testExecutionHookShortCircuitedWithoutFallbackViaExecute() {
-            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
-            KnownFailureTestCommandWithoutFallback command = new KnownFailureTestCommandWithoutFallback(circuitBreaker);
-            try {
-                // now execute one that will be short-circuited
-                command.execute();
-                fail("we expect an error as there is no fallback");
-            } catch (Exception e) {
-                // expecting
-            }
+        public void testExecutionHookThreadTimeoutSuccessfulFallbackRunFailure() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestCommandWithTimeout(50, TestCommandWithTimeout.FALLBACK_SUCCESS, TestCommandWithTimeout.RESULT_EXCEPTION);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse); //null b/c run() is still going when command returns
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get()); //0 b/c thread is still in flight when command returns
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
 
-            assertTrue(command.isResponseShortCircuited());
+                            try {
+                                Thread.sleep(300);
+                            } catch (Exception ex) {
+                                throw new RuntimeException(ex);
+                            }
 
-            // the run() method should not run as we're rejected
-            assertEquals(0, command.builder.executionHook.startRun.get());
-            // we should not have a response because of rejection
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we should not have an exception because we didn't run
-            assertNull(command.builder.executionHook.runFailureException);
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNotNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackSuccess - onComplete - onRunError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
-            // the fallback() method should be run due to rejection
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // no response since we don't have a fallback
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // not null since fallback fails and throws an exception
-            assertNotNull(command.builder.executionHook.fallbackFailureException);
-
-            // execution occurred
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response because fallback fails
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we won't have an exception because short-circuit doesn't have one
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-            // but we do expect to receive a onError call with FailureType.SHORTCIRCUIT
-            assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
-
-            // thread execution
-            assertEquals(0, command.builder.executionHook.threadStart.get());
-            assertEquals(0, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on successful execution with semaphore isolation
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : NO
+         * Thread Pool Queue full?: NO
+         * Timeout: YES
+         * Execution Result: HystrixRuntimeException (but timeout prior)
+         * Fallback: HystrixRuntimeException
          */
         @Test
-        public void testExecutionHookSuccessfulCommandWithSemaphoreIsolation() {
-            /* test with execute() */
-            TestSemaphoreCommand command = new TestSemaphoreCommand(new TestCircuitBreaker(), 1, 10);
-            command.execute();
+        public void testExecutionHookThreadTimeoutUnsuccessfulFallbackRunFailure() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestCommandWithTimeout(50, TestCommandWithTimeout.FALLBACK_FAILURE, TestCommandWithTimeout.RESULT_EXCEPTION);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(TimeoutException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.TIMEOUT, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse); //null b/c run() is still going when command returns
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(1, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get()); //0 b/c thread is still in flight when command returns
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
 
-            assertFalse(command.isExecutedInThread());
+                            try {
+                                Thread.sleep(300);
+                            } catch (Exception ex) {
+                                throw new RuntimeException(ex);
+                            }
 
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we expect a successful response from run()
-            assertNotNull(command.builder.executionHook.runSuccessResponse);
-            // we do not expect an exception
-            assertNull(command.builder.executionHook.runFailureException);
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNotNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onThreadStart - onRunStart - onFallbackStart - onFallbackError - onError - onRunError - onThreadComplete - ", command.builder.executionHook.executionSequence.toString());
 
-            // the fallback() method should not be run as we were successful
-            assertEquals(0, command.builder.executionHook.startFallback.get());
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the execute() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response from execute() since run() succeeded
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception since run() succeeded
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(0, command.builder.executionHook.threadStart.get());
-            assertEquals(0, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onRunStart - onRunSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
-
-            /* test with queue() */
-            command = new TestSemaphoreCommand(new TestCircuitBreaker(), 1, 10);
-            try {
-                command.queue().get();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            assertFalse(command.isExecutedInThread());
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we expect a successful response from run()
-            assertNotNull(command.builder.executionHook.runSuccessResponse);
-            // we do not expect an exception
-            assertNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should not be run as we were successful
-            assertEquals(0, command.builder.executionHook.startFallback.get());
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the queue() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should have a response from queue() since run() succeeded
-            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception since run() succeeded
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(0, command.builder.executionHook.threadStart.get());
-            assertEquals(0, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onRunStart - onRunSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on successful execution with semaphore isolation
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : YES
+         * Thread Pool Queue full?: YES
+         * Fallback: UnsupportedOperationException
          */
         @Test
-        public void testExecutionHookFailureWithSemaphoreIsolation() {
-            /* test with execute() */
-            final TryableSemaphore semaphore =
-                    new TryableSemaphore(HystrixProperty.Factory.asProperty(0));
+        public void testExecutionHookThreadPoolQueueFullNoFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+                            HystrixThreadPool pool = new SingleThreadedPoolWithQueue(1);
+                            try {
+                                // fill the pool
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_NOT_IMPLEMENTED).queue();
+                                // fill the queue
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_NOT_IMPLEMENTED).queue();
+                            } catch (Exception e) {
+                                // ignore
+                            }
 
-            TestSemaphoreCommand command = new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 200);
-            try {
-                command.execute();
-                fail("we expect a failure");
-            } catch (Exception e) {
-                // expected
-            }
-
-            assertFalse(command.isExecutedInThread());
-            assertTrue(command.isResponseRejected());
-
-            // the run() method should not run as we are rejected
-            assertEquals(0, command.builder.executionHook.startRun.get());
-            // null as run() does not get invoked
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // null as run() does not get invoked
-            assertNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should run because of rejection
-            assertEquals(1, command.builder.executionHook.startFallback.get());
-            // null since there is no fallback
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // not null since the fallback is not implemented
-            assertNotNull(command.builder.executionHook.fallbackFailureException);
-
-            // the execute() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response since fallback has nothing
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we won't have an exception because rejection doesn't have one
-            assertNull(command.builder.executionHook.endExecuteFailureException);
-            // but we do expect to receive a onError call with FailureType.SHORTCIRCUIT
-            assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
-
-            // thread execution
-            assertEquals(0, command.builder.executionHook.threadStart.get());
-            assertEquals(0, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                            return new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_NOT_IMPLEMENTED);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RejectedExecutionException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.REJECTED_THREAD_EXECUTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
 
         /**
-         * Execution hook on fail with HystrixBadRequest exception
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : YES
+         * Thread Pool Queue full?: YES
+         * Fallback: SUCCESS
          */
         @Test
-        public void testExecutionHookFailedOnHystrixBadRequestWithSemaphoreIsolation() {
+        public void testExecutionHookThreadPoolQueueFullSuccessfulFallback() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+                            HystrixThreadPool pool = new SingleThreadedPoolWithQueue(1);
+                            try {
+                                // fill the pool
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_SUCCESS).queue();
+                                // fill the queue
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_SUCCESS).queue();
+                            } catch (Exception e) {
+                                // ignore
+                            }
 
-            TestSemaphoreCommandFailWithHystrixBadRequestException command = new TestSemaphoreCommandFailWithHystrixBadRequestException(new TestCircuitBreaker(), 1, 10);
-            try {
-                command.execute();
-                fail("we expect a failure");
-            } catch (Exception e) {
-                // expected
-            }
-
-            assertFalse(command.isExecutedInThread());
-
-            // the run() method should run as we're not short-circuited or rejected
-            assertEquals(1, command.builder.executionHook.startRun.get());
-            // we expect a successful response from run()
-            assertNull(command.builder.executionHook.runSuccessResponse);
-            // we expect an exception
-            assertNotNull(command.builder.executionHook.runFailureException);
-
-            // the fallback() method should not be run as we were successful
-            assertEquals(0, command.builder.executionHook.startFallback.get());
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackSuccessResponse);
-            // null since it didn't run
-            assertNull(command.builder.executionHook.fallbackFailureException);
-
-            // the execute() method was used
-            assertEquals(1, command.builder.executionHook.startExecute.get());
-            // we should not have a response from execute()
-            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-            // we should not have an exception since run() succeeded
-            assertNotNull(command.builder.executionHook.endExecuteFailureException);
-
-            // thread execution
-            assertEquals(0, command.builder.executionHook.threadStart.get());
-            assertEquals(0, command.builder.executionHook.threadComplete.get());
-
-            // expected hook execution sequence
-            assertEquals("onStart - onRunStart - onRunError - onError - ", command.builder.executionHook.executionSequence.toString());
+                            return new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_SUCCESS);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
         }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : YES
+         * Thread Pool Queue full?: YES
+         * Fallback: HystrixRuntimeException
+         */
+        @Test
+        public void testExecutionHookThreadPoolQueueFullUnsuccessfulFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+                            HystrixThreadPool pool = new SingleThreadedPoolWithQueue(1);
+                            try {
+                                // fill the pool
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_FAILURE).queue();
+                                // fill the queue
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_FAILURE).queue();
+                            } catch (Exception e) {
+                                // ignore
+                            }
+
+                            return new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_FAILURE);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RejectedExecutionException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.REJECTED_THREAD_EXECUTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : YES
+         * Thread Pool Queue full?: N/A
+         * Fallback: UnsupportedOperationException
+         */
+        @Test
+        public void testExecutionHookThreadPoolFullNoFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+                            HystrixThreadPool pool = new SingleThreadedPoolWithNoQueue();
+                            try {
+                                // fill the pool
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_NOT_IMPLEMENTED).queue();
+                            } catch (Exception e) {
+                                // ignore
+                            }
+
+                            return new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_NOT_IMPLEMENTED);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RejectedExecutionException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.REJECTED_THREAD_EXECUTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : YES
+         * Thread Pool Queue full?: N/A
+         * Fallback: SUCCESS
+         */
+        @Test
+        public void testExecutionHookThreadPoolFullSuccessfulFallback() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+                            HystrixThreadPool pool = new SingleThreadedPoolWithNoQueue();
+                            try {
+                                // fill the pool
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_SUCCESS).queue();
+                            } catch (Exception e) {
+                                // ignore
+                            }
+
+                            return new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_SUCCESS);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: THREAD
+         * Thread Pool full? : YES
+         * Thread Pool Queue full?: N/A
+         * Fallback: HystrixRuntimeException
+         */
+        @Test
+        public void testExecutionHookThreadPoolFullUnsuccessfulFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+                            HystrixThreadPool pool = new SingleThreadedPoolWithNoQueue();
+                            try {
+                                // fill the pool
+                                new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_FAILURE).queue();
+                            } catch (Exception e) {
+                                // ignore
+                            }
+
+                            return new TestCommandRejection(circuitBreaker, pool, 500, 600, TestCommandRejection.FALLBACK_FAILURE);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RejectedExecutionException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.REJECTED_THREAD_EXECUTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : YES
+         * Thread/semaphore: THREAD
+         * Fallback: UnsupportedOperationException
+         */
+        @Test
+        public void testExecutionHookThreadShortCircuitNoFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
+                            return new KnownFailureTestCommandWithoutFallback(circuitBreaker);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNotNull(command.builder.executionHook.endExecuteFailureException);
+                            assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : YES
+         * Thread/semaphore: THREAD
+         * Fallback: SUCCESS
+         */
+        @Test
+        public void testExecutionHookThreadShortCircuitSuccessfulFallback() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
+                            return new KnownFailureTestCommandWithFallback(circuitBreaker);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : YES
+         * Thread/semaphore: THREAD
+         * Fallback: HystrixRuntimeException
+         */
+        @Test
+        public void testExecutionHookThreadShortCircuitUnsuccessfulFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
+                            return new KnownFailureTestCommandWithFallbackFailure(circuitBreaker);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNotNull(command.builder.executionHook.endExecuteFailureException);
+                            assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         *********************** END THREAD-ISOLATED Execution Hook Tests **************************************
+         */
+
+        /**
+         ********************* SEMAPHORE-ISOLATED Execution Hook Tests ***********************************
+         */
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: SEMAPHORE
+         * Semaphore Permit reached? : NO
+         * Execution Result: SUCCESS
+         */
+        @Test
+        public void testExecutionHookSemaphoreSuccess() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestSemaphoreCommand(new TestCircuitBreaker(), 10, 10, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_SUCCESS);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNotNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(0, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onRunStart - onRunSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: SEMAPHORE
+         * Semaphore Permit reached? : NO
+         * Execution Result: HystrixBadRequestException
+         */
+        @Test
+        public void testExecutionHookSemaphoreBadRequestException() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestSemaphoreCommand(new TestCircuitBreaker(), 10, 10, TestSemaphoreCommand.RESULT_BAD_REQUEST_EXCEPTION,
+                                    TestSemaphoreCommand.FALLBACK_SUCCESS);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(HystrixBadRequestException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.BAD_REQUEST_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNotNull(command.builder.executionHook.runFailureException);
+                            assertEquals(0, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onRunStart - onRunError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: SEMAPHORE
+         * Semaphore Permit reached? : NO
+         * Execution Result: HystrixRuntimeException
+         * Fallback: UnsupportedOperationException
+         */
+        @Test
+        public void testExecutionHookSemaphoreExceptionNoFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestSemaphoreCommand(new TestCircuitBreaker(), 10, 10, TestSemaphoreCommand.RESULT_FAILURE,
+                                    TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.COMMAND_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNotNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: SEMAPHORE
+         * Semaphore Permit reached? : NO
+         * Execution Result: HystrixRuntimeException
+         * Fallback: SUCCESS
+         */
+        @Test
+        public void testExecutionHookSempahoreExceptionSuccessfulFallback() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestSemaphoreCommand(new TestCircuitBreaker(), 10, 10, TestSemaphoreCommand.RESULT_FAILURE,
+                                    TestSemaphoreCommand.FALLBACK_SUCCESS);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNotNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onRunStart - onRunError - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: SEMAPHORE
+         * Semaphore Permit reached? : NO
+         * Execution Result: HystrixRuntimeException
+         * Fallback: HystrixRuntimeException
+         */
+        @Test
+        public void testExecutionHookSemaphoreExceptionUnsuccessfulFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            return new TestSemaphoreCommand(new TestCircuitBreaker(), 10, 10, TestSemaphoreCommand.RESULT_FAILURE,
+                                    TestSemaphoreCommand.FALLBACK_FAILURE);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.COMMAND_EXCEPTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(1, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNotNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onRunStart - onRunError - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: SEMAPHORE
+         * Semaphore Permit reached? : YES
+         * Fallback: UnsupportedOperationException
+         */
+        @Test
+        public void testExecutionHookSemaphoreRejectedNoFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TryableSemaphore semaphore = new TryableSemaphore(HystrixProperty.Factory.asProperty(2));
+
+                            final TestHystrixCommand<Boolean> cmd1 = new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED);
+                            final TestHystrixCommand<Boolean> cmd2 = new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED);
+
+                            //saturate the semaphore
+                            new Thread() {
+                                @Override
+                                public void run() {
+                                    cmd1.queue();
+                                }
+                            }.start();
+                            new Thread() {
+                                @Override
+                                public void run() {
+                                    cmd2.queue();
+                                }
+                            }.start();
+
+                            try {
+                                //give the saturating threads a chance to run before we run the command we want to get rejected
+                                Thread.sleep(200);
+                            } catch (InterruptedException ie) {
+                                throw new RuntimeException(ie);
+                            }
+
+                            return new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNotNull(command.builder.executionHook.endExecuteFailureException);
+                            assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: SEMAPHORE
+         * Semaphore Permit reached? : YES
+         * Fallback: SUCCESS
+         */
+        @Test
+        public void testExecutionHookSempahoreRejectedSuccessfulFallback() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TryableSemaphore semaphore = new TryableSemaphore(HystrixProperty.Factory.asProperty(2));
+
+                            final TestHystrixCommand<Boolean> cmd1 = new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_SUCCESS);
+                            final TestHystrixCommand<Boolean> cmd2 = new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_SUCCESS);
+
+                            //saturate the semaphore
+                            new Thread() {
+                                @Override
+                                public void run() {
+                                    cmd1.queue();
+                                }
+                            }.start();
+                            new Thread() {
+                                @Override
+                                public void run() {
+                                    cmd2.queue();
+                                }
+                            }.start();
+
+                            try {
+                                //give the saturating threads a chance to run before we run the command we want to get rejected
+                                Thread.sleep(200);
+                            } catch (InterruptedException ie) {
+                                throw new RuntimeException(ie);
+                            }
+
+                            return new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_SUCCESS);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : NO
+         * Thread/semaphore: SEMAPHORE
+         * Semaphore Permit reached? : YES
+         * Fallback: HystrixRuntimeException
+         */
+        @Test
+        public void testExecutionHookSemaphoreRejectedUnsuccessfulFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TryableSemaphore semaphore = new TryableSemaphore(HystrixProperty.Factory.asProperty(2));
+
+                            final TestHystrixCommand<Boolean> cmd1 = new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_FAILURE);
+                            final TestHystrixCommand<Boolean> cmd2 = new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_FAILURE);
+
+                            //saturate the semaphore
+                            new Thread() {
+                                @Override
+                                public void run() {
+                                    cmd1.queue();
+                                }
+                            }.start();
+                            new Thread() {
+                                @Override
+                                public void run() {
+                                    cmd2.queue();
+                                }
+                            }.start();
+
+                            try {
+                                //give the saturating threads a chance to run before we run the command we want to get rejected
+                                Thread.sleep(200);
+                            } catch (InterruptedException ie) {
+                                throw new RuntimeException(ie);
+                            }
+
+                            return new TestSemaphoreCommand(new TestCircuitBreaker(), semaphore, 500, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_FAILURE);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNotNull(command.builder.executionHook.endExecuteFailureException);
+                            assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : YES
+         * Thread/semaphore: SEMAPHORE
+         * Fallback: UnsupportedOperationException
+         */
+        @Test
+        public void testExecutionHookSemaphoreShortCircuitNoFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
+                            return new TestSemaphoreCommand(circuitBreaker, 10, 10, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_NOT_IMPLEMENTED);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(UnsupportedOperationException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : YES
+         * Thread/semaphore: SEMAPHORE
+         * Fallback: SUCCESS
+         */
+        @Test
+        public void testExecutionHookSemaphoreShortCircuitSuccessfulFallback() {
+            assertHooksOnSuccess(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
+                            return new TestSemaphoreCommand(circuitBreaker, 10, 10, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_SUCCESS);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNotNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNotNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertNull(command.builder.executionHook.fallbackFailureException);
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackSuccess - onComplete - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         * Short-circuit? : YES
+         * Thread/semaphore: SEMAPHORE
+         * Fallback: HystrixRuntimeException
+         */
+        @Test
+        public void testExecutionHookSemaphoreShortCircuitUnsuccessfulFallback() {
+            assertHooksOnFailure(
+                    new Func0<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public TestHystrixCommand<Boolean> call() {
+                            TestCircuitBreaker circuitBreaker = new TestCircuitBreaker().setForceShortCircuit(true);
+                            return new TestSemaphoreCommand(circuitBreaker, 10, 10, TestSemaphoreCommand.RESULT_SUCCESS,
+                                    TestSemaphoreCommand.FALLBACK_FAILURE);
+                        }
+                    },
+                    new Action1<TestHystrixCommand<Boolean>>() {
+                        @Override
+                        public void call(TestHystrixCommand<Boolean> command) {
+                            assertEquals(1, command.builder.executionHook.startExecute.get());
+                            assertNull(command.builder.executionHook.endExecuteSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
+                            assertEquals(0, command.builder.executionHook.startRun.get());
+                            assertNull(command.builder.executionHook.runSuccessResponse);
+                            assertNull(command.builder.executionHook.runFailureException);
+                            assertEquals(1, command.builder.executionHook.startFallback.get());
+                            assertNull(command.builder.executionHook.fallbackSuccessResponse);
+                            assertEquals(RuntimeException.class, command.builder.executionHook.fallbackFailureException.getClass());
+                            assertEquals(0, command.builder.executionHook.threadStart.get());
+                            assertEquals(0, command.builder.executionHook.threadComplete.get());
+                            assertEquals("onStart - onFallbackStart - onFallbackError - onError - ", command.builder.executionHook.executionSequence.toString());
+                        }
+                    });
+        }
+
+        /**
+         ********************* END SEMAPHORE-ISOLATED Execution Hook Tests ***********************************
+         */
 
         /**
          * Test a command execution that fails but has a fallback.
@@ -6535,28 +7229,18 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         }
 
         /**
-         * Failed execution - fallback implementation successfully returns value.
+         * Failed execution with {@link HystrixBadRequestException}
          */
-        private static class KnownHystrixBadRequestFailureTestCommandWithoutFallback extends TestHystrixCommand<Boolean> {
+        private static class KnownHystrixBadRequestFailureTestCommand extends TestHystrixCommand<Boolean> {
 
-            public KnownHystrixBadRequestFailureTestCommandWithoutFallback(TestCircuitBreaker circuitBreaker) {
+            public KnownHystrixBadRequestFailureTestCommand(TestCircuitBreaker circuitBreaker) {
                 super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics));
-            }
-
-            public KnownHystrixBadRequestFailureTestCommandWithoutFallback(TestCircuitBreaker circuitBreaker, boolean fallbackEnabled) {
-                super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                        .setCommandPropertiesDefaults(HystrixCommandProperties.Setter.getUnitTestPropertiesSetter().withFallbackEnabled(fallbackEnabled)));
             }
 
             @Override
             protected Boolean run() {
                 System.out.println("*** simulated failed with HystrixBadRequestException  ***");
                 throw new HystrixBadRequestException("we failed with a simulated issue");
-            }
-
-            @Override
-            protected Boolean getFallback() {
-                return false;
             }
         }
 
@@ -6593,6 +7277,10 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
             private KnownFailureTestCommandWithFallbackFailure() {
                 super(testPropsBuilder());
+            }
+
+            private KnownFailureTestCommandWithFallbackFailure(TestCircuitBreaker circuitBreaker) {
+                super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics));
             }
 
             @Override
@@ -6743,17 +7431,30 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
             private final int fallbackBehavior;
 
+            private final static int RESULT_SUCCESS = 10;
+            private final static int RESULT_EXCEPTION = 11;
+
+            private final int result;
+
             private TestCommandWithTimeout(long timeout, int fallbackBehavior) {
                 super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandProperties.Setter.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds((int) timeout)));
                 this.timeout = timeout;
                 this.fallbackBehavior = fallbackBehavior;
+                this.result = RESULT_SUCCESS;
+            }
+
+            private TestCommandWithTimeout(long timeout, int fallbackBehavior, int result) {
+                super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandProperties.Setter.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds((int) timeout)));
+                this.timeout = timeout;
+                this.fallbackBehavior = fallbackBehavior;
+                this.result = result;
             }
 
             @Override
             protected Boolean run() {
                 System.out.println("***** running");
                 try {
-                    Thread.sleep(timeout * 10);
+                    Thread.sleep(timeout * 3);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                     // ignore and sleep some more to simulate a dependency that doesn't obey interrupts
@@ -6764,7 +7465,13 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                     }
                     System.out.println("after interruption with extra sleep");
                 }
-                return true;
+                if (result == RESULT_SUCCESS) {
+                    return true;
+                } else if (result == RESULT_EXCEPTION) {
+                    throw new RuntimeException("Failure at end of TestCommandWithTimeout");
+                } else {
+                    throw new RuntimeException("You passed in a bad result enum : " + result);
+                }
             }
 
             @Override
@@ -6783,17 +7490,17 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
         /**
          * Threadpool with 1 thread, queue of size 1
          */
-        private static class SingleThreadedPool implements HystrixThreadPool {
+        private static class SingleThreadedPoolWithQueue implements HystrixThreadPool {
 
             final LinkedBlockingQueue<Runnable> queue;
             final ThreadPoolExecutor pool;
             private final int rejectionQueueSizeThreshold;
 
-            public SingleThreadedPool(int queueSize) {
+            public SingleThreadedPoolWithQueue(int queueSize) {
                 this(queueSize, 100);
             }
 
-            public SingleThreadedPool(int queueSize, int rejectionQueueSizeThreshold) {
+            public SingleThreadedPoolWithQueue(int queueSize, int rejectionQueueSizeThreshold) {
                 queue = new LinkedBlockingQueue<Runnable>(queueSize);
                 pool = new ThreadPoolExecutor(1, 1, 1, TimeUnit.MINUTES, queue);
                 this.rejectionQueueSizeThreshold = rejectionQueueSizeThreshold;
@@ -6817,6 +7524,41 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
             @Override
             public boolean isQueueSpaceAvailable() {
                 return queue.size() < rejectionQueueSizeThreshold;
+            }
+
+        }
+
+        /**
+         * Threadpool with 1 thread, queue of size 1
+         */
+        private static class SingleThreadedPoolWithNoQueue implements HystrixThreadPool {
+
+            final SynchronousQueue<Runnable> queue;
+            final ThreadPoolExecutor pool;
+
+            public SingleThreadedPoolWithNoQueue() {
+                queue = new SynchronousQueue<Runnable>();
+                pool = new ThreadPoolExecutor(1, 1, 1, TimeUnit.MINUTES, queue);
+            }
+
+            @Override
+            public ThreadPoolExecutor getExecutor() {
+                return pool;
+            }
+
+            @Override
+            public void markThreadExecution() {
+                // not used for this test
+            }
+
+            @Override
+            public void markThreadCompletion() {
+                // not used for this test
+            }
+
+            @Override
+            public boolean isQueueSpaceAvailable() {
+                return true; //let the thread pool reject
             }
 
         }
@@ -6953,60 +7695,66 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
             private final long executionSleep;
 
-            private TestSemaphoreCommand(TestCircuitBreaker circuitBreaker, int executionSemaphoreCount, long executionSleep) {
+            private final static int RESULT_SUCCESS = 1;
+            private final static int RESULT_FAILURE = 2;
+            private final static int RESULT_BAD_REQUEST_EXCEPTION = 3;
+
+            private final int resultBehavior;
+
+            private final static int FALLBACK_SUCCESS = 10;
+            private final static int FALLBACK_NOT_IMPLEMENTED = 11;
+            private final static int FALLBACK_FAILURE = 12;
+
+            private final int fallbackBehavior;
+
+            private TestSemaphoreCommand(TestCircuitBreaker circuitBreaker, int executionSemaphoreCount, long executionSleep, int resultBehavior, int fallbackBehavior) {
                 super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
                         .setCommandPropertiesDefaults(HystrixCommandProperties.Setter.getUnitTestPropertiesSetter()
                                 .withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE)
                                 .withExecutionIsolationSemaphoreMaxConcurrentRequests(executionSemaphoreCount)));
                 this.executionSleep = executionSleep;
+                this.resultBehavior = resultBehavior;
+                this.fallbackBehavior = fallbackBehavior;
             }
 
-            private TestSemaphoreCommand(TestCircuitBreaker circuitBreaker, TryableSemaphore semaphore, long executionSleep) {
+            private TestSemaphoreCommand(TestCircuitBreaker circuitBreaker, TryableSemaphore semaphore, long executionSleep, int resultBehavior, int fallbackBehavior) {
                 super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
                         .setCommandPropertiesDefaults(HystrixCommandProperties.Setter.getUnitTestPropertiesSetter()
                                 .withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE))
                         .setExecutionSemaphore(semaphore));
                 this.executionSleep = executionSleep;
+                this.resultBehavior = resultBehavior;
+                this.fallbackBehavior = fallbackBehavior;
             }
 
             @Override
             protected Boolean run() {
+                System.out.println("Invoking run() on : " + Thread.currentThread().getName());
                 try {
                     Thread.sleep(executionSleep);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
-                return true;
-            }
-        }
-
-        /**
-         * The run() will take time. No fallback implementation.
-         */
-        private static class TestSemaphoreCommandFailWithHystrixBadRequestException extends TestHystrixCommand<Boolean> {
-
-            private final long executionSleep;
-
-            private TestSemaphoreCommandFailWithHystrixBadRequestException(TestCircuitBreaker circuitBreaker, int executionSemaphoreCount, long executionSleep) {
-                super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                        .setCommandPropertiesDefaults(HystrixCommandProperties.Setter.getUnitTestPropertiesSetter()
-                                .withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE)
-                                .withExecutionIsolationSemaphoreMaxConcurrentRequests(executionSemaphoreCount)));
-                this.executionSleep = executionSleep;
-            }
-
-            private TestSemaphoreCommandFailWithHystrixBadRequestException(TestCircuitBreaker circuitBreaker, TryableSemaphore semaphore, long executionSleep) {
-                super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                        .setCommandPropertiesDefaults(HystrixCommandProperties.Setter.getUnitTestPropertiesSetter()
-                                .withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE))
-                        .setExecutionSemaphore(semaphore));
-                this.executionSleep = executionSleep;
+                if (resultBehavior == RESULT_SUCCESS) {
+                    return true;
+                } else if (resultBehavior == RESULT_FAILURE) {
+                    throw new RuntimeException("TestSemaphoreCommand failure");
+                } else if (resultBehavior == RESULT_BAD_REQUEST_EXCEPTION) {
+                    throw new HystrixBadRequestException("TestSempahoreCommand BadRequestException");
+                } else {
+                    throw new IllegalStateException("Didn't use a proper enum for result behavior");
+                }
             }
 
             @Override
-            protected Boolean run() {
-                System.out.print("*** simulated failed execution ***");
-                throw new HystrixBadRequestException("we failed with a simulated issue");
+            protected Boolean getFallback() {
+                if (fallbackBehavior == FALLBACK_SUCCESS) {
+                    return false;
+                } else if (fallbackBehavior == FALLBACK_FAILURE) {
+                    throw new RuntimeException("fallback failure");
+                } else { //FALLBACK_NOT_IMPLEMENTED
+                    return super.getFallback();
+                }
             }
         }
 
@@ -7052,38 +7800,6 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 }
                 return true;
             }
-        }
-
-        /**
-         * The run() will take time. Contains fallback.
-         */
-        private static class TestSemaphoreCommandWithFallback extends TestHystrixCommand<Boolean> {
-
-            private final long executionSleep;
-            private final Boolean fallback;
-
-            private TestSemaphoreCommandWithFallback(TestCircuitBreaker circuitBreaker, int executionSemaphoreCount, long executionSleep, Boolean fallback) {
-                super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                        .setCommandPropertiesDefaults(HystrixCommandProperties.Setter.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE).withExecutionIsolationSemaphoreMaxConcurrentRequests(executionSemaphoreCount)));
-                this.executionSleep = executionSleep;
-                this.fallback = fallback;
-            }
-
-            @Override
-            protected Boolean run() {
-                try {
-                    Thread.sleep(executionSleep);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                return true;
-            }
-
-            @Override
-            protected Boolean getFallback() {
-                return fallback;
-            }
-
         }
 
         private static class RequestCacheNullPointerExceptionCase extends TestHystrixCommand<Boolean> {
@@ -7324,6 +8040,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
             @Override
             public <T> Exception onError(HystrixCommand<T> commandInstance, FailureType failureType, Exception e) {
+                System.out.println("onError invoked with : " + commandInstance + " : " + failureType + " : " + e);
                 endExecuteFailureException = e;
                 endExecuteFailureType = failureType;
                 recordHookCall(executionSequence, "onError");

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -6322,7 +6322,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                         public void call(TestHystrixCommand<Boolean> command) {
                             assertEquals(1, command.builder.executionHook.startExecute.get());
                             assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                            assertNotNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
                             assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                             assertEquals(0, command.builder.executionHook.startRun.get());
                             assertNull(command.builder.executionHook.runSuccessResponse);
@@ -6392,7 +6392,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                         public void call(TestHystrixCommand<Boolean> command) {
                             assertEquals(1, command.builder.executionHook.startExecute.get());
                             assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                            assertNotNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
                             assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                             assertEquals(0, command.builder.executionHook.startRun.get());
                             assertNull(command.builder.executionHook.runSuccessResponse);
@@ -6647,7 +6647,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                         public void call(TestHystrixCommand<Boolean> command) {
                             assertEquals(1, command.builder.executionHook.startExecute.get());
                             assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                            assertNotNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureException); //by design, null=ex in this case
                             assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
                             assertEquals(0, command.builder.executionHook.startRun.get());
                             assertNull(command.builder.executionHook.runSuccessResponse);
@@ -6775,7 +6775,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                         public void call(TestHystrixCommand<Boolean> command) {
                             assertEquals(1, command.builder.executionHook.startExecute.get());
                             assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                            assertNotNull(command.builder.executionHook.endExecuteFailureException);
+                            assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
                             assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
                             assertEquals(0, command.builder.executionHook.startRun.get());
                             assertNull(command.builder.executionHook.runSuccessResponse);
@@ -6811,7 +6811,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                         public void call(TestHystrixCommand<Boolean> command) {
                             assertEquals(1, command.builder.executionHook.startExecute.get());
                             assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                            assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
                             assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                             assertEquals(0, command.builder.executionHook.startRun.get());
                             assertNull(command.builder.executionHook.runSuccessResponse);
@@ -6883,7 +6883,7 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                         public void call(TestHystrixCommand<Boolean> command) {
                             assertEquals(1, command.builder.executionHook.startExecute.get());
                             assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                            assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
+                            assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
                             assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                             assertEquals(0, command.builder.executionHook.startRun.get());
                             assertNull(command.builder.executionHook.runSuccessResponse);

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -5401,6 +5401,9 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 } catch (ExecutionException ee) {
                     System.out.println("Received expected ex : " + ee.getCause());
                     ee.getCause().printStackTrace();
+                } catch (Exception e) {
+                    System.out.println("Received expected ex : " + e);
+                    e.printStackTrace();
                 }
             }
 
@@ -5437,6 +5440,9 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
                 } catch (ExecutionException ee) {
                     System.out.println("Received expected ex : " + ee.getCause());
                     ee.getCause().printStackTrace();
+                } catch (Exception e) {
+                    System.out.println("Received expected ex : " + e);
+                    e.printStackTrace();
                 }
             }
         }
@@ -8040,7 +8046,6 @@ public abstract class HystrixCommand<R> implements HystrixExecutable<R> {
 
             @Override
             public <T> Exception onError(HystrixCommand<T> commandInstance, FailureType failureType, Exception e) {
-                System.out.println("onError invoked with : " + commandInstance + " : " + failureType + " : " + e);
                 endExecuteFailureException = e;
                 endExecuteFailureType = failureType;
                 recordHookCall(executionSequence, "onError");


### PR DESCRIPTION
For addressing #509, I added comprehensive (I *think*) tests of all execution flows and what hooks get invoked on each.  Out of this, I discovered #513, #514, #515, which will get addressed in separate PRs.

I will also be porting this test suite to master next, and hopefully uncovering the actual issue in #509 that I'm looking for.