### PR TITLE
Add a new interface, `DefaultRequestLogStrategy`, to disable requestLog for the concurrency strategy.

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.netflix.hystrix.strategy.concurrency.DefaultRequestLogStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -258,7 +259,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
         this.requestCache = HystrixRequestCache.getInstance(this.commandKey, this.concurrencyStrategy);
 
         /* store reference to request log regardless of which thread later hits it */
-        if (concurrencyStrategy instanceof HystrixConcurrencyStrategyDefault) {
+        if (concurrencyStrategy instanceof DefaultRequestLogStrategy) {
             // if we're using the default we support only optionally using a request context
             if (HystrixRequestContext.isCurrentThreadInitialized()) {
                 currentRequestLog = HystrixRequestLog.getCurrentRequest(concurrencyStrategy);

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/DefaultRequestLogStrategy.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/DefaultRequestLogStrategy.java
@@ -1,0 +1,8 @@
+package com.netflix.hystrix.strategy.concurrency;
+
+/**
+ * Indicates that the HystrixConcurrencyStrategy does not use a custom request log,
+ * therefore threads do not need to initialize the request log.
+ */
+public interface DefaultRequestLogStrategy {
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixConcurrencyStrategyDefault.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixConcurrencyStrategyDefault.java
@@ -20,7 +20,7 @@ package com.netflix.hystrix.strategy.concurrency;
  * 
  * @ExcludeFromJavadoc
  */
-public class HystrixConcurrencyStrategyDefault extends HystrixConcurrencyStrategy {
+public class HystrixConcurrencyStrategyDefault extends HystrixConcurrencyStrategy implements DefaultRequestLogStrategy {
 
     private static HystrixConcurrencyStrategyDefault INSTANCE = new HystrixConcurrencyStrategyDefault();
 


### PR DESCRIPTION
In https://github.com/Netflix/Hystrix/commit/706a0f267ed65a215de1d813598c6c72b00f76eb, the removal of checking of the request log is enabled before the request log initialization has made it impossible to override the concurrency strategy without wrapping all creation/execution of hystrix commands in hystrix context initializations.

This change adds an opt-in interface to use the default request log behavior, instead of forcing the implementor of a concurrency strategy to also change the request log behavior. The advantage of a separate interface is that this is class-file backwards compatible - already compiled concurrency strategies will still work with this commit and will retain the current behavior.

@mattrjacobs 