### PR TITLE
Change calls from getExecutedCommands() to getAllExecutedCommands()

### DIFF
--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/CommonUtils.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/CommonUtils.java
@@ -30,8 +30,8 @@ public class CommonUtils {
     }
 
     public static void assertExecutedCommands(String... commands) {
-        Collection<HystrixCommand<?>> executedCommands =
-                HystrixRequestLog.getCurrentRequest().getExecutedCommands();
+        Collection<HystrixInvokableInfo<?>> executedCommands =
+                HystrixRequestLog.getCurrentRequest().getAllExecutedCommands();
 
         List<String> executedCommandsKeys = getExecutedCommandsKeys(Lists.newArrayList(executedCommands));
 
@@ -41,27 +41,27 @@ public class CommonUtils {
     }
 
     public static List<String> getExecutedCommandsKeys() {
-        Collection<HystrixCommand<?>> executedCommands =
-                HystrixRequestLog.getCurrentRequest().getExecutedCommands();
+        Collection<HystrixInvokableInfo<?>> executedCommands =
+                HystrixRequestLog.getCurrentRequest().getAllExecutedCommands();
 
         return getExecutedCommandsKeys(Lists.newArrayList(executedCommands));
     }
 
-    public static List<String> getExecutedCommandsKeys(List<HystrixCommand<?>> executedCommands) {
-        return Lists.transform(executedCommands, new Function<HystrixCommand<?>, String>() {
+    public static List<String> getExecutedCommandsKeys(List<HystrixInvokableInfo<?>> executedCommands) {
+        return Lists.transform(executedCommands, new Function<HystrixInvokableInfo<?>, String>() {
             @Nullable
             @Override
-            public String apply(@Nullable HystrixCommand<?> input) {
+            public String apply(@Nullable HystrixInvokableInfo<?> input) {
                 return input.getCommandKey().name();
             }
         });
     }
 
-    public static HystrixCommand getHystrixCommandByKey(String key) {
-        HystrixCommand hystrixCommand = null;
-        Collection<HystrixCommand<?>> executedCommands =
-                HystrixRequestLog.getCurrentRequest().getExecutedCommands();
-        for (HystrixCommand command : executedCommands) {
+    public static HystrixInvokableInfo getHystrixCommandByKey(String key) {
+        HystrixInvokableInfo hystrixCommand = null;
+        Collection<HystrixInvokableInfo<?>> executedCommands =
+                HystrixRequestLog.getCurrentRequest().getAllExecutedCommands();
+        for (HystrixInvokableInfo command : executedCommands) {
             if (command.getCommandKey().name().equals(key)) {
                 hystrixCommand = command;
                 break;

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/collapser/CollapserTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/collapser/CollapserTest.java
@@ -111,7 +111,7 @@ public class CollapserTest {
             assertEquals("name: 5", f5.get().getName());
 
             assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-            com.netflix.hystrix.HystrixCommand getUserCommand = getHystrixCommandByKey("getUserAsyncWithFallback");
+            com.netflix.hystrix.HystrixInvokableInfo getUserCommand = getHystrixCommandByKey("getUserAsyncWithFallback");
 
             // confirm that it was a COLLAPSED command execution
             assertTrue(getUserCommand.getExecutionEvents().contains(HystrixEventType.COLLAPSED));
@@ -144,7 +144,7 @@ public class CollapserTest {
             assertEquals("name: 5", f5.get().getName());
 
             assertEquals(2, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-            com.netflix.hystrix.HystrixCommand getUserCommand = getHystrixCommandByKey("getUserAsyncWithFallbackCommand");
+            com.netflix.hystrix.HystrixInvokableInfo getUserCommand = getHystrixCommandByKey("getUserAsyncWithFallbackCommand");
 
             // confirm that it was a COLLAPSED command execution
             assertTrue(getUserCommand.getExecutionEvents().contains(HystrixEventType.COLLAPSED));

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/command/CommandTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/command/CommandTest.java
@@ -53,8 +53,8 @@ public class CommandTest {
         Future<User> f1 = userService.getUserAsync("1", "name: ");
 
         assertEquals("name: 1", f1.get().getName());
-        assertEquals(1, HystrixRequestLog.getCurrentRequest().getExecutedCommands().size());
-        com.netflix.hystrix.HystrixCommand<?> command = getCommand();
+        assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
+        com.netflix.hystrix.HystrixInvokableInfo<?> command = getCommand();
         // assert the command key name is the we're expecting
         assertEquals("GetUserCommand", command.getCommandKey().name());
         // assert the command group key name is the we're expecting
@@ -69,8 +69,8 @@ public class CommandTest {
     public void testGetUserSync() {
         User u1 = userService.getUserSync("1", "name: ");
         assertEquals("name: 1", u1.getName());
-        assertEquals(1, HystrixRequestLog.getCurrentRequest().getExecutedCommands().size());
-        com.netflix.hystrix.HystrixCommand<?> command = getCommand();
+        assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
+        com.netflix.hystrix.HystrixInvokableInfo<?> command = getCommand();
         assertEquals("getUserSync", command.getCommandKey().name());
         assertEquals("UserGroup", command.getCommandGroup().name());
         assertEquals("UserGroup", command.getThreadPoolKey().name());
@@ -81,12 +81,12 @@ public class CommandTest {
     public void should_work_with_parameterized_method() throws Exception {
         assertEquals(Integer.valueOf(1), userService.echo(1));
 
-        assertEquals(1, HystrixRequestLog.getCurrentRequest().getExecutedCommands().size());
+        assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
         assertTrue(getCommand().getExecutionEvents().contains(HystrixEventType.SUCCESS));
     }
 
-    private com.netflix.hystrix.HystrixCommand<?> getCommand() {
-        return HystrixRequestLog.getCurrentRequest().getExecutedCommands().iterator().next();
+    private com.netflix.hystrix.HystrixInvokableInfo<?> getCommand() {
+        return HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().iterator().next();
     }
 
     public static class UserService {

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/error/ErrorPropagationTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/error/ErrorPropagationTest.java
@@ -64,7 +64,7 @@ public class ErrorPropagationTest {
             userService.getUserById(badId);
         } finally {
             assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-            com.netflix.hystrix.HystrixCommand getUserCommand = getHystrixCommandByKey(COMMAND_KEY);
+            com.netflix.hystrix.HystrixInvokableInfo getUserCommand = getHystrixCommandByKey(COMMAND_KEY);
             // will not affect metrics
             assertFalse(getUserCommand.getExecutionEvents().contains(HystrixEventType.FAILURE));
             // and will not trigger fallback logic
@@ -80,7 +80,7 @@ public class ErrorPropagationTest {
             userService.getUserById("4"); // user with id 4 doesn't exist
         } finally {
             assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-            com.netflix.hystrix.HystrixCommand getUserCommand = getHystrixCommandByKey(COMMAND_KEY);
+            com.netflix.hystrix.HystrixInvokableInfo getUserCommand = getHystrixCommandByKey(COMMAND_KEY);
             // will not affect metrics
             assertFalse(getUserCommand.getExecutionEvents().contains(HystrixEventType.FAILURE));
             // and will not trigger fallback logic
@@ -96,7 +96,7 @@ public class ErrorPropagationTest {
             userService.activateUser("1"); // this method always throws ActivationException
         } finally {
             assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-            com.netflix.hystrix.HystrixCommand activateUserCommand = getHystrixCommandByKey("activateUser");
+            com.netflix.hystrix.HystrixInvokableInfo activateUserCommand = getHystrixCommandByKey("activateUser");
             // will not affect metrics
             assertTrue(activateUserCommand.getExecutionEvents().contains(HystrixEventType.FAILURE));
             assertTrue(activateUserCommand.getExecutionEvents().contains(HystrixEventType.FALLBACK_SUCCESS));
@@ -113,7 +113,7 @@ public class ErrorPropagationTest {
             userService.blockUser("1"); // this method always throws ActivationException
         } finally {
             assertEquals(2, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-            com.netflix.hystrix.HystrixCommand activateUserCommand = getHystrixCommandByKey("blockUser");
+            com.netflix.hystrix.HystrixInvokableInfo activateUserCommand = getHystrixCommandByKey("blockUser");
             // will not affect metrics
             assertTrue(activateUserCommand.getExecutionEvents().contains(HystrixEventType.FAILURE));
             assertTrue(activateUserCommand.getExecutionEvents().contains(HystrixEventType.FALLBACK_FAILURE));

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/fallback/CommandFallbackTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/fallback/CommandFallbackTest.java
@@ -97,8 +97,8 @@ public class CommandFallbackTest {
             assertEquals(3, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
             HystrixInvokableInfo<?> getUserAsyncFallbackCommand = getHystrixCommandByKey(
                     "getUserAsyncFallbackCommand");
-            com.netflix.hystrix.HystrixCommand firstFallbackCommand = getHystrixCommandByKey("firstFallbackCommand");
-            com.netflix.hystrix.HystrixCommand secondFallbackCommand = getHystrixCommandByKey("secondFallbackCommand");
+            com.netflix.hystrix.HystrixInvokableInfo firstFallbackCommand = getHystrixCommandByKey("firstFallbackCommand");
+            com.netflix.hystrix.HystrixInvokableInfo secondFallbackCommand = getHystrixCommandByKey("secondFallbackCommand");
 
             assertEquals("getUserAsyncFallbackCommand", getUserAsyncFallbackCommand.getCommandKey().name());
             // confirm that command has failed
@@ -122,8 +122,8 @@ public class CommandFallbackTest {
             assertEquals(3, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
             HystrixInvokableInfo<?> getUserSyncFallbackCommand = getHystrixCommandByKey(
                     "getUserSyncFallbackCommand");
-            com.netflix.hystrix.HystrixCommand firstFallbackCommand = getHystrixCommandByKey("firstFallbackCommand");
-            com.netflix.hystrix.HystrixCommand secondFallbackCommand = getHystrixCommandByKey("secondFallbackCommand");
+            com.netflix.hystrix.HystrixInvokableInfo firstFallbackCommand = getHystrixCommandByKey("firstFallbackCommand");
+            com.netflix.hystrix.HystrixInvokableInfo secondFallbackCommand = getHystrixCommandByKey("secondFallbackCommand");
 
             assertEquals("getUserSyncFallbackCommand", getUserSyncFallbackCommand.getCommandKey().name());
             // confirm that command has failed

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/observable/ObservableTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/observable/ObservableTest.java
@@ -74,7 +74,7 @@ public class ObservableTest {
                 }
             });
             assertEquals(3, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-            com.netflix.hystrix.HystrixCommand getUserCommand = getHystrixCommandByKey("getUser");
+            com.netflix.hystrix.HystrixInvokableInfo getUserCommand = getHystrixCommandByKey("getUser");
             assertTrue(getUserCommand.getExecutionEvents().contains(HystrixEventType.SUCCESS));
         } finally {
             context.shutdown();
@@ -90,7 +90,7 @@ public class ObservableTest {
             // blocking
             assertEquals(exUser, userService.getUser(" ", "").toBlocking().single());
             assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-            com.netflix.hystrix.HystrixCommand getUserCommand = getHystrixCommandByKey("getUser");
+            com.netflix.hystrix.HystrixInvokableInfo getUserCommand = getHystrixCommandByKey("getUser");
             // confirm that command has failed
             assertTrue(getUserCommand.getExecutionEvents().contains(HystrixEventType.FAILURE));
             // and that fallback was successful

--- a/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandCollapserGetValueForKey.java
+++ b/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandCollapserGetValueForKey.java
@@ -29,6 +29,7 @@ import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixEventType;
+import com.netflix.hystrix.HystrixInvokableInfo;
 import com.netflix.hystrix.HystrixRequestLog;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 
@@ -98,7 +99,7 @@ public class CommandCollapserGetValueForKey extends HystrixCollapser<List<String
                 assertEquals("ValueForKey: 3", f3.get());
                 assertEquals("ValueForKey: 4", f4.get());
 
-                int numExecuted = HystrixRequestLog.getCurrentRequest().getExecutedCommands().size();
+                int numExecuted = HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size();
 
                 System.err.println("num executed: " + numExecuted);
 
@@ -108,11 +109,10 @@ public class CommandCollapserGetValueForKey extends HystrixCollapser<List<String
                     fail("some of the commands should have been collapsed");
                 }
 
-                System.err.println("HystrixRequestLog.getCurrentRequest().getExecutedCommands(): " + HystrixRequestLog.getCurrentRequest().getExecutedCommands());
                 System.err.println("HystrixRequestLog.getCurrentRequest().getAllExecutedCommands(): " + HystrixRequestLog.getCurrentRequest().getAllExecutedCommands());
 
                 int numLogs = 0;
-                for (HystrixCommand<?> command : HystrixRequestLog.getCurrentRequest().getExecutedCommands()) {
+                for (HystrixInvokableInfo<?> command : HystrixRequestLog.getCurrentRequest().getAllExecutedCommands()) {
                     numLogs++;
                     
                     // assert the command is the one we're expecting

--- a/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandWithFallbackViaNetwork.java
+++ b/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandWithFallbackViaNetwork.java
@@ -23,6 +23,7 @@ import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixEventType;
+import com.netflix.hystrix.HystrixInvokableInfo;
 import com.netflix.hystrix.HystrixRequestLog;
 import com.netflix.hystrix.HystrixThreadPoolKey;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
@@ -93,11 +94,11 @@ public class CommandWithFallbackViaNetwork extends HystrixCommand<String> {
             try {
                 assertEquals(null, new CommandWithFallbackViaNetwork(1).execute());
 
-                HystrixCommand<?> command1 = HystrixRequestLog.getCurrentRequest().getExecutedCommands().toArray(new HystrixCommand<?>[2])[0];
+                HystrixInvokableInfo<?> command1 = HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().toArray(new HystrixInvokableInfo<?>[2])[0];
                 assertEquals("GetValueCommand", command1.getCommandKey().name());
                 assertTrue(command1.getExecutionEvents().contains(HystrixEventType.FAILURE));
 
-                HystrixCommand<?> command2 = HystrixRequestLog.getCurrentRequest().getExecutedCommands().toArray(new HystrixCommand<?>[2])[1];
+                HystrixInvokableInfo<?> command2 = HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().toArray(new HystrixInvokableInfo<?>[2])[1];
                 assertEquals("GetValueFallbackCommand", command2.getCommandKey().name());
                 assertTrue(command2.getExecutionEvents().contains(HystrixEventType.FAILURE));
             } finally {


### PR DESCRIPTION
The calls to the deprecated getExecutedCommands() from HystrixRequestLog have been updated to getAllExecutedCommands(). This method returns a HystrixInvokableInfo instead of a HystrixCommand, so a few tests and examples have been updated to reflect this changed type as well.