### PR TITLE
Hard-coded group name when publishing CodaHale metrics fixed

### DIFF
--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
@@ -43,7 +43,7 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
         this.circuitBreaker = circuitBreaker;
         this.properties = properties;
         this.metricRegistry = metricRegistry;
-        this.metricGroup = "HystrixCommand";
+        this.metricGroup = commandGroupKey.name();
         this.metricType = key.name();
     }
 


### PR DESCRIPTION
Currently all commands are published to CodaHale metrics under the same, hard-coded group name `"HystrixCommand"`. Even if I have multiple groups and many commands within them, all commands appear flat under the same name. This PR fixes it by using *real* group name and building correct metrics hierarchy.