### PR TITLE
Fixed HystrixContextScheduler to conform with RxJava Worker contract

### DIFF
--- a/hystrix-core/src/test/java/com/netflix/hystrix/strategy/concurrency/HystrixContextSchedulerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/strategy/concurrency/HystrixContextSchedulerTest.java
@@ -1,0 +1,54 @@
+package com.netflix.hystrix.strategy.concurrency;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import rx.Scheduler;
+import rx.functions.Action0;
+import rx.schedulers.Schedulers;
+
+public class HystrixContextSchedulerTest {
+    
+    @Test(timeout = 2500)
+    public void testUnsubscribeWrappedScheduler() throws InterruptedException {
+        Scheduler s = Schedulers.newThread();
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch end = new CountDownLatch(1);
+
+        HystrixContextScheduler hcs = new HystrixContextScheduler(s);
+
+        Scheduler.Worker w = hcs.createWorker();
+        try {
+            w.schedule(new Action0() {
+                @Override
+                public void call() {
+                    start.countDown();
+                    try {
+                        try {
+                            Thread.sleep(5000);
+                        } catch (InterruptedException ex) {
+                            interrupted.set(true);
+                        }
+                    } finally {
+                        end.countDown();
+                    }
+                }
+            });
+            
+            start.await();
+            
+            w.unsubscribe();
+            
+            end.await();
+            
+            assertTrue(interrupted.get());
+        } finally {
+            w.unsubscribe();
+        }
+    }
+}


### PR DESCRIPTION
Fixed issue in #354 by making ```HystrixContextScheduler``` conform with RxJava's Worker contract. See also #593.

To avoid code duplication, it uses the ```rx.internal.schedulers.ScheduledAction```. I don't know how close Hystrix follows RxJava releases, but I'll make steps to have ```ScheduledAction``` part of the stable RxJava API eventually.