### PR TITLE
Favor timeout property that is not thread-specific. (execution.timeoutInMilliseconds)

### DIFF
--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
@@ -254,10 +254,17 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
                 return properties.circuitBreakerForceClosed().get();
             }
         });
+        //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
         metricRegistry.register(createMetricName("propertyValue_executionIsolationThreadTimeoutInMilliseconds"), new Gauge<Number>() {
             @Override
             public Number getValue() {
-                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
+                return properties.executionTimeoutInMilliseconds().get();
+            }
+        });
+        metricRegistry.register(createMetricName("propertyValue_executionTimeoutInMilliseconds"), new Gauge<Number>() {
+            @Override
+            public Number getValue() {
+                return properties.executionTimeoutInMilliseconds().get();
             }
         });
         metricRegistry.register(createMetricName("propertyValue_executionIsolationStrategy"), new Gauge<String>() {

--- a/hystrix-contrib/hystrix-javanica/README.md
+++ b/hystrix-contrib/hystrix-javanica/README.md
@@ -343,7 +343,7 @@ Command properties can be set using @HystrixCommand's 'commandProperties' like b
 
 ```java
     @HystrixCommand(commandProperties = {
-            @HystrixProperty(name = "execution.isolation.thread.timeoutInMilliseconds", value = "500")
+            @HystrixProperty(name = "execution.timeoutInMilliseconds", value = "500")
         })
     public User getUserById(String id) {
         return userResource.getUserById(id);
@@ -353,7 +353,7 @@ Command properties can be set using @HystrixCommand's 'commandProperties' like b
 Javanica dynamically sets properties using Hystrix ConfigurationManager.
 For the example above Javanica behind the scenes performs next action:
 ```java
-ConfigurationManager.getConfigInstance().setProperty("hystrix.command.getUserById.execution.isolation.thread.timeoutInMilliseconds", "500");
+ConfigurationManager.getConfigInstance().setProperty("hystrix.command.getUserById.execution.timeoutInMilliseconds", "500");
 ```
 More about Hystrix command properties [command](https://github.com/Netflix/Hystrix/wiki/Configuration#wiki-CommandExecution) and [fallback](https://github.com/Netflix/Hystrix/wiki/Configuration#wiki-CommandFallback)
 
@@ -361,7 +361,7 @@ ThreadPoolProperties can be set using @HystrixCommand's 'threadPoolProperties' l
 
 ```java
     @HystrixCommand(commandProperties = {
-            @HystrixProperty(name = "execution.isolation.thread.timeoutInMilliseconds", value = "500")
+            @HystrixProperty(name = "execution.timeoutInMilliseconds", value = "500")
         },
                 threadPoolProperties = {
                         @HystrixProperty(name = "coreSize", value = "30"),

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/configuration/command/CommandPropertiesTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/configuration/command/CommandPropertiesTest.java
@@ -46,7 +46,7 @@ public class CommandPropertiesTest {
             assertEquals("Test", command.getThreadPoolKey().name());
             assertTrue(command.getExecutionEvents().contains(HystrixEventType.SUCCESS));
             // assert properties
-            assertEquals(110, command.getProperties().executionIsolationThreadTimeoutInMilliseconds().get().intValue());
+            assertEquals(110, command.getProperties().executionTimeoutInMilliseconds().get().intValue());
             assertEquals(false, command.getProperties().executionIsolationThreadInterruptOnTimeout().get());
 
             Field field = command.getClass().getSuperclass().getSuperclass().getSuperclass().getDeclaredField("threadPool");
@@ -90,7 +90,7 @@ public class CommandPropertiesTest {
 
         @HystrixCommand(commandKey = "GetUserCommand", groupKey = "UserGroupKey", threadPoolKey = "Test",
                 commandProperties = {
-                        @HystrixProperty(name = "execution.isolation.thread.timeoutInMilliseconds", value = "110"),
+                        @HystrixProperty(name = "execution.timeoutInMilliseconds", value = "110"),
                         @HystrixProperty(name = "execution.isolation.thread.interruptOnTimeout", value = "false")
                 },
                 threadPoolProperties = {

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
@@ -260,7 +260,9 @@ public class HystrixMetricsPoller {
             json.writeBooleanField("propertyValue_circuitBreakerEnabled", commandProperties.circuitBreakerEnabled().get());
 
             json.writeStringField("propertyValue_executionIsolationStrategy", commandProperties.executionIsolationStrategy().get().name());
-            json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionIsolationThreadTimeoutInMilliseconds().get());
+            //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
+            json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
+            json.writeNumberField("propertyValue_executionTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
             json.writeBooleanField("propertyValue_executionIsolationThreadInterruptOnTimeout", commandProperties.executionIsolationThreadInterruptOnTimeout().get());
             json.writeStringField("propertyValue_executionIsolationThreadPoolKeyOverride", commandProperties.executionIsolationThreadPoolKeyOverride().get());
             json.writeNumberField("propertyValue_executionIsolationSemaphoreMaxConcurrentRequests", commandProperties.executionIsolationSemaphoreMaxConcurrentRequests().get());

--- a/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/JsonMappers.java
+++ b/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/JsonMappers.java
@@ -108,7 +108,9 @@ final class JsonMappers {
         json.writeBooleanField("propertyValue_circuitBreakerEnabled", commandProperties.circuitBreakerEnabled().get());
 
         json.writeStringField("propertyValue_executionIsolationStrategy", commandProperties.executionIsolationStrategy().get().name());
-        json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionIsolationThreadTimeoutInMilliseconds().get());
+        //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
+        json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
+        json.writeNumberField("propertyValue_executionTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
         json.writeBooleanField("propertyValue_executionIsolationThreadInterruptOnTimeout", commandProperties.executionIsolationThreadInterruptOnTimeout().get());
         json.writeStringField("propertyValue_executionIsolationThreadPoolKeyOverride", commandProperties.executionIsolationThreadPoolKeyOverride().get());
         json.writeNumberField("propertyValue_executionIsolationSemaphoreMaxConcurrentRequests", commandProperties.executionIsolationSemaphoreMaxConcurrentRequests().get());

--- a/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java
@@ -323,10 +323,17 @@ public class HystrixServoMetricsPublisherCommand extends HystrixServoMetricsPubl
                 return properties.circuitBreakerForceClosed().get();
             }
         });
+        //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
         monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_executionIsolationThreadTimeoutInMilliseconds").build()) {
             @Override
             public Number getValue() {
-                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
+                return properties.executionTimeoutInMilliseconds().get();
+            }
+        });
+        monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_executionTimeoutInMilliseconds").build()) {
+            @Override
+            public Number getValue() {
+                return properties.executionTimeoutInMilliseconds().get();
             }
         });
         monitors.add(new InformationalMetric<String>(MonitorConfig.builder("propertyValue_executionIsolationStrategy").build()) {

--- a/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherCommand.java
@@ -255,10 +255,17 @@ public class HystrixYammerMetricsPublisherCommand implements HystrixMetricsPubli
                 return properties.circuitBreakerForceClosed().get();
             }
         });
+        //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
         metricsRegistry.newGauge(createMetricName("propertyValue_executionIsolationThreadTimeoutInMilliseconds"), new Gauge<Number>() {
             @Override
             public Number value() {
-                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
+                return properties.executionTimeoutInMilliseconds().get();
+            }
+        });
+        metricsRegistry.newGauge(createMetricName("propertyValue_executionTimeoutInMilliseconds"), new Gauge<Number>() {
+            @Override
+            public Number value() {
+                return properties.executionTimeoutInMilliseconds().get();
             }
         });
         metricsRegistry.newGauge(createMetricName("propertyValue_executionIsolationStrategy"), new Gauge<String>() {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -954,7 +954,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
                 @Override
                 public int getIntervalTimeInMilliseconds() {
-                    return originalCommand.properties.executionIsolationThreadTimeoutInMilliseconds().get();
+                    return originalCommand.properties.executionTimeoutInMilliseconds().get();
                 }
             };
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -84,11 +84,11 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
      *            <p>
      *            The {@link HystrixCommandGroupKey} is used to represent a common relationship between commands. For example, a library or team name, the system all related commands interact with,
      *            common business purpose etc.
-     * @param executionIsolationThreadTimeoutInMilliseconds
-     *            Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
+     * @param executionTimeoutInMilliseconds
+     *            Time in milliseconds at which point the calling thread will timeout and unsubscribe from the command
      */
-    protected HystrixCommand(HystrixCommandGroupKey group, int executionIsolationThreadTimeoutInMilliseconds) {
-        this(new Setter(group).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(executionIsolationThreadTimeoutInMilliseconds)));
+    protected HystrixCommand(HystrixCommandGroupKey group, int executionTimeoutInMilliseconds) {
+        this(new Setter(group).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(executionTimeoutInMilliseconds)));
     }
 
     /**
@@ -103,11 +103,11 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
      *            common business purpose etc.
      * @param threadPool
      *            {@link HystrixThreadPoolKey} used to identify the thread pool in which a {@link HystrixCommand} executes.
-     * @param executionIsolationThreadTimeoutInMilliseconds
-     *            Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
+     * @param executionTimeoutInMilliseconds
+     *            Time in milliseconds at which point the calling thread will timeout and unsubscribe from the command
      */
-    protected HystrixCommand(HystrixCommandGroupKey group, HystrixThreadPoolKey threadPool, int executionIsolationThreadTimeoutInMilliseconds) {
-        this(new Setter(group).andThreadPoolKey(threadPool).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(executionIsolationThreadTimeoutInMilliseconds)));
+    protected HystrixCommand(HystrixCommandGroupKey group, HystrixThreadPoolKey threadPool, int executionTimeoutInMilliseconds) {
+        this(new Setter(group).andThreadPoolKey(threadPool).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(executionTimeoutInMilliseconds)));
     }
 
     /**

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandProperties.java
@@ -45,8 +45,7 @@ public abstract class HystrixCommandProperties {
     private static final Integer default_circuitBreakerErrorThresholdPercentage = 50;// default => errorThresholdPercentage = 50 = if 50%+ of requests in 10 seconds are failures or latent when we will trip the circuit
     private static final Boolean default_circuitBreakerForceOpen = false;// default => forceCircuitOpen = false (we want to allow traffic)
     /* package */ static final Boolean default_circuitBreakerForceClosed = false;// default => ignoreErrors = false 
-    private static final Integer default_executionIsolationThreadTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
-    private static final Integer default_executionIsolationSemaphoreTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
+    private static final Integer default_executionTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
     private static final ExecutionIsolationStrategy default_executionIsolationStrategy = ExecutionIsolationStrategy.THREAD;
     private static final Boolean default_executionIsolationThreadInterruptOnTimeout = true;
     private static final Boolean default_metricsRollingPercentileEnabled = true;
@@ -69,9 +68,8 @@ public abstract class HystrixCommandProperties {
     private final HystrixProperty<Boolean> circuitBreakerForceOpen; // a property to allow forcing the circuit open (stopping all requests)
     private final HystrixProperty<Boolean> circuitBreakerForceClosed; // a property to allow ignoring errors and therefore never trip 'open' (ie. allow all traffic through)
     private final HystrixProperty<ExecutionIsolationStrategy> executionIsolationStrategy; // Whether a command should be executed in a separate thread or not.
-    private final HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds; // Timeout value in milliseconds for a command being executed in a thread.
+    private final HystrixProperty<Integer> executionTimeoutInMilliseconds; // Timeout value in milliseconds for a command.
     private final HystrixProperty<String> executionIsolationThreadPoolKeyOverride; // What thread-pool this command should run in (if running on a separate thread).
-    private final HystrixProperty<Integer> executionIsolationSemaphoreTimeoutInMilliseconds; // Timeout value in milliseconds for a async semaphore command being executed.
     private final HystrixProperty<Integer> executionIsolationSemaphoreMaxConcurrentRequests; // Number of permits for execution semaphore
     private final HystrixProperty<Integer> fallbackIsolationSemaphoreMaxConcurrentRequests; // Number of permits for fallback semaphore
     private final HystrixProperty<Boolean> fallbackEnabled; // Whether fallback should be attempted.
@@ -116,9 +114,7 @@ public abstract class HystrixCommandProperties {
         this.circuitBreakerForceOpen = getProperty(propertyPrefix, key, "circuitBreaker.forceOpen", builder.getCircuitBreakerForceOpen(), default_circuitBreakerForceOpen);
         this.circuitBreakerForceClosed = getProperty(propertyPrefix, key, "circuitBreaker.forceClosed", builder.getCircuitBreakerForceClosed(), default_circuitBreakerForceClosed);
         this.executionIsolationStrategy = getProperty(propertyPrefix, key, "execution.isolation.strategy", builder.getExecutionIsolationStrategy(), default_executionIsolationStrategy);
-        this.executionIsolationThreadTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.thread.timeoutInMilliseconds", builder.getExecutionIsolationThreadTimeoutInMilliseconds(), default_executionIsolationThreadTimeoutInMilliseconds);
         this.executionIsolationThreadInterruptOnTimeout = getProperty(propertyPrefix, key, "execution.isolation.thread.interruptOnTimeout", builder.getExecutionIsolationThreadInterruptOnTimeout(), default_executionIsolationThreadInterruptOnTimeout);
-        this.executionIsolationSemaphoreTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.semaphore.timeoutInMilliseconds", builder.getExecutionIsolationSemaphoreTimeoutInMilliseconds(), default_executionIsolationSemaphoreTimeoutInMilliseconds);
         this.executionIsolationSemaphoreMaxConcurrentRequests = getProperty(propertyPrefix, key, "execution.isolation.semaphore.maxConcurrentRequests", builder.getExecutionIsolationSemaphoreMaxConcurrentRequests(), default_executionIsolationSemaphoreMaxConcurrentRequests);
         this.fallbackIsolationSemaphoreMaxConcurrentRequests = getProperty(propertyPrefix, key, "fallback.isolation.semaphore.maxConcurrentRequests", builder.getFallbackIsolationSemaphoreMaxConcurrentRequests(), default_fallbackIsolationSemaphoreMaxConcurrentRequests);
         this.fallbackEnabled = getProperty(propertyPrefix, key, "fallback.enabled", builder.getFallbackEnabled(), default_fallbackEnabled);
@@ -134,6 +130,10 @@ public abstract class HystrixCommandProperties {
 
         // threadpool doesn't have a global override, only instance level makes sense
         this.executionIsolationThreadPoolKeyOverride = asProperty(new DynamicStringProperty(propertyPrefix + ".command." + key.name() + ".threadPoolKeyOverride", null));
+
+        //thread-specific timeout is deprecated.  If the documented property is not used, still respect the deprecated value
+        HystrixProperty<Integer> deprecatedThreadSpecificExecutionTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.thread.timeoutInMilliseconds", builder.getExecutionTimeoutInMilliseconds(), default_executionTimeoutInMilliseconds);
+        this.executionTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.timeoutInMilliseconds", builder.getExecutionTimeoutInMilliseconds(), deprecatedThreadSpecificExecutionTimeoutInMilliseconds.get());
     }
 
     /**
@@ -252,29 +252,26 @@ public abstract class HystrixCommandProperties {
     }
 
     /**
-     * Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
-     * <p>
-     * If {@link #executionIsolationThreadInterruptOnTimeout} == true the executing thread will be interrupted.
-     * <p>
-     * Applicable only when {@link #executionIsolationStrategy()} == THREAD.
-     * 
+     * Deprecated in favor of {@link #executionTimeoutInMilliseconds()}
      * @return {@code HystrixProperty<Integer>}
      */
+    @Deprecated
     public HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds() {
-        return executionIsolationThreadTimeoutInMilliseconds;
+        return executionTimeoutInMilliseconds;
     }
-    
+
     /**
-     * Time in milliseconds at which point the async command will be cancelled. 
+     * Time in milliseconds at which point the calling thread will timeout
      * <p>
-     * If {@link #executionIsolationSemaphoreInterruptOnTimeout} == true the executing command will be cancelled.
+     * If the command is thread-isolated and {@link #executionIsolationThreadInterruptOnTimeout} == true, the executing thread will be interrupted.
      * <p>
-     * Applicable only when {@link #executionIsolationStrategy()} == SEMAPHORE.
-     * 
+     * In both semaphore- and thread-isolated commands, the command will be unsubscribed from.  If the command is a {@link HystrixObservableCommand},
+     * it should respect this unsubscription and stop as early as it is able
+     *
      * @return {@code HystrixProperty<Integer>}
      */
-    public HystrixProperty<Integer> executionIsolationSemaphoreTimeoutInMilliseconds() {
-        return executionIsolationSemaphoreTimeoutInMilliseconds;
+    public HystrixProperty<Integer> executionTimeoutInMilliseconds() {
+        return executionTimeoutInMilliseconds;
     }
 
     /**
@@ -496,8 +493,7 @@ public abstract class HystrixCommandProperties {
         private Integer executionIsolationSemaphoreMaxConcurrentRequests = null;
         private ExecutionIsolationStrategy executionIsolationStrategy = null;
         private Boolean executionIsolationThreadInterruptOnTimeout = null;
-        private Integer executionIsolationThreadTimeoutInMilliseconds = null;
-        private Integer executionIsolationSemaphoreTimeoutInMilliseconds = null;
+        private Integer executionTimeoutInMilliseconds = null;
         private Integer fallbackIsolationSemaphoreMaxConcurrentRequests = null;
         private Boolean fallbackEnabled = null;
         private Integer metricsHealthSnapshotIntervalInMilliseconds = null;
@@ -550,14 +546,15 @@ public abstract class HystrixCommandProperties {
             return executionIsolationThreadInterruptOnTimeout;
         }
 
+        @Deprecated
         public Integer getExecutionIsolationThreadTimeoutInMilliseconds() {
-            return executionIsolationThreadTimeoutInMilliseconds;
-        }
-        
-        public Integer getExecutionIsolationSemaphoreTimeoutInMilliseconds() {
-            return executionIsolationSemaphoreTimeoutInMilliseconds;
+            return executionTimeoutInMilliseconds;
         }
 
+        public Integer getExecutionTimeoutInMilliseconds() {
+            return executionTimeoutInMilliseconds;
+        }
+        
         public Integer getFallbackIsolationSemaphoreMaxConcurrentRequests() {
             return fallbackIsolationSemaphoreMaxConcurrentRequests;
         }
@@ -647,21 +644,14 @@ public abstract class HystrixCommandProperties {
             return this;
         }
 
+        @Deprecated
         public Setter withExecutionIsolationThreadTimeoutInMilliseconds(int value) {
-            this.executionIsolationThreadTimeoutInMilliseconds = value;
+            this.executionTimeoutInMilliseconds = value;
             return this;
         }
 
-        public Setter withExecutionIsolationSemaphoreTimeoutInMilliseconds(int value) {
-            this.executionIsolationSemaphoreTimeoutInMilliseconds = value;
-            return this;
-        }
-        
-
-        public Setter withTimeoutInMilliseconds(int value) {
-            // We can set both values here, as only one will be applicable (based upon executionIsolation)
-            this.executionIsolationThreadTimeoutInMilliseconds = value;
-            this.executionIsolationSemaphoreTimeoutInMilliseconds = value;
+        public Setter withExecutionTimeoutInMilliseconds(int value) {
+            this.executionTimeoutInMilliseconds = value;
             return this;
         }
         
@@ -719,8 +709,5 @@ public abstract class HystrixCommandProperties {
             this.requestLogEnabled = value;
             return this;
         }
-
     }
-
-
 }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
@@ -102,7 +102,12 @@ public class HystrixCommandPropertiesTest {
 
             @Override
             public HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds() {
-                return HystrixProperty.Factory.asProperty(builder.getExecutionIsolationThreadTimeoutInMilliseconds());
+                return HystrixProperty.Factory.asProperty(builder.getExecutionTimeoutInMilliseconds());
+            }
+
+            @Override
+            public HystrixProperty<Integer> executionTimeoutInMilliseconds() {
+                return HystrixProperty.Factory.asProperty(builder.getExecutionTimeoutInMilliseconds());
             }
 
             @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixTest.java
@@ -172,13 +172,13 @@ public class HystrixTest {
     @Test
     public void testResetCommandProperties() {
         HystrixCommand<Boolean> cmd1 = new ResettableCommand(100, 10);
-        assertEquals(100L, (long) cmd1.getProperties().executionIsolationThreadTimeoutInMilliseconds().get());
+        assertEquals(100L, (long) cmd1.getProperties().executionTimeoutInMilliseconds().get());
         assertEquals(10L, (long) cmd1.threadPool.getExecutor().getCorePoolSize());
 
         Hystrix.reset();
 
         HystrixCommand<Boolean> cmd2 = new ResettableCommand(700, 40);
-        assertEquals(700L, (long) cmd2.getProperties().executionIsolationThreadTimeoutInMilliseconds().get());
+        assertEquals(700L, (long) cmd2.getProperties().executionTimeoutInMilliseconds().get());
         assertEquals(40L, (long) cmd2.threadPool.getExecutor().getCorePoolSize());
 
 	}*/

--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
@@ -170,6 +170,7 @@
             assertNotNull(data,"propertyValue_circuitBreakerForceOpen");
             assertNotNull(data,"propertyValue_executionIsolationStrategy");
             assertNotNull(data,"propertyValue_executionIsolationThreadTimeoutInMilliseconds");
+            //this key was deprecated in 1.4.0-RC7. //TODO prefer propertyValue_executionInterruptOnTimeout instead
             assertNotNull(data,"propertyValue_executionIsolationThreadInterruptOnTimeout");
             // assertNotNull(data,"propertyValue_executionIsolationThreadPoolKeyOverride");
             assertNotNull(data,"propertyValue_executionIsolationSemaphoreMaxConcurrentRequests");


### PR DESCRIPTION
Also deprecate usages of thread-specific setting (like execution.thread.isolation.timeoutInMilliseconds).

This addresses #300 