### PR TITLE
Creating a synthetic exception in the semaphore execution and short-circuited case

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -404,7 +404,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                         metrics.markSemaphoreRejection();
                         logger.debug("HystrixCommand Execution Rejection by Semaphore."); // debug only since we're throwing the exception and someone higher will do something with it
                         // retrieve a fallback or throw an exception if no fallback available
-                        getFallbackOrThrowException(HystrixEventType.SEMAPHORE_REJECTED, FailureType.REJECTED_SEMAPHORE_EXECUTION, "could not acquire a semaphore for execution").
+                        getFallbackOrThrowException(HystrixEventType.SEMAPHORE_REJECTED, FailureType.REJECTED_SEMAPHORE_EXECUTION, "could not acquire a semaphore for execution", new RuntimeException("could not acquire a semaphore for execution")).
                                 map(new Func1<R, R>() {
 
                                     @Override
@@ -420,7 +420,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                     metrics.markShortCircuited();
                     // short-circuit and go directly to fallback (or throw an exception if no fallback implemented)
                     try {
-                        getFallbackOrThrowException(HystrixEventType.SHORT_CIRCUITED, FailureType.SHORTCIRCUIT, "short-circuited")
+                        getFallbackOrThrowException(HystrixEventType.SHORT_CIRCUITED, FailureType.SHORTCIRCUIT, "short-circuited", new RuntimeException("Hystrix circuit short-circuited and is OPEN"))
                                 .map(new Func1<R, R>() {
 
                                     @Override
@@ -770,13 +770,6 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
             // if we couldn't acquire a permit, we "fail fast" by throwing an exception
             return Observable.error(new HystrixRuntimeException(FailureType.REJECTED_SEMAPHORE_FALLBACK, this.getClass(), getLogMessagePrefix() + " fallback execution rejected.", null, null));
         }
-    }
-
-    /**
-     * @throws HystrixRuntimeException
-     */
-    private Observable<R> getFallbackOrThrowException(HystrixEventType eventType, FailureType failureType, String message) {
-        return getFallbackOrThrowException(eventType, failureType, message, null);
     }
 
     /**

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -4426,7 +4426,7 @@ public class HystrixCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4496,7 +4496,7 @@ public class HystrixCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4751,7 +4751,7 @@ public class HystrixCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, null=ex in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4879,7 +4879,7 @@ public class HystrixCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4915,7 +4915,7 @@ public class HystrixCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4987,7 +4987,7 @@ public class HystrixCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -4012,7 +4012,7 @@ public class HystrixObservableCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4082,7 +4082,7 @@ public class HystrixObservableCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4337,7 +4337,7 @@ public class HystrixObservableCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, null=ex in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4465,7 +4465,7 @@ public class HystrixObservableCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.REJECTED_SEMAPHORE_EXECUTION, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4501,7 +4501,7 @@ public class HystrixObservableCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);
@@ -4573,7 +4573,7 @@ public class HystrixObservableCommandTest {
                     public void call(TestHystrixCommand<Boolean> command) {
                         assertEquals(1, command.builder.executionHook.startExecute.get());
                         assertNull(command.builder.executionHook.endExecuteSuccessResponse);
-                        assertNull(command.builder.executionHook.endExecuteFailureException); //by design, ex=null in this case
+                        assertEquals(RuntimeException.class, command.builder.executionHook.endExecuteFailureException.getClass());
                         assertEquals(FailureType.SHORTCIRCUIT, command.builder.executionHook.endExecuteFailureType);
                         assertEquals(0, command.builder.executionHook.startRun.get());
                         assertNull(command.builder.executionHook.runSuccessResponse);


### PR DESCRIPTION
This allows ```onError()``` hook to always receive a non-null ```Exception```.

Fixes #513 for master