### PR TITLE
Unit tests demonstrating problems with thread interruptions

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -814,7 +814,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
                         return Observable.error(new HystrixRuntimeException(failureType, _cmd.getClass(), getLogMessagePrefix() + " " + message + " and no fallback available.", e, fe));
                     } else {
-                        logger.debug("HystrixCommand execution " + failureType.name() + " and fallback retrieval failed.", fe);
+                        logger.debug("HystrixCommand execution " + failureType.name() + " and fallback failed.", fe);
                         metrics.markFallbackFailure();
                         // record the executionResult
                         executionResult = executionResult.addEvents(HystrixEventType.FALLBACK_FAILURE);
@@ -826,7 +826,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                             logger.warn("Error calling ExecutionHook.onError", hookException);
                         }
 
-                        return Observable.error(new HystrixRuntimeException(failureType, _cmd.getClass(), getLogMessagePrefix() + " " + message + " and failed retrieving fallback.", e, fe));
+                        return Observable.error(new HystrixRuntimeException(failureType, _cmd.getClass(), getLogMessagePrefix() + " " + message + " and fallback failed.", e, fe));
                     }
                 }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -5421,6 +5421,34 @@ public class HystrixCommandTest {
         assertTrue(2 == new PrimaryCommand(new TestCircuitBreaker()).execute());
     }
 
+    @Test
+    public void testSlowFallback() {
+        class PrimaryCommand extends TestHystrixCommand<Integer> {
+            public PrimaryCommand(TestCircuitBreaker circuitBreaker) {
+                super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics));
+            }
+
+            @Override
+            protected Integer run() throws Exception {
+                throw new RuntimeException("primary failure");
+            }
+
+            @Override
+            protected Integer getFallback() {
+                try {
+                    Thread.sleep(1500);
+                    return 1;
+                } catch (InterruptedException ie) {
+                    System.out.println("Caught Interrupted Exception");
+                    ie.printStackTrace();
+                }
+                return -1;
+            }
+        }
+
+        assertTrue(1 == new PrimaryCommand(new TestCircuitBreaker()).execute());
+    }
+
     /* ******************************************************************************** */
     /* ******************************************************************************** */
     /* private HystrixCommand class implementations for unit testing */


### PR DESCRIPTION
In both unit tests, the InterruptedException is caused by an unsubscription, which in turn is caused by the OnErrorResumeNext operator.