### PR TITLE
Up the time before failure in HystrixCommandTest.testFallbackRejectionOccursWithLatentFallback

### DIFF
--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -3645,7 +3645,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         }
 
         try {
-            latch.await(5, TimeUnit.SECONDS);
+            latch.await(30, TimeUnit.SECONDS);
 
             System.out.println("MAP : " + exceptionTypes);
         } catch (InterruptedException ie) {


### PR DESCRIPTION
Hopefully fixes #726 