### PR TITLE
Don't pass on the Transfer-Encoding header when streaming

### DIFF
--- a/hystrix-dashboard/src/main/java/com/netflix/hystrix/dashboard/stream/ProxyStreamServlet.java
+++ b/hystrix-dashboard/src/main/java/com/netflix/hystrix/dashboard/stream/ProxyStreamServlet.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
@@ -106,7 +107,9 @@ public class ProxyStreamServlet extends HttpServlet {
 
                 // set headers
                 for (Header header : httpResponse.getAllHeaders()) {
-                    response.addHeader(header.getName(), header.getValue());
+                    if (!HttpHeaders.TRANSFER_ENCODING.equals(header.getName())) {
+                        response.addHeader(header.getName(), header.getValue());
+                    }
                 }
 
                 // copy data from source to response


### PR DESCRIPTION
When running the hystrix-dashboard on Tomcat with apache in front using AJP/mod_JK, we could not get the streams (from either hystrix directly, or through Turbine) working. In the Chrome JS-console there were errors mentioning the chunked response from proxy.stream was in error. 

curling a bit showed this: 

curl -iv --raw http://dev.dashboard.finn.no/hystrix-dashboard/proxy.stream?origin=dev-api1.finntech.no/iad/hystrix.stream

* additional stuff not fine transfer.c:1037: 0 0
* HTTP 1.1 or later with persistent connection, pipelining supported
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Wed, 11 Feb 2015 13:57:03 GMT
Date: Wed, 11 Feb 2015 13:57:03 GMT
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
Pragma: no-cache
< Keep-Alive: timeout=1, max=100
Keep-Alive: timeout=1, max=100
< Connection: Keep-Alive
Connection: Keep-Alive
< Transfer-Encoding: chunked
Transfer-Encoding: chunked
< Content-Type: text/event-stream;charset=UTF-8
Content-Type: text/event-stream;charset=UTF-8

<
ping:

* Problem (2) in the Chunked-Encoded data
* Closing connection #0


So the Transfer-Encoding: chunked header is set, but the data is not actually chunked (Missing a byte-count before the "ping: "-data)

The only related post I could find on google is from 2010 and is related to AJP/mod_JK:
https://issues.apache.org/bugzilla/show_bug.cgi?id=50275 which describes our situation pretty much spot on. 

In short: It doesn't seem like the AJP connector wants to get the Transfer-Encoding header from the backend. 

The supplied change solved our problems. 