### PR TITLE
This fixes #709: JS error: "isNan is not defined"

### DIFF
--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
@@ -237,7 +237,7 @@
 			var ratePerSecond = data.ratePerSecond;
 			var ratePerSecondPerHost = data.ratePerSecondPerHost;
 			var ratePerSecondPerHostDisplay = ratePerSecondPerHost;
-			var errorThenVolume = isNan( ratePerSecond )? -1: (data.errorPercentage * 100000000) +  ratePerSecond;
+			var errorThenVolume = isNaN( ratePerSecond )? -1: (data.errorPercentage * 100000000) +  ratePerSecond;
 			// set the rates on the div element so it's available for sorting
 			$('#CIRCUIT_' + data.escapedName).attr('rate_value', ratePerSecond);
 			$('#CIRCUIT_' + data.escapedName).attr('error_then_volume', errorThenVolume);


### PR DESCRIPTION
This fixes #709, correcting the mistake introduced by https://github.com/Netflix/Hystrix/commit/dc3bc3cac5ff349cb7cdca93c3bbf0b875f473f7, where "isNaN" is incorrectly cased as "isNan", causing the JavaScript error "isNan is not defined".