### PR TITLE
Filter out thread pools from metrics stream that have had no commands executed on them

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
@@ -162,8 +162,10 @@ public class HystrixMetricsPoller {
                 }
 
                 for (HystrixThreadPoolMetrics threadPoolMetrics : HystrixThreadPoolMetrics.getInstances()) {
-                    String jsonString = getThreadPoolJson(threadPoolMetrics);
-                    listener.handleJsonMetric(jsonString);
+                    if (hasExecutedCommandsOnThread(threadPoolMetrics)) {
+                        String jsonString = getThreadPoolJson(threadPoolMetrics);
+                        listener.handleJsonMetric(jsonString);
+                    }
                 }
 
                 for (HystrixCollapserMetrics collapserMetrics : HystrixCollapserMetrics.getInstances()) {
@@ -290,6 +292,10 @@ public class HystrixMetricsPoller {
             json.close();
 
             return jsonString.getBuffer().toString();
+        }
+
+        private boolean hasExecutedCommandsOnThread(HystrixThreadPoolMetrics threadPoolMetrics) {
+            return threadPoolMetrics.getCurrentCompletedTaskCount().intValue() > 0;
         }
 
         private String getThreadPoolJson(HystrixThreadPoolMetrics threadPoolMetrics) throws IOException {


### PR DESCRIPTION
Fixes #704 