### PR TITLE
Updated the RxNetty based version of HystrixMetricsStreamHandler

### DIFF
--- a/hystrix-contrib/hystrix-rx-netty-metrics-stream/build.gradle
+++ b/hystrix-contrib/hystrix-rx-netty-metrics-stream/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':hystrix-core')
-    compile "com.netflix.rxnetty:rx-netty:0.3.8"
+    compile 'io.reactivex:rxnetty:0.4.7'
     compile 'org.codehaus.jackson:jackson-core-asl:1.9.2'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'
     testCompile 'junit:junit-dep:4.10'

--- a/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/HystrixMetricsStreamHandler.java
+++ b/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/HystrixMetricsStreamHandler.java
@@ -47,6 +47,7 @@ import static com.netflix.hystrix.contrib.rxnetty.metricsstream.JsonMappers.*;
  * (unless the client is shutdown).
  *
  * @author Tomasz Bak
+ * @author Christian Schmitt <c.schmitt@envisia.de>
  */
 public class HystrixMetricsStreamHandler<I, O> implements RequestHandler<I, O> {
 
@@ -89,7 +90,7 @@ public class HystrixMetricsStreamHandler<I, O> implements RequestHandler<I, O> {
                 .subscribe(new Action1<Long>() {
                     @Override
                     public void call(Long tick) {
-                        if (!response.getChannelHandlerContext().channel().isOpen()) {
+                        if (!response.getChannel().isOpen()) {
                             subscription.unsubscribe();
                             return;
                         }


### PR DESCRIPTION
I updated the RxNetty based Hystrix Metrics Stream to a newer version of RxNetty that it could work with Karyon2.