### PR TITLE
Make HystrixCommand.execute()/queue() and AbstractCommand.observe()/toObservable() nonfinal

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -307,7 +307,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
      * @throws IllegalStateException
      *             if invoked more than once
      */
-    final public Observable<R> observe() {
+    public Observable<R> observe() {
         // us a ReplaySubject to buffer the eagerly subscribed-to Observable
         ReplaySubject<R> subject = ReplaySubject.create();
         // eagerly kick off subscription
@@ -342,7 +342,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
      * @throws IllegalStateException
      *             if invoked more than once
      */
-    final public Observable<R> toObservable() {
+    public Observable<R> toObservable() {
         /* this is a stateful object so can only be used once */
         if (!started.compareAndSet(false, true)) {
             throw new IllegalStateException("This instance can only be executed once. Please instantiate a new instance.");

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -330,7 +330,7 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
      * @throws IllegalStateException
      *             if invoked more than once
      */
-    final public R execute() {
+    public R execute() {
         try {
             return queue().get();
         } catch (Exception e) {
@@ -360,7 +360,7 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
      * @throws IllegalStateException
      *             if invoked more than once
      */
-    final public Future<R> queue() {
+    public Future<R> queue() {
         /*
          * --- Schedulers.immediate()
          * 


### PR DESCRIPTION
Addresses #715 