### PR TITLE
Revert timeout property name change

### DIFF
--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
@@ -259,7 +259,13 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
         metricRegistry.register(createMetricName("propertyValue_executionIsolationThreadTimeoutInMilliseconds"), new Gauge<Number>() {
             @Override
             public Number getValue() {
-                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
+                return properties.executionTimeoutInMilliseconds().get();
+            }
+        });
+        metricRegistry.register(createMetricName("propertyValue_executionTimeoutInMilliseconds"), new Gauge<Number>() {
+            @Override
+            public Number getValue() {
+                return properties.executionTimeoutInMilliseconds().get();
             }
         });
         metricRegistry.register(createMetricName("propertyValue_executionIsolationStrategy"), new Gauge<String>() {

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
@@ -256,17 +256,10 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
                 return properties.circuitBreakerForceClosed().get();
             }
         });
-        //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
         metricRegistry.register(createMetricName("propertyValue_executionIsolationThreadTimeoutInMilliseconds"), new Gauge<Number>() {
             @Override
             public Number getValue() {
-                return properties.executionTimeoutInMilliseconds().get();
-            }
-        });
-        metricRegistry.register(createMetricName("propertyValue_executionTimeoutInMilliseconds"), new Gauge<Number>() {
-            @Override
-            public Number getValue() {
-                return properties.executionTimeoutInMilliseconds().get();
+                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
             }
         });
         metricRegistry.register(createMetricName("propertyValue_executionIsolationStrategy"), new Gauge<String>() {

--- a/hystrix-contrib/hystrix-javanica/README.md
+++ b/hystrix-contrib/hystrix-javanica/README.md
@@ -343,7 +343,7 @@ Command properties can be set using @HystrixCommand's 'commandProperties' like b
 
 ```java
     @HystrixCommand(commandProperties = {
-            @HystrixProperty(name = "execution.timeoutInMilliseconds", value = "500")
+            @HystrixProperty(name = "execution.isolation.thread.timeoutInMilliseconds", value = "500")
         })
     public User getUserById(String id) {
         return userResource.getUserById(id);
@@ -353,7 +353,7 @@ Command properties can be set using @HystrixCommand's 'commandProperties' like b
 Javanica dynamically sets properties using Hystrix ConfigurationManager.
 For the example above Javanica behind the scenes performs next action:
 ```java
-ConfigurationManager.getConfigInstance().setProperty("hystrix.command.getUserById.execution.timeoutInMilliseconds", "500");
+ConfigurationManager.getConfigInstance().setProperty("hystrix.command.getUserById.execution.isolation.thread.timeoutInMilliseconds", "500");
 ```
 More about Hystrix command properties [command](https://github.com/Netflix/Hystrix/wiki/Configuration#wiki-CommandExecution) and [fallback](https://github.com/Netflix/Hystrix/wiki/Configuration#wiki-CommandFallback)
 
@@ -361,7 +361,7 @@ ThreadPoolProperties can be set using @HystrixCommand's 'threadPoolProperties' l
 
 ```java
     @HystrixCommand(commandProperties = {
-            @HystrixProperty(name = "execution.timeoutInMilliseconds", value = "500")
+            @HystrixProperty(name = "execution.isolation.thread.timeoutInMilliseconds", value = "500")
         },
                 threadPoolProperties = {
                         @HystrixProperty(name = "coreSize", value = "30"),

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/configuration/command/CommandPropertiesTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/configuration/command/CommandPropertiesTest.java
@@ -61,7 +61,7 @@ public class CommandPropertiesTest {
             assertEquals("Test", command.getThreadPoolKey().name());
             assertTrue(command.getExecutionEvents().contains(HystrixEventType.SUCCESS));
             // assert properties
-            assertEquals(110, command.getProperties().executionTimeoutInMilliseconds().get().intValue());
+            assertEquals(110, command.getProperties().executionIsolationThreadTimeoutInMilliseconds().get().intValue());
             assertEquals(false, command.getProperties().executionIsolationThreadInterruptOnTimeout().get());
 
             Field field = command.getClass().getSuperclass().getSuperclass().getSuperclass().getDeclaredField("threadPool");
@@ -105,7 +105,7 @@ public class CommandPropertiesTest {
 
         @HystrixCommand(commandKey = "GetUserCommand", groupKey = "UserGroupKey", threadPoolKey = "Test",
                 commandProperties = {
-                        @HystrixProperty(name = "execution.timeoutInMilliseconds", value = "110"),
+                        @HystrixProperty(name = "execution.isolation.thread.timeoutInMilliseconds", value = "110"),
                         @HystrixProperty(name = "execution.isolation.thread.interruptOnTimeout", value = "false")
                 },
                 threadPoolProperties = {

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/configuration/command/CommandPropertiesTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/configuration/command/CommandPropertiesTest.java
@@ -61,7 +61,7 @@ public class CommandPropertiesTest {
             assertEquals("Test", command.getThreadPoolKey().name());
             assertTrue(command.getExecutionEvents().contains(HystrixEventType.SUCCESS));
             // assert properties
-            assertEquals(110, command.getProperties().executionIsolationThreadTimeoutInMilliseconds().get().intValue());
+            assertEquals(110, command.getProperties().executionTimeoutInMilliseconds().get().intValue());
             assertEquals(false, command.getProperties().executionIsolationThreadInterruptOnTimeout().get());
 
             Field field = command.getClass().getSuperclass().getSuperclass().getSuperclass().getDeclaredField("threadPool");

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
@@ -260,9 +260,7 @@ public class HystrixMetricsPoller {
             json.writeBooleanField("propertyValue_circuitBreakerEnabled", commandProperties.circuitBreakerEnabled().get());
 
             json.writeStringField("propertyValue_executionIsolationStrategy", commandProperties.executionIsolationStrategy().get().name());
-            //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
-            json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
-            json.writeNumberField("propertyValue_executionTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
+            json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionIsolationThreadTimeoutInMilliseconds().get());
             json.writeBooleanField("propertyValue_executionIsolationThreadInterruptOnTimeout", commandProperties.executionIsolationThreadInterruptOnTimeout().get());
             json.writeStringField("propertyValue_executionIsolationThreadPoolKeyOverride", commandProperties.executionIsolationThreadPoolKeyOverride().get());
             json.writeNumberField("propertyValue_executionIsolationSemaphoreMaxConcurrentRequests", commandProperties.executionIsolationSemaphoreMaxConcurrentRequests().get());

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
@@ -260,7 +260,8 @@ public class HystrixMetricsPoller {
             json.writeBooleanField("propertyValue_circuitBreakerEnabled", commandProperties.circuitBreakerEnabled().get());
 
             json.writeStringField("propertyValue_executionIsolationStrategy", commandProperties.executionIsolationStrategy().get().name());
-            json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionIsolationThreadTimeoutInMilliseconds().get());
+            json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
+            json.writeNumberField("propertyValue_executionTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
             json.writeBooleanField("propertyValue_executionIsolationThreadInterruptOnTimeout", commandProperties.executionIsolationThreadInterruptOnTimeout().get());
             json.writeStringField("propertyValue_executionIsolationThreadPoolKeyOverride", commandProperties.executionIsolationThreadPoolKeyOverride().get());
             json.writeNumberField("propertyValue_executionIsolationSemaphoreMaxConcurrentRequests", commandProperties.executionIsolationSemaphoreMaxConcurrentRequests().get());

--- a/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/JsonMappers.java
+++ b/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/JsonMappers.java
@@ -124,7 +124,8 @@ final class JsonMappers {
         json.writeBooleanField("propertyValue_circuitBreakerEnabled", commandProperties.circuitBreakerEnabled().get());
 
         json.writeStringField("propertyValue_executionIsolationStrategy", commandProperties.executionIsolationStrategy().get().name());
-        json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionIsolationThreadTimeoutInMilliseconds().get());
+        json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
+        json.writeNumberField("propertyValue_executionTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
         json.writeBooleanField("propertyValue_executionIsolationThreadInterruptOnTimeout", commandProperties.executionIsolationThreadInterruptOnTimeout().get());
         json.writeStringField("propertyValue_executionIsolationThreadPoolKeyOverride", commandProperties.executionIsolationThreadPoolKeyOverride().get());
         json.writeNumberField("propertyValue_executionIsolationSemaphoreMaxConcurrentRequests", commandProperties.executionIsolationSemaphoreMaxConcurrentRequests().get());

--- a/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/JsonMappers.java
+++ b/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/JsonMappers.java
@@ -124,9 +124,7 @@ final class JsonMappers {
         json.writeBooleanField("propertyValue_circuitBreakerEnabled", commandProperties.circuitBreakerEnabled().get());
 
         json.writeStringField("propertyValue_executionIsolationStrategy", commandProperties.executionIsolationStrategy().get().name());
-        //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
-        json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
-        json.writeNumberField("propertyValue_executionTimeoutInMilliseconds", commandProperties.executionTimeoutInMilliseconds().get());
+        json.writeNumberField("propertyValue_executionIsolationThreadTimeoutInMilliseconds", commandProperties.executionIsolationThreadTimeoutInMilliseconds().get());
         json.writeBooleanField("propertyValue_executionIsolationThreadInterruptOnTimeout", commandProperties.executionIsolationThreadInterruptOnTimeout().get());
         json.writeStringField("propertyValue_executionIsolationThreadPoolKeyOverride", commandProperties.executionIsolationThreadPoolKeyOverride().get());
         json.writeNumberField("propertyValue_executionIsolationSemaphoreMaxConcurrentRequests", commandProperties.executionIsolationSemaphoreMaxConcurrentRequests().get());

--- a/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java
@@ -326,7 +326,13 @@ public class HystrixServoMetricsPublisherCommand extends HystrixServoMetricsPubl
         monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_executionIsolationThreadTimeoutInMilliseconds").build()) {
             @Override
             public Number getValue() {
-                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
+                return properties.executionTimeoutInMilliseconds().get();
+            }
+        });
+        monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_executionTimeoutInMilliseconds").build()) {
+            @Override
+            public Number getValue() {
+                return properties.executionTimeoutInMilliseconds().get();
             }
         });
         monitors.add(new InformationalMetric<String>(MonitorConfig.builder("propertyValue_executionIsolationStrategy").build()) {

--- a/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java
@@ -323,17 +323,10 @@ public class HystrixServoMetricsPublisherCommand extends HystrixServoMetricsPubl
                 return properties.circuitBreakerForceClosed().get();
             }
         });
-        //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
         monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_executionIsolationThreadTimeoutInMilliseconds").build()) {
             @Override
             public Number getValue() {
-                return properties.executionTimeoutInMilliseconds().get();
-            }
-        });
-        monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_executionTimeoutInMilliseconds").build()) {
-            @Override
-            public Number getValue() {
-                return properties.executionTimeoutInMilliseconds().get();
+                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
             }
         });
         monitors.add(new InformationalMetric<String>(MonitorConfig.builder("propertyValue_executionIsolationStrategy").build()) {

--- a/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherCommand.java
@@ -257,17 +257,10 @@ public class HystrixYammerMetricsPublisherCommand implements HystrixMetricsPubli
                 return properties.circuitBreakerForceClosed().get();
             }
         });
-        //this naming convention is deprecated as of 1.4.0-RC7, remove in 1.5.x
         metricsRegistry.newGauge(createMetricName("propertyValue_executionIsolationThreadTimeoutInMilliseconds"), new Gauge<Number>() {
             @Override
             public Number value() {
-                return properties.executionTimeoutInMilliseconds().get();
-            }
-        });
-        metricsRegistry.newGauge(createMetricName("propertyValue_executionTimeoutInMilliseconds"), new Gauge<Number>() {
-            @Override
-            public Number value() {
-                return properties.executionTimeoutInMilliseconds().get();
+                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
             }
         });
         metricsRegistry.newGauge(createMetricName("propertyValue_executionIsolationStrategy"), new Gauge<String>() {

--- a/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherCommand.java
@@ -257,10 +257,16 @@ public class HystrixYammerMetricsPublisherCommand implements HystrixMetricsPubli
                 return properties.circuitBreakerForceClosed().get();
             }
         });
+        metricsRegistry.newGauge(createMetricName("propertyValue_executionTimeoutInMilliseconds"), new Gauge<Number>() {
+            @Override
+            public Number value() {
+                return properties.executionTimeoutInMilliseconds().get();
+            }
+        });
         metricsRegistry.newGauge(createMetricName("propertyValue_executionIsolationThreadTimeoutInMilliseconds"), new Gauge<Number>() {
             @Override
             public Number value() {
-                return properties.executionIsolationThreadTimeoutInMilliseconds().get();
+                return properties.executionTimeoutInMilliseconds().get();
             }
         });
         metricsRegistry.newGauge(createMetricName("propertyValue_executionIsolationStrategy"), new Gauge<String>() {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -960,7 +960,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
                 @Override
                 public int getIntervalTimeInMilliseconds() {
-                    return originalCommand.properties.executionIsolationThreadTimeoutInMilliseconds().get();
+                    return originalCommand.properties.executionTimeoutInMilliseconds().get();
                 }
             };
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -960,7 +960,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
                 @Override
                 public int getIntervalTimeInMilliseconds() {
-                    return originalCommand.properties.executionTimeoutInMilliseconds().get();
+                    return originalCommand.properties.executionIsolationThreadTimeoutInMilliseconds().get();
                 }
             };
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -84,11 +84,11 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
      *            <p>
      *            The {@link HystrixCommandGroupKey} is used to represent a common relationship between commands. For example, a library or team name, the system all related commands interact with,
      *            common business purpose etc.
-     * @param executionTimeoutInMilliseconds
-     *            Time in milliseconds at which point the calling thread will timeout and unsubscribe from the command
+     * @param executionIsolationThreadTimeoutInMilliseconds
+     *            Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
      */
-    protected HystrixCommand(HystrixCommandGroupKey group, int executionTimeoutInMilliseconds) {
-        this(new Setter(group).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(executionTimeoutInMilliseconds)));
+    protected HystrixCommand(HystrixCommandGroupKey group, int executionIsolationThreadTimeoutInMilliseconds) {
+        this(new Setter(group).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(executionIsolationThreadTimeoutInMilliseconds)));
     }
 
     /**
@@ -103,11 +103,11 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
      *            common business purpose etc.
      * @param threadPool
      *            {@link HystrixThreadPoolKey} used to identify the thread pool in which a {@link HystrixCommand} executes.
-     * @param executionTimeoutInMilliseconds
-     *            Time in milliseconds at which point the calling thread will timeout and unsubscribe from the command
+     * @param executionIsolationThreadTimeoutInMilliseconds
+     *            Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
      */
-    protected HystrixCommand(HystrixCommandGroupKey group, HystrixThreadPoolKey threadPool, int executionTimeoutInMilliseconds) {
-        this(new Setter(group).andThreadPoolKey(threadPool).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(executionTimeoutInMilliseconds)));
+    protected HystrixCommand(HystrixCommandGroupKey group, HystrixThreadPoolKey threadPool, int executionIsolationThreadTimeoutInMilliseconds) {
+        this(new Setter(group).andThreadPoolKey(threadPool).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(executionIsolationThreadTimeoutInMilliseconds)));
     }
 
     /**

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -88,7 +88,7 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
      *            Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
      */
     protected HystrixCommand(HystrixCommandGroupKey group, int executionIsolationThreadTimeoutInMilliseconds) {
-        this(new Setter(group).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(executionIsolationThreadTimeoutInMilliseconds)));
+        this(new Setter(group).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(executionIsolationThreadTimeoutInMilliseconds)));
     }
 
     /**
@@ -107,7 +107,7 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
      *            Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
      */
     protected HystrixCommand(HystrixCommandGroupKey group, HystrixThreadPoolKey threadPool, int executionIsolationThreadTimeoutInMilliseconds) {
-        this(new Setter(group).andThreadPoolKey(threadPool).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(executionIsolationThreadTimeoutInMilliseconds)));
+        this(new Setter(group).andThreadPoolKey(threadPool).andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(executionIsolationThreadTimeoutInMilliseconds)));
     }
 
     /**

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandProperties.java
@@ -45,7 +45,8 @@ public abstract class HystrixCommandProperties {
     private static final Integer default_circuitBreakerErrorThresholdPercentage = 50;// default => errorThresholdPercentage = 50 = if 50%+ of requests in 10 seconds are failures or latent when we will trip the circuit
     private static final Boolean default_circuitBreakerForceOpen = false;// default => forceCircuitOpen = false (we want to allow traffic)
     /* package */ static final Boolean default_circuitBreakerForceClosed = false;// default => ignoreErrors = false 
-    private static final Integer default_executionTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
+    private static final Integer default_executionIsolationThreadTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
+    private static final Integer default_executionIsolationSemaphoreTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
     private static final ExecutionIsolationStrategy default_executionIsolationStrategy = ExecutionIsolationStrategy.THREAD;
     private static final Boolean default_executionIsolationThreadInterruptOnTimeout = true;
     private static final Boolean default_metricsRollingPercentileEnabled = true;
@@ -68,8 +69,9 @@ public abstract class HystrixCommandProperties {
     private final HystrixProperty<Boolean> circuitBreakerForceOpen; // a property to allow forcing the circuit open (stopping all requests)
     private final HystrixProperty<Boolean> circuitBreakerForceClosed; // a property to allow ignoring errors and therefore never trip 'open' (ie. allow all traffic through)
     private final HystrixProperty<ExecutionIsolationStrategy> executionIsolationStrategy; // Whether a command should be executed in a separate thread or not.
-    private final HystrixProperty<Integer> executionTimeoutInMilliseconds; // Timeout value in milliseconds for a command.
+    private final HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds; // Timeout value in milliseconds for a command being executed in a thread.
     private final HystrixProperty<String> executionIsolationThreadPoolKeyOverride; // What thread-pool this command should run in (if running on a separate thread).
+    private final HystrixProperty<Integer> executionIsolationSemaphoreTimeoutInMilliseconds; // Timeout value in milliseconds for a async semaphore command being executed.
     private final HystrixProperty<Integer> executionIsolationSemaphoreMaxConcurrentRequests; // Number of permits for execution semaphore
     private final HystrixProperty<Integer> fallbackIsolationSemaphoreMaxConcurrentRequests; // Number of permits for fallback semaphore
     private final HystrixProperty<Boolean> fallbackEnabled; // Whether fallback should be attempted.
@@ -114,7 +116,9 @@ public abstract class HystrixCommandProperties {
         this.circuitBreakerForceOpen = getProperty(propertyPrefix, key, "circuitBreaker.forceOpen", builder.getCircuitBreakerForceOpen(), default_circuitBreakerForceOpen);
         this.circuitBreakerForceClosed = getProperty(propertyPrefix, key, "circuitBreaker.forceClosed", builder.getCircuitBreakerForceClosed(), default_circuitBreakerForceClosed);
         this.executionIsolationStrategy = getProperty(propertyPrefix, key, "execution.isolation.strategy", builder.getExecutionIsolationStrategy(), default_executionIsolationStrategy);
+        this.executionIsolationThreadTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.thread.timeoutInMilliseconds", builder.getExecutionIsolationThreadTimeoutInMilliseconds(), default_executionIsolationThreadTimeoutInMilliseconds);
         this.executionIsolationThreadInterruptOnTimeout = getProperty(propertyPrefix, key, "execution.isolation.thread.interruptOnTimeout", builder.getExecutionIsolationThreadInterruptOnTimeout(), default_executionIsolationThreadInterruptOnTimeout);
+        this.executionIsolationSemaphoreTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.semaphore.timeoutInMilliseconds", builder.getExecutionIsolationSemaphoreTimeoutInMilliseconds(), default_executionIsolationSemaphoreTimeoutInMilliseconds);
         this.executionIsolationSemaphoreMaxConcurrentRequests = getProperty(propertyPrefix, key, "execution.isolation.semaphore.maxConcurrentRequests", builder.getExecutionIsolationSemaphoreMaxConcurrentRequests(), default_executionIsolationSemaphoreMaxConcurrentRequests);
         this.fallbackIsolationSemaphoreMaxConcurrentRequests = getProperty(propertyPrefix, key, "fallback.isolation.semaphore.maxConcurrentRequests", builder.getFallbackIsolationSemaphoreMaxConcurrentRequests(), default_fallbackIsolationSemaphoreMaxConcurrentRequests);
         this.fallbackEnabled = getProperty(propertyPrefix, key, "fallback.enabled", builder.getFallbackEnabled(), default_fallbackEnabled);
@@ -130,10 +134,6 @@ public abstract class HystrixCommandProperties {
 
         // threadpool doesn't have a global override, only instance level makes sense
         this.executionIsolationThreadPoolKeyOverride = asProperty(new DynamicStringProperty(propertyPrefix + ".command." + key.name() + ".threadPoolKeyOverride", null));
-
-        //thread-specific timeout is deprecated.  If the documented property is not used, still respect the deprecated value
-        HystrixProperty<Integer> deprecatedThreadSpecificExecutionTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.thread.timeoutInMilliseconds", builder.getExecutionTimeoutInMilliseconds(), default_executionTimeoutInMilliseconds);
-        this.executionTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.timeoutInMilliseconds", builder.getExecutionTimeoutInMilliseconds(), deprecatedThreadSpecificExecutionTimeoutInMilliseconds.get());
     }
 
     /**
@@ -252,26 +252,29 @@ public abstract class HystrixCommandProperties {
     }
 
     /**
-     * Deprecated in favor of {@link #executionTimeoutInMilliseconds()}
+     * Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
+     * <p>
+     * If {@link #executionIsolationThreadInterruptOnTimeout} == true the executing thread will be interrupted.
+     * <p>
+     * Applicable only when {@link #executionIsolationStrategy()} == THREAD.
+     * 
      * @return {@code HystrixProperty<Integer>}
      */
-    @Deprecated
     public HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds() {
-        return executionTimeoutInMilliseconds;
+        return executionIsolationThreadTimeoutInMilliseconds;
     }
-
+    
     /**
-     * Time in milliseconds at which point the calling thread will timeout
+     * Time in milliseconds at which point the async command will be cancelled. 
      * <p>
-     * If the command is thread-isolated and {@link #executionIsolationThreadInterruptOnTimeout} == true, the executing thread will be interrupted.
+     * If {@link #executionIsolationSemaphoreInterruptOnTimeout} == true the executing command will be cancelled.
      * <p>
-     * In both semaphore- and thread-isolated commands, the command will be unsubscribed from.  If the command is a {@link HystrixObservableCommand},
-     * it should respect this unsubscription and stop as early as it is able
-     *
+     * Applicable only when {@link #executionIsolationStrategy()} == SEMAPHORE.
+     * 
      * @return {@code HystrixProperty<Integer>}
      */
-    public HystrixProperty<Integer> executionTimeoutInMilliseconds() {
-        return executionTimeoutInMilliseconds;
+    public HystrixProperty<Integer> executionIsolationSemaphoreTimeoutInMilliseconds() {
+        return executionIsolationSemaphoreTimeoutInMilliseconds;
     }
 
     /**
@@ -493,7 +496,8 @@ public abstract class HystrixCommandProperties {
         private Integer executionIsolationSemaphoreMaxConcurrentRequests = null;
         private ExecutionIsolationStrategy executionIsolationStrategy = null;
         private Boolean executionIsolationThreadInterruptOnTimeout = null;
-        private Integer executionTimeoutInMilliseconds = null;
+        private Integer executionIsolationThreadTimeoutInMilliseconds = null;
+        private Integer executionIsolationSemaphoreTimeoutInMilliseconds = null;
         private Integer fallbackIsolationSemaphoreMaxConcurrentRequests = null;
         private Boolean fallbackEnabled = null;
         private Integer metricsHealthSnapshotIntervalInMilliseconds = null;
@@ -546,15 +550,14 @@ public abstract class HystrixCommandProperties {
             return executionIsolationThreadInterruptOnTimeout;
         }
 
-        @Deprecated
         public Integer getExecutionIsolationThreadTimeoutInMilliseconds() {
-            return executionTimeoutInMilliseconds;
-        }
-
-        public Integer getExecutionTimeoutInMilliseconds() {
-            return executionTimeoutInMilliseconds;
+            return executionIsolationThreadTimeoutInMilliseconds;
         }
         
+        public Integer getExecutionIsolationSemaphoreTimeoutInMilliseconds() {
+            return executionIsolationSemaphoreTimeoutInMilliseconds;
+        }
+
         public Integer getFallbackIsolationSemaphoreMaxConcurrentRequests() {
             return fallbackIsolationSemaphoreMaxConcurrentRequests;
         }
@@ -644,14 +647,21 @@ public abstract class HystrixCommandProperties {
             return this;
         }
 
-        @Deprecated
         public Setter withExecutionIsolationThreadTimeoutInMilliseconds(int value) {
-            this.executionTimeoutInMilliseconds = value;
+            this.executionIsolationThreadTimeoutInMilliseconds = value;
             return this;
         }
 
-        public Setter withExecutionTimeoutInMilliseconds(int value) {
-            this.executionTimeoutInMilliseconds = value;
+        public Setter withExecutionIsolationSemaphoreTimeoutInMilliseconds(int value) {
+            this.executionIsolationSemaphoreTimeoutInMilliseconds = value;
+            return this;
+        }
+        
+
+        public Setter withTimeoutInMilliseconds(int value) {
+            // We can set both values here, as only one will be applicable (based upon executionIsolation)
+            this.executionIsolationThreadTimeoutInMilliseconds = value;
+            this.executionIsolationSemaphoreTimeoutInMilliseconds = value;
             return this;
         }
         
@@ -709,5 +719,8 @@ public abstract class HystrixCommandProperties {
             this.requestLogEnabled = value;
             return this;
         }
+
     }
+
+
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandProperties.java
@@ -45,8 +45,7 @@ public abstract class HystrixCommandProperties {
     private static final Integer default_circuitBreakerErrorThresholdPercentage = 50;// default => errorThresholdPercentage = 50 = if 50%+ of requests in 10 seconds are failures or latent when we will trip the circuit
     private static final Boolean default_circuitBreakerForceOpen = false;// default => forceCircuitOpen = false (we want to allow traffic)
     /* package */ static final Boolean default_circuitBreakerForceClosed = false;// default => ignoreErrors = false 
-    private static final Integer default_executionIsolationThreadTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
-    private static final Integer default_executionIsolationSemaphoreTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
+    private static final Integer default_executionTimeoutInMilliseconds = 1000; // default => executionTimeoutInMilliseconds: 1000 = 1 second
     private static final ExecutionIsolationStrategy default_executionIsolationStrategy = ExecutionIsolationStrategy.THREAD;
     private static final Boolean default_executionIsolationThreadInterruptOnTimeout = true;
     private static final Boolean default_metricsRollingPercentileEnabled = true;
@@ -69,9 +68,8 @@ public abstract class HystrixCommandProperties {
     private final HystrixProperty<Boolean> circuitBreakerForceOpen; // a property to allow forcing the circuit open (stopping all requests)
     private final HystrixProperty<Boolean> circuitBreakerForceClosed; // a property to allow ignoring errors and therefore never trip 'open' (ie. allow all traffic through)
     private final HystrixProperty<ExecutionIsolationStrategy> executionIsolationStrategy; // Whether a command should be executed in a separate thread or not.
-    private final HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds; // Timeout value in milliseconds for a command being executed in a thread.
+    private final HystrixProperty<Integer> executionTimeoutInMilliseconds; // Timeout value in milliseconds for a command
     private final HystrixProperty<String> executionIsolationThreadPoolKeyOverride; // What thread-pool this command should run in (if running on a separate thread).
-    private final HystrixProperty<Integer> executionIsolationSemaphoreTimeoutInMilliseconds; // Timeout value in milliseconds for a async semaphore command being executed.
     private final HystrixProperty<Integer> executionIsolationSemaphoreMaxConcurrentRequests; // Number of permits for execution semaphore
     private final HystrixProperty<Integer> fallbackIsolationSemaphoreMaxConcurrentRequests; // Number of permits for fallback semaphore
     private final HystrixProperty<Boolean> fallbackEnabled; // Whether fallback should be attempted.
@@ -116,9 +114,9 @@ public abstract class HystrixCommandProperties {
         this.circuitBreakerForceOpen = getProperty(propertyPrefix, key, "circuitBreaker.forceOpen", builder.getCircuitBreakerForceOpen(), default_circuitBreakerForceOpen);
         this.circuitBreakerForceClosed = getProperty(propertyPrefix, key, "circuitBreaker.forceClosed", builder.getCircuitBreakerForceClosed(), default_circuitBreakerForceClosed);
         this.executionIsolationStrategy = getProperty(propertyPrefix, key, "execution.isolation.strategy", builder.getExecutionIsolationStrategy(), default_executionIsolationStrategy);
-        this.executionIsolationThreadTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.thread.timeoutInMilliseconds", builder.getExecutionIsolationThreadTimeoutInMilliseconds(), default_executionIsolationThreadTimeoutInMilliseconds);
+        //this property name is now misleading.  //TODO figure out a good way to deprecate this property name
+        this.executionTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.thread.timeoutInMilliseconds", builder.getExecutionIsolationThreadTimeoutInMilliseconds(), default_executionTimeoutInMilliseconds);
         this.executionIsolationThreadInterruptOnTimeout = getProperty(propertyPrefix, key, "execution.isolation.thread.interruptOnTimeout", builder.getExecutionIsolationThreadInterruptOnTimeout(), default_executionIsolationThreadInterruptOnTimeout);
-        this.executionIsolationSemaphoreTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.semaphore.timeoutInMilliseconds", builder.getExecutionIsolationSemaphoreTimeoutInMilliseconds(), default_executionIsolationSemaphoreTimeoutInMilliseconds);
         this.executionIsolationSemaphoreMaxConcurrentRequests = getProperty(propertyPrefix, key, "execution.isolation.semaphore.maxConcurrentRequests", builder.getExecutionIsolationSemaphoreMaxConcurrentRequests(), default_executionIsolationSemaphoreMaxConcurrentRequests);
         this.fallbackIsolationSemaphoreMaxConcurrentRequests = getProperty(propertyPrefix, key, "fallback.isolation.semaphore.maxConcurrentRequests", builder.getFallbackIsolationSemaphoreMaxConcurrentRequests(), default_fallbackIsolationSemaphoreMaxConcurrentRequests);
         this.fallbackEnabled = getProperty(propertyPrefix, key, "fallback.enabled", builder.getFallbackEnabled(), default_fallbackEnabled);
@@ -252,31 +250,32 @@ public abstract class HystrixCommandProperties {
     }
 
     /**
-     * Time in milliseconds at which point the calling thread will timeout (using {@link Future#get}) and walk away from the executing thread.
+     * Time in milliseconds at which point the command will timeout and halt execution.
      * <p>
-     * If {@link #executionIsolationThreadInterruptOnTimeout} == true the executing thread will be interrupted.
+     * If {@link #executionIsolationThreadInterruptOnTimeout} == true and the command is thread-isolated, the executing thread will be interrupted.
+     * If the command is semaphore-isolated and a {@link HystrixObservableCommand}, that command will get unsubscribed.
      * <p>
-     * Applicable only when {@link #executionIsolationStrategy()} == THREAD.
-     * 
+     *
      * @return {@code HystrixProperty<Integer>}
      */
+    @Deprecated //prefer {@link #executionTimeoutInMilliseconds}
     public HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds() {
-        return executionIsolationThreadTimeoutInMilliseconds;
-    }
-    
-    /**
-     * Time in milliseconds at which point the async command will be cancelled. 
-     * <p>
-     * If {@link #executionIsolationSemaphoreInterruptOnTimeout} == true the executing command will be cancelled.
-     * <p>
-     * Applicable only when {@link #executionIsolationStrategy()} == SEMAPHORE.
-     * 
-     * @return {@code HystrixProperty<Integer>}
-     */
-    public HystrixProperty<Integer> executionIsolationSemaphoreTimeoutInMilliseconds() {
-        return executionIsolationSemaphoreTimeoutInMilliseconds;
+        return executionTimeoutInMilliseconds;
     }
 
+    /**
+     * Time in milliseconds at which point the command will timeout and halt execution.
+     * <p>
+     * If {@link #executionIsolationThreadInterruptOnTimeout} == true and the command is thread-isolated, the executing thread will be interrupted.
+     * If the command is semaphore-isolated and a {@link HystrixObservableCommand}, that command will get unsubscribed.
+     * <p>
+     *
+     * @return {@code HystrixProperty<Integer>}
+     */
+    public HystrixProperty<Integer> executionTimeoutInMilliseconds() {
+        return executionTimeoutInMilliseconds;
+    }
+    
     /**
      * Number of concurrent requests permitted to {@link HystrixCommand#getFallback()}. Requests beyond the concurrent limit will fail-fast and not attempt retrieving a fallback.
      * 
@@ -496,8 +495,7 @@ public abstract class HystrixCommandProperties {
         private Integer executionIsolationSemaphoreMaxConcurrentRequests = null;
         private ExecutionIsolationStrategy executionIsolationStrategy = null;
         private Boolean executionIsolationThreadInterruptOnTimeout = null;
-        private Integer executionIsolationThreadTimeoutInMilliseconds = null;
-        private Integer executionIsolationSemaphoreTimeoutInMilliseconds = null;
+        private Integer executionTimeoutInMilliseconds = null;
         private Integer fallbackIsolationSemaphoreMaxConcurrentRequests = null;
         private Boolean fallbackEnabled = null;
         private Integer metricsHealthSnapshotIntervalInMilliseconds = null;
@@ -550,14 +548,15 @@ public abstract class HystrixCommandProperties {
             return executionIsolationThreadInterruptOnTimeout;
         }
 
+        @Deprecated //prefer getExecutionTimeoutInMillisconds()
         public Integer getExecutionIsolationThreadTimeoutInMilliseconds() {
-            return executionIsolationThreadTimeoutInMilliseconds;
-        }
-        
-        public Integer getExecutionIsolationSemaphoreTimeoutInMilliseconds() {
-            return executionIsolationSemaphoreTimeoutInMilliseconds;
+            return executionTimeoutInMilliseconds;
         }
 
+        public Integer getExecutionTimeoutInMilliseconds() {
+            return executionTimeoutInMilliseconds;
+        }
+        
         public Integer getFallbackIsolationSemaphoreMaxConcurrentRequests() {
             return fallbackIsolationSemaphoreMaxConcurrentRequests;
         }
@@ -647,24 +646,17 @@ public abstract class HystrixCommandProperties {
             return this;
         }
 
+        @Deprecated //prefer {@link #withExecutionTimeoutInMilliseconds}
         public Setter withExecutionIsolationThreadTimeoutInMilliseconds(int value) {
-            this.executionIsolationThreadTimeoutInMilliseconds = value;
+            this.executionTimeoutInMilliseconds = value;
             return this;
         }
 
-        public Setter withExecutionIsolationSemaphoreTimeoutInMilliseconds(int value) {
-            this.executionIsolationSemaphoreTimeoutInMilliseconds = value;
+        public Setter withExecutionTimeoutInMilliseconds(int value) {
+            this.executionTimeoutInMilliseconds = value;
             return this;
         }
-        
 
-        public Setter withTimeoutInMilliseconds(int value) {
-            // We can set both values here, as only one will be applicable (based upon executionIsolation)
-            this.executionIsolationThreadTimeoutInMilliseconds = value;
-            this.executionIsolationSemaphoreTimeoutInMilliseconds = value;
-            return this;
-        }
-        
         public Setter withFallbackIsolationSemaphoreMaxConcurrentRequests(int value) {
             this.fallbackIsolationSemaphoreMaxConcurrentRequests = value;
             return this;

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCollapserTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCollapserTest.java
@@ -1097,7 +1097,7 @@ public class HystrixCollapserTest {
         private final Collection<CollapsedRequest<String, String>> requests;
 
         TestCollapserCommand(Collection<CollapsedRequest<String, String>> requests) {
-            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(50)));
+            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(50)));
             this.requests = requests;
         }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
@@ -117,12 +117,7 @@ public class HystrixCommandPropertiesTest {
 
             @Override
             public HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds() {
-                return HystrixProperty.Factory.asProperty(builder.getExecutionTimeoutInMilliseconds());
-            }
-
-            @Override
-            public HystrixProperty<Integer> executionTimeoutInMilliseconds() {
-                return HystrixProperty.Factory.asProperty(builder.getExecutionTimeoutInMilliseconds());
+                return HystrixProperty.Factory.asProperty(builder.getExecutionIsolationThreadTimeoutInMilliseconds());
             }
 
             @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
@@ -32,7 +32,7 @@ public class HystrixCommandPropertiesTest {
      */
     /* package */static HystrixCommandProperties.Setter getUnitTestPropertiesSetter() {
         return new HystrixCommandProperties.Setter()
-                .withExecutionIsolationThreadTimeoutInMilliseconds(1000)// when an execution will be timed out
+                .withExecutionTimeoutInMilliseconds(1000)// when an execution will be timed out
                 .withExecutionIsolationStrategy(ExecutionIsolationStrategy.THREAD) // we want thread execution by default in tests
                 .withExecutionIsolationThreadInterruptOnTimeout(true)
                 .withCircuitBreakerForceOpen(false) // we don't want short-circuiting by default
@@ -116,8 +116,8 @@ public class HystrixCommandPropertiesTest {
             }
 
             @Override
-            public HystrixProperty<Integer> executionIsolationThreadTimeoutInMilliseconds() {
-                return HystrixProperty.Factory.asProperty(builder.getExecutionIsolationThreadTimeoutInMilliseconds());
+            public HystrixProperty<Integer> executionTimeoutInMilliseconds() {
+                return HystrixProperty.Factory.asProperty(builder.getExecutionTimeoutInMilliseconds());
             }
 
             @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -1768,9 +1768,9 @@ public class HystrixCommandTest {
         TestCircuitBreaker s2 = new TestCircuitBreaker();
 
         // execution will take 100ms, thread pool has a 600ms timeout
-        CommandWithCustomThreadPool c1 = new CommandWithCustomThreadPool(s1, pool, 500, HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(600));
+        CommandWithCustomThreadPool c1 = new CommandWithCustomThreadPool(s1, pool, 500, HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(600));
         // execution will take 200ms, thread pool has a 20ms timeout
-        CommandWithCustomThreadPool c2 = new CommandWithCustomThreadPool(s2, pool, 200, HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(20));
+        CommandWithCustomThreadPool c2 = new CommandWithCustomThreadPool(s2, pool, 200, HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(20));
         // queue up c1 first
         Future<Boolean> c1f = c1.queue();
         // now queue up c2 and wait on it
@@ -5199,7 +5199,7 @@ public class HystrixCommandTest {
         HystrixCommand.Setter properties = HystrixCommand.Setter
                 .withGroupKey(HystrixCommandGroupKey.Factory.asKey("TestKey"))
                 .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                        .withExecutionIsolationThreadTimeoutInMilliseconds(50));
+                        .withExecutionTimeoutInMilliseconds(50));
 
         HystrixCommand<String> command = new HystrixCommand<String>(properties) {
             @Override
@@ -5841,7 +5841,7 @@ public class HystrixCommandTest {
 
         private TestCommandWithTimeout(long timeout, int fallbackBehavior) {
             super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
-                    .withExecutionIsolationThreadTimeoutInMilliseconds((int) timeout)));
+                    .withExecutionTimeoutInMilliseconds((int) timeout)));
             this.timeout = timeout;
             this.fallbackBehavior = fallbackBehavior;
             this.result = RESULT_SUCCESS;
@@ -5849,7 +5849,7 @@ public class HystrixCommandTest {
 
         private TestCommandWithTimeout(long timeout, int fallbackBehavior, int result) {
             super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
-                    .withExecutionIsolationThreadTimeoutInMilliseconds((int) timeout)));
+                    .withExecutionTimeoutInMilliseconds((int) timeout)));
             this.timeout = timeout;
             this.fallbackBehavior = fallbackBehavior;
             this.result = result;
@@ -6003,7 +6003,7 @@ public class HystrixCommandTest {
 
         private TestCommandRejection(TestCircuitBreaker circuitBreaker, HystrixThreadPool threadPool, int sleepTime, int timeout, int fallbackBehavior) {
             super(testPropsBuilder().setThreadPool(threadPool).setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(timeout)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(timeout)));
             this.fallbackBehavior = fallbackBehavior;
             this.sleepTime = sleepTime;
         }
@@ -6091,7 +6091,7 @@ public class HystrixCommandTest {
     private static class NoRequestCacheTimeoutWithoutFallback extends TestHystrixCommand<Boolean> {
         public NoRequestCacheTimeoutWithoutFallback(TestCircuitBreaker circuitBreaker) {
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(200)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(200)));
 
             // we want it to timeout
         }
@@ -6262,7 +6262,7 @@ public class HystrixCommandTest {
     private static class RequestCacheNullPointerExceptionCase extends TestHystrixCommand<Boolean> {
         public RequestCacheNullPointerExceptionCase(TestCircuitBreaker circuitBreaker) {
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(200)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(200)));
             // we want it to timeout
         }
 
@@ -6290,7 +6290,7 @@ public class HystrixCommandTest {
     private static class RequestCacheTimeoutWithoutFallback extends TestHystrixCommand<Boolean> {
         public RequestCacheTimeoutWithoutFallback(TestCircuitBreaker circuitBreaker) {
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(200)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(200)));
             // we want it to timeout
         }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTimeoutConcurrencyTesting.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTimeoutConcurrencyTesting.java
@@ -60,7 +60,7 @@ public class HystrixCommandTimeoutConcurrencyTesting {
             super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("testTimeoutConcurrency"))
                     .andCommandKey(HystrixCommandKey.Factory.asKey("testTimeoutConcurrencyCommand"))
                     .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                            .withExecutionIsolationThreadTimeoutInMilliseconds(1)));
+                            .withExecutionTimeoutInMilliseconds(1)));
         }
 
         @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCollapserTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCollapserTest.java
@@ -210,7 +210,7 @@ public class HystrixObservableCollapserTest {
         private final Collection<CollapsedRequest<String, String>> requests;
 
         TestCollapserCommand(Collection<CollapsedRequest<String, String>> requests) {
-            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(50)));
+            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(50)));
             this.requests = requests;
         }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -4827,7 +4827,7 @@ public class HystrixObservableCommandTest {
                 .withGroupKey(HystrixCommandGroupKey.Factory.asKey("TestKey"))
                 .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
                         .withExecutionIsolationStrategy(ExecutionIsolationStrategy.THREAD)
-                        .withExecutionIsolationThreadTimeoutInMilliseconds(50));
+                        .withExecutionTimeoutInMilliseconds(50));
 
         System.out.println(">>>>> Begin: " + System.currentTimeMillis());
 
@@ -4879,7 +4879,7 @@ public class HystrixObservableCommandTest {
                 .withGroupKey(HystrixCommandGroupKey.Factory.asKey("TestKey"))
                 .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
                         .withExecutionIsolationStrategy(ExecutionIsolationStrategy.THREAD)
-                        .withExecutionIsolationThreadTimeoutInMilliseconds(50));
+                        .withExecutionTimeoutInMilliseconds(50));
 
         HystrixObservableCommand<String> command = new HystrixObservableCommand<String>(properties) {
             @Override
@@ -4925,7 +4925,7 @@ public class HystrixObservableCommandTest {
         HystrixObservableCommand.Setter properties = HystrixObservableCommand.Setter
                 .withGroupKey(HystrixCommandGroupKey.Factory.asKey("TestKey"))
                 .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                        .withExecutionIsolationThreadTimeoutInMilliseconds(50));
+                        .withExecutionTimeoutInMilliseconds(50));
 
         HystrixObservableCommand<String> command = new HystrixObservableCommand<String>(properties) {
             @Override
@@ -5748,7 +5748,7 @@ public class HystrixObservableCommandTest {
     private RequestContextTestResults testRequestContextOnTimeout(ExecutionIsolationStrategy isolation, final Scheduler userScheduler) {
         final RequestContextTestResults results = new RequestContextTestResults();
         TestHystrixCommand<Boolean> command = new TestHystrixCommand<Boolean>(TestHystrixCommand.testPropsBuilder()
-                .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(isolation).withExecutionIsolationThreadTimeoutInMilliseconds(50))) {
+                .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(isolation).withExecutionTimeoutInMilliseconds(50))) {
 
             @Override
             protected Observable<Boolean> construct() {
@@ -5814,7 +5814,7 @@ public class HystrixObservableCommandTest {
     private RequestContextTestResults testRequestContextOnTimeoutWithFallback(ExecutionIsolationStrategy isolation, final Scheduler userScheduler) {
         final RequestContextTestResults results = new RequestContextTestResults();
         TestHystrixCommand<Boolean> command = new TestHystrixCommand<Boolean>(TestHystrixCommand.testPropsBuilder()
-                .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(isolation).withExecutionIsolationThreadTimeoutInMilliseconds(50))) {
+                .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(isolation).withExecutionTimeoutInMilliseconds(50))) {
 
             @Override
             protected Observable<Boolean> construct() {
@@ -7680,7 +7680,7 @@ public class HystrixObservableCommandTest {
 
         private TestCommandRejection(TestCircuitBreaker circuitBreaker, HystrixThreadPool threadPool, int sleepTime, int timeout, int fallbackBehavior) {
             super(testPropsBuilder().setThreadPool(threadPool).setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationThreadTimeoutInMilliseconds(timeout)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(timeout)));
             this.fallbackBehavior = fallbackBehavior;
             this.sleepTime = sleepTime;
         }
@@ -7765,7 +7765,7 @@ public class HystrixObservableCommandTest {
         }
 
         private TestCommandWithTimeout(long timeout, int fallbackBehavior, ExecutionIsolationStrategy isolationStrategy, int result) {
-            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(isolationStrategy).withExecutionIsolationThreadTimeoutInMilliseconds((int) timeout)));
+            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(isolationStrategy).withExecutionTimeoutInMilliseconds((int) timeout)));
             this.timeout = timeout;
             this.fallbackBehavior = fallbackBehavior;
             this.result = result;
@@ -7774,7 +7774,7 @@ public class HystrixObservableCommandTest {
 
 
         private TestCommandWithTimeout(long timeout, int fallbackBehavior, ExecutionIsolationStrategy isolationStrategy, int result, boolean asyncFallbackException) {
-            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(isolationStrategy).withExecutionIsolationThreadTimeoutInMilliseconds((int) timeout)));
+            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(isolationStrategy).withExecutionTimeoutInMilliseconds((int) timeout)));
             this.timeout = timeout;
             this.fallbackBehavior = fallbackBehavior;
             this.result = result;
@@ -7837,7 +7837,7 @@ public class HystrixObservableCommandTest {
     private static class NoRequestCacheTimeoutWithoutFallback extends TestHystrixCommand<Boolean> {
         public NoRequestCacheTimeoutWithoutFallback(TestCircuitBreaker circuitBreaker) {
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE).withExecutionIsolationThreadTimeoutInMilliseconds(200)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE).withExecutionTimeoutInMilliseconds(200)));
 
             // we want it to timeout
         }
@@ -8115,7 +8115,7 @@ public class HystrixObservableCommandTest {
                     .setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
                     .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
                             .withExecutionIsolationThreadInterruptOnTimeout(shouldInterrupt)
-                            .withExecutionIsolationThreadTimeoutInMilliseconds(100)));
+                            .withExecutionTimeoutInMilliseconds(100)));
         }
 
         private volatile boolean hasBeenInterrupted;
@@ -8143,7 +8143,7 @@ public class HystrixObservableCommandTest {
     private static class RequestCacheNullPointerExceptionCase extends TestHystrixCommand<Boolean> {
         public RequestCacheNullPointerExceptionCase(TestCircuitBreaker circuitBreaker) {
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE).withExecutionIsolationThreadTimeoutInMilliseconds(200)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE).withExecutionTimeoutInMilliseconds(200)));
             // we want it to timeout
         }
 
@@ -8180,7 +8180,7 @@ public class HystrixObservableCommandTest {
     private static class RequestCacheTimeoutWithoutFallback extends TestHystrixCommand<Boolean> {
         public RequestCacheTimeoutWithoutFallback(TestCircuitBreaker circuitBreaker) {
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
-                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE).withExecutionIsolationThreadTimeoutInMilliseconds(200)));
+                    .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE).withExecutionTimeoutInMilliseconds(200)));
             // we want it to timeout
         }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixTest.java
@@ -201,7 +201,7 @@ public class HystrixTest {
     private static class ResettableCommand extends HystrixCommand<Boolean> {
         ResettableCommand(int timeout, int poolCoreSize) {
             super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("GROUP"))
-                    .andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(timeout))
+                    .andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(timeout))
                     .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter().withCoreSize(poolCoreSize)));
         }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixTest.java
@@ -187,13 +187,13 @@ public class HystrixTest {
     @Test
     public void testResetCommandProperties() {
         HystrixCommand<Boolean> cmd1 = new ResettableCommand(100, 10);
-        assertEquals(100L, (long) cmd1.getProperties().executionTimeoutInMilliseconds().get());
+        assertEquals(100L, (long) cmd1.getProperties().executionIsolationThreadTimeoutInMilliseconds().get());
         assertEquals(10L, (long) cmd1.threadPool.getExecutor().getCorePoolSize());
 
         Hystrix.reset();
 
         HystrixCommand<Boolean> cmd2 = new ResettableCommand(700, 40);
-        assertEquals(700L, (long) cmd2.getProperties().executionTimeoutInMilliseconds().get());
+        assertEquals(700L, (long) cmd2.getProperties().executionIsolationThreadTimeoutInMilliseconds().get());
         assertEquals(40L, (long) cmd2.threadPool.getExecutor().getCorePoolSize());
 
 	}*/

--- a/hystrix-core/src/test/java/com/netflix/hystrix/strategy/concurrency/HystrixConcurrencyStrategyTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/strategy/concurrency/HystrixConcurrencyStrategyTest.java
@@ -110,7 +110,7 @@ public class HystrixConcurrencyStrategyTest {
         static final HystrixCommand.Setter properties = HystrixCommand.Setter
                 .withGroupKey(HystrixCommandGroupKey.Factory.asKey("TimeoutTest"))
                 .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                        .withExecutionIsolationThreadTimeoutInMilliseconds(50));
+                        .withExecutionTimeoutInMilliseconds(50));
 
         public TimeoutCommand() {
             super(properties);

--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
@@ -170,7 +170,6 @@
             assertNotNull(data,"propertyValue_circuitBreakerForceOpen");
             assertNotNull(data,"propertyValue_executionIsolationStrategy");
             assertNotNull(data,"propertyValue_executionIsolationThreadTimeoutInMilliseconds");
-            //this key was deprecated in 1.4.0-RC7. //TODO prefer propertyValue_executionInterruptOnTimeout instead
             assertNotNull(data,"propertyValue_executionIsolationThreadInterruptOnTimeout");
             // assertNotNull(data,"propertyValue_executionIsolationThreadPoolKeyOverride");
             assertNotNull(data,"propertyValue_executionIsolationSemaphoreMaxConcurrentRequests");

--- a/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandFacadeWithPrimarySecondary.java
+++ b/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandFacadeWithPrimarySecondary.java
@@ -82,7 +82,7 @@ public class CommandFacadeWithPrimarySecondary extends HystrixCommand<String> {
                     .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey("PrimaryCommand"))
                     .andCommandPropertiesDefaults(
                             // we default to a 600ms timeout for primary
-                            HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(600)));
+                            HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(600)));
             this.id = id;
         }
 
@@ -105,7 +105,7 @@ public class CommandFacadeWithPrimarySecondary extends HystrixCommand<String> {
                     .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey("SecondaryCommand"))
                     .andCommandPropertiesDefaults(
                             // we default to a 100ms timeout for secondary
-                            HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(100)));
+                            HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(100)));
             this.id = id;
         }
 

--- a/hystrix-examples/src/main/java/com/netflix/hystrix/examples/demo/CreditCardCommand.java
+++ b/hystrix-examples/src/main/java/com/netflix/hystrix/examples/demo/CreditCardCommand.java
@@ -79,7 +79,7 @@ public class CreditCardCommand extends HystrixCommand<CreditCardAuthorizationRes
     private CreditCardCommand(AuthorizeNetGateway gateway, Order order, PaymentInformation payment, BigDecimal amount) {
         super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("CreditCard"))
                 // defaulting to a fairly long timeout value because failing a credit card transaction is a bad user experience and 'costly' to re-attempt
-                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionIsolationThreadTimeoutInMilliseconds(3000)));
+                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(3000)));
         this.gateway = gateway;
         this.order = order;
         this.payment = payment;


### PR DESCRIPTION
Revert #664 in favor of a similar approach which does not attempt to migrate the property name.