### PR TITLE
Allow for thread interruption

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -937,7 +937,6 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
                         timeoutRunnable.run();
                     }
-
                 }
 
                 @Override

--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -1034,6 +1034,10 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
                 @Override
                 public void onNext(final Observable<T> o) {
+                    /**
+                     * This is the diff from OperatorSubscribeOn.  In that version, inner.schedule is called and then
+                     * the Subscription is lost.  Here we call subscriber.add on it.
+                     */
                     Subscription subscription = inner.schedule(new Action0() {
 
                         @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -5294,28 +5294,79 @@ public class HystrixCommandTest {
     @Test
     public void testInterruptFutureOnTimeout() throws InterruptedException, ExecutionException {
         // given
-        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker());
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker(), true);
 
         // when
         Future<Boolean> f = cmd.queue();
 
         // then
-        Thread.sleep(3000);
-        System.out.println("RESULT : " + f.get());
+        Thread.sleep(500);
         assertTrue(cmd.hasBeenInterrupted());
     }
 
     @Test
-    public void testInterruptObservableOnTimeout() throws InterruptedException {
+    public void testInterruptObserveOnTimeout() throws InterruptedException {
         // given
-        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker());
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker(), true);
 
         // when
         cmd.observe().subscribe();
 
         // then
-        Thread.sleep(3000);
+        Thread.sleep(500);
         assertTrue(cmd.hasBeenInterrupted());
+    }
+
+    @Test
+    public void testInterruptToObservableOnTimeout() throws InterruptedException {
+        // given
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker(), true);
+
+        // when
+        cmd.toObservable().subscribe();
+
+        // then
+        Thread.sleep(500);
+        assertTrue(cmd.hasBeenInterrupted());
+    }
+
+    @Test
+    public void testDoNotInterruptFutureOnTimeoutIfPropertySaysNotTo() throws InterruptedException, ExecutionException {
+        // given
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker(), false);
+
+        // when
+        Future<Boolean> f = cmd.queue();
+
+        // then
+        Thread.sleep(500);
+        assertFalse(cmd.hasBeenInterrupted());
+    }
+
+    @Test
+    public void testDoNotInterruptObserveOnTimeoutIfPropertySaysNotTo() throws InterruptedException {
+        // given
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker(), false);
+
+        // when
+        cmd.observe().subscribe();
+
+        // then
+        Thread.sleep(500);
+        assertFalse(cmd.hasBeenInterrupted());
+    }
+
+    @Test
+    public void testDoNotInterruptToObservableOnTimeoutIfPropertySaysNotTo() throws InterruptedException {
+        // given
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker(), false);
+
+        // when
+        cmd.toObservable().subscribe();
+
+        // then
+        Thread.sleep(500);
+        assertFalse(cmd.hasBeenInterrupted());
     }
 
     /* ******************************************************************************** */
@@ -5927,7 +5978,7 @@ public class HystrixCommandTest {
 
         private TestSemaphoreCommandWithSlowFallback(TestCircuitBreaker circuitBreaker, int fallbackSemaphoreExecutionCount, long fallbackSleep) {
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withFallbackIsolationSemaphoreMaxConcurrentRequests(fallbackSemaphoreExecutionCount)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withFallbackIsolationSemaphoreMaxConcurrentRequests(fallbackSemaphoreExecutionCount).withExecutionIsolationThreadInterruptOnTimeout(false)));
             this.fallbackSleep = fallbackSleep;
         }
 
@@ -6316,11 +6367,11 @@ public class HystrixCommandTest {
 
     private static class InterruptibleCommand extends TestHystrixCommand<Boolean> {
 
-        public InterruptibleCommand(TestCircuitBreaker circuitBreaker) {
+        public InterruptibleCommand(TestCircuitBreaker circuitBreaker, boolean shouldInterrupt) {
             super(testPropsBuilder()
                     .setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
                     .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
-                            .withExecutionIsolationThreadInterruptOnTimeout(true)
+                            .withExecutionIsolationThreadInterruptOnTimeout(shouldInterrupt)
                             .withExecutionIsolationThreadTimeoutInMilliseconds(100)));
         }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -5272,7 +5272,7 @@ public class HystrixCommandTest {
     }
 
     @Test
-    public void testExceptionConvertedToBadRequestExceptionInExecutionHookBypassesCircuitBreaker(){
+    public void testExceptionConvertedToBadRequestExceptionInExecutionHookBypassesCircuitBreaker() {
         TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
         try {
             new ExceptionToBadRequestByExecutionHookCommand(circuitBreaker, ExecutionIsolationStrategy.THREAD).execute();
@@ -5289,6 +5289,33 @@ public class HystrixCommandTest {
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.BAD_REQUEST));
+    }
+
+    @Test
+    public void testInterruptFutureOnTimeout() throws InterruptedException, ExecutionException {
+        // given
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker());
+
+        // when
+        Future<Boolean> f = cmd.queue();
+
+        // then
+        Thread.sleep(3000);
+        System.out.println("RESULT : " + f.get());
+        assertTrue(cmd.hasBeenInterrupted());
+    }
+
+    @Test
+    public void testInterruptObservableOnTimeout() throws InterruptedException {
+        // given
+        InterruptibleCommand cmd = new InterruptibleCommand(new TestCircuitBreaker());
+
+        // when
+        cmd.observe().subscribe();
+
+        // then
+        Thread.sleep(3000);
+        assertTrue(cmd.hasBeenInterrupted());
     }
 
     /* ******************************************************************************** */
@@ -6285,6 +6312,39 @@ public class HystrixCommandTest {
             throw new IOException("simulated checked exception message");
         }
 
+    }
+
+    private static class InterruptibleCommand extends TestHystrixCommand<Boolean> {
+
+        public InterruptibleCommand(TestCircuitBreaker circuitBreaker) {
+            super(testPropsBuilder()
+                    .setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
+                            .withExecutionIsolationThreadInterruptOnTimeout(true)
+                            .withExecutionIsolationThreadTimeoutInMilliseconds(100)));
+        }
+
+        private volatile boolean hasBeenInterrupted;
+
+        public boolean hasBeenInterrupted()
+        {
+            return hasBeenInterrupted;
+        }
+
+        @Override
+        protected Boolean run() throws Exception
+        {
+            try {
+                Thread.sleep(2000);
+            }
+            catch (InterruptedException e) {
+                System.out.println("Interrupted!");
+                e.printStackTrace();
+                hasBeenInterrupted = true;
+            }
+
+            return hasBeenInterrupted;
+        }
     }
 
     enum CommandKeyForUnitTest implements HystrixCommandKey {


### PR DESCRIPTION
This PR addresses #354, but I would like feedback before I consider merging.  Especially from @benjchristensen / @abersnaze.

All of the unit tests that are added (Thanks @aadeon!) now pass, but I would love to see a better way to accomplish this goal.

It's hacky in a few ways:
1) I believe that the ```Observable.subscribeOn``` method has a bug where unsubscription is not propagated to the work which is submitted to the new Scheduler.  A ```Subscription``` is generated in ```OperatorSubscribeOn``` in the ```schedule()``` method and then forgotten about.  I believe that's the precise ```Subscription``` we need to unsubscribe from.
2) Upon unsubscription, we need to optionally interrupt the thread.  At the moment, ```Subscriptions.from(Future<?> f)``` wraps a ```Future``` and upon unsubscription, cancels this future.  It hardcodes the parameter to cancel, however.  This is the value we need to have drawn from the ```HystrixCommandProperties```.  So I believe that we should consider adding this to RxJava proper, rather than the hack I've done here. That hack is to not call the ```createWorker()``` in the ```Scheduler``` interface, but cast the ```Scheduler``` to a ```HystrixContextScheduler``` and call its (new) ```createWorker(boolean shouldInterrupt)``` method.  Since this is really only valid for thread pools, I'm not sure how much of this belongs in the ```Scheduler``` interface.
