### PR TITLE
fixed AopUtils#getDeclaredMethod to look for method also in superclasses

### DIFF
--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/utils/AopUtils.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/utils/AopUtils.java
@@ -84,7 +84,10 @@ public final class AopUtils {
         try {
             method = type.getDeclaredMethod(methodName, parameterTypes);
         } catch (NoSuchMethodException e) {
-            // do nothing
+            Class<?> superclass = type.getSuperclass();
+            if (superclass != null) {
+                method = getDeclaredMethod(superclass, methodName, parameterTypes);
+            }
         }
         return method;
     }

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/command/CommandTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/command/CommandTest.java
@@ -51,6 +51,8 @@ public class CommandTest {
 
     @Autowired
     private UserService userService;
+    @Autowired
+    private AdvancedUserService advancedUserService;
     private HystrixRequestContext context;
 
     @Before
@@ -83,13 +85,13 @@ public class CommandTest {
     @Test
     public void testGetUserSync() {
         User u1 = userService.getUserSync("1", "name: ");
-        assertEquals("name: 1", u1.getName());
-        assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
-        com.netflix.hystrix.HystrixInvokableInfo<?> command = getCommand();
-        assertEquals("getUserSync", command.getCommandKey().name());
-        assertEquals("UserGroup", command.getCommandGroup().name());
-        assertEquals("UserGroup", command.getThreadPoolKey().name());
-        assertTrue(command.getExecutionEvents().contains(HystrixEventType.SUCCESS));
+        assertGetUserSnycCommandExecuted(u1);
+    }
+
+    @Test
+    public void shouldWorkWithInheritedMethod() {
+        User u1 = advancedUserService.getUserSync("1", "name: ");
+        assertGetUserSnycCommandExecuted(u1);
     }
 
     @Test
@@ -98,6 +100,16 @@ public class CommandTest {
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
         assertTrue(getCommand().getExecutionEvents().contains(HystrixEventType.SUCCESS));
+    }
+
+    private void assertGetUserSnycCommandExecuted(User u1) {
+        assertEquals("name: 1", u1.getName());
+        assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
+        com.netflix.hystrix.HystrixInvokableInfo<?> command = getCommand();
+        assertEquals("getUserSync", command.getCommandKey().name());
+        assertEquals("UserGroup", command.getCommandGroup().name());
+        assertEquals("UserGroup", command.getThreadPoolKey().name());
+        assertTrue(command.getExecutionEvents().contains(HystrixEventType.SUCCESS));
     }
 
     private com.netflix.hystrix.HystrixInvokableInfo<?> getCommand() {
@@ -128,12 +140,21 @@ public class CommandTest {
 
     }
 
+    public static class AdvancedUserService extends UserService {
+
+    }
+
     @Configurable
     public static class CommandTestConfig {
 
         @Bean
         public UserService userService() {
             return new UserService();
+        }
+
+        @Bean
+        public AdvancedUserService advancedUserService() {
+            return new AdvancedUserService();
         }
     }
 


### PR DESCRIPTION
The HystrixCommandAspect fails with NPE if the method annotated with @HystrixCommand is implemented in a superclass. Since the Class#getDeclaredMethod can't see inherited methods but in spite of Class#getMethod can see private ones, I performed a recursive search up by class hierarchy.