### PR TITLE
Check if the request log is enabled before requiring the context is initialized.

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -257,21 +257,25 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
         /* setup the request cache for this instance */
         this.requestCache = HystrixRequestCache.getInstance(this.commandKey, this.concurrencyStrategy);
 
-        /* store reference to request log regardless of which thread later hits it */
-        if (concurrencyStrategy instanceof HystrixConcurrencyStrategyDefault) {
-            // if we're using the default we support only optionally using a request context
-            if (HystrixRequestContext.isCurrentThreadInitialized()) {
+        if (properties.requestLogEnabled().get()) {
+            /* store reference to request log regardless of which thread later hits it */
+            if (concurrencyStrategy instanceof HystrixConcurrencyStrategyDefault) {
+              // if we're using the default we support only optionally using a request context
+              if (HystrixRequestContext.isCurrentThreadInitialized()) {
                 currentRequestLog = HystrixRequestLog.getCurrentRequest(concurrencyStrategy);
-            } else {
+              } else {
                 currentRequestLog = null;
+              }
+            } else {
+              // if it's a custom strategy it must ensure the context is initialized
+              if (HystrixRequestLog.getCurrentRequest(concurrencyStrategy) != null) {
+                currentRequestLog = HystrixRequestLog.getCurrentRequest(concurrencyStrategy);
+              } else {
+                currentRequestLog = null;
+              }
             }
         } else {
-            // if it's a custom strategy it must ensure the context is initialized
-            if (HystrixRequestLog.getCurrentRequest(concurrencyStrategy) != null) {
-                currentRequestLog = HystrixRequestLog.getCurrentRequest(concurrencyStrategy);
-            } else {
-                currentRequestLog = null;
-            }
+            currentRequestLog = null;
         }
     }
 


### PR DESCRIPTION
In https://github.com/Netflix/Hystrix/commit/706a0f267ed65a215de1d813598c6c72b00f76eb,
the guard to initialize the request log based on the property was removed. This
causes a dependency on hystrix context initialization for all custom concurrency
strategies.

Here we add that back in, along with a test to ensure that a custom strategy could
still run without an initialized context.

This PR supercedes https://github.com/Netflix/Hystrix/pull/718/

/cc @mattrjacobs 