### PR TITLE
Added HystrixCounters to hold global metrics on Hystrix behavior

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -534,6 +534,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                         } catch (Throwable hookEx) {
                             logger.warn("Error calling HystrixCommandExecutionHook.onExecutionStart", hookEx);
                         }
+                        HystrixCounters.incrementGlobalConcurrentThreads();
                         threadPool.markThreadExecution();
                         // store the command that is being run
                         endCurrentThreadExecutingCommand.set(Hystrix.startCurrentThreadExecutingCommand(getCommandKey()));
@@ -914,6 +915,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
             endCurrentThreadExecutingCommand.get().call();
         }
         if (isExecutedInThread.get()) {
+            HystrixCounters.decrementGlobalConcurrentThreads();
             threadPool.markThreadCompletion();
             try {
                 executionHook.onThreadComplete(this);

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCounters.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCounters.java
@@ -1,0 +1,19 @@
+package com.netflix.hystrix;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class HystrixCounters {
+    private static final AtomicInteger concurrentThreadsExecuting = new AtomicInteger(0);
+
+    /* package-private */ static void incrementGlobalConcurrentThreads() {
+        concurrentThreadsExecuting.incrementAndGet();
+    }
+
+    /* package-private */ static void decrementGlobalConcurrentThreads() {
+        concurrentThreadsExecuting.decrementAndGet();
+    }
+
+    public static int getGlobalConcurrentThreadsExecuting() {
+        return concurrentThreadsExecuting.get();
+    }
+}

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -23,16 +23,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -46,11 +40,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.omg.PortableServer.THREAD_POLICY_ID;
 import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
-import rx.Subscriber;
 import rx.functions.Action1;
 import rx.functions.Func0;
 import rx.observers.TestSubscriber;
@@ -68,7 +60,6 @@ import com.netflix.hystrix.strategy.concurrency.HystrixContextScheduler;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 import com.netflix.hystrix.strategy.properties.HystrixProperty;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
-import rx.schedulers.Schedulers;
 
 public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCommand<?>> {
 
@@ -976,7 +967,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertEquals(100, circuitBreaker_one.metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, circuitBreaker_one.metrics.getCurrentConcurrentExecutionCount());
 
-
         assertEquals(0, circuitBreaker_two.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, circuitBreaker_two.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
         assertEquals(1, circuitBreaker_two.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -992,7 +982,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, circuitBreaker_two.metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, circuitBreaker_two.metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(4, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1026,7 +1015,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(0, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1076,7 +1064,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
 
-
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
@@ -1114,7 +1101,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1157,7 +1143,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1211,7 +1196,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
 
-
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
@@ -1260,7 +1244,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
 
-
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
@@ -1295,7 +1278,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1340,7 +1322,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1390,7 +1371,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
 
-
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
@@ -1425,7 +1405,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1470,7 +1449,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1520,7 +1498,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, circuitBreaker.metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, circuitBreaker.metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(2, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1603,7 +1580,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(50, circuitBreaker.metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, circuitBreaker.metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(2, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -1804,7 +1780,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertEquals(100, circuitBreaker.metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, circuitBreaker.metrics.getCurrentConcurrentExecutionCount());
 
-
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
@@ -1871,7 +1846,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertEquals(0, s1.metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, s1.metrics.getCurrentConcurrentExecutionCount());
 
-
         assertEquals(0, s2.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, s2.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
         assertEquals(0, s2.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -1887,7 +1861,6 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(100, s2.metrics.getHealthCounts().getErrorPercentage());
         assertEquals(0, s2.metrics.getCurrentConcurrentExecutionCount());
-
 
         assertEquals(2, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -3428,6 +3428,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals(0, commandDisabled.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE));
 
         assertEquals(100, commandDisabled.getBuilder().metrics.getHealthCounts().getErrorPercentage());
+        assertEquals(0, commandDisabled.metrics.getCurrentConcurrentExecutionCount());
 
         assertEquals(2, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -3484,6 +3485,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         // Thread isolated
         assertTrue(command.isExecutedInThread());
 
+        assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
@@ -3531,6 +3534,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         // Thread isolated
         assertTrue(command.isExecutedInThread());
 
+        assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
@@ -3577,6 +3582,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         // semaphore isolated
         assertFalse(command.isExecutedInThread());
+
+        assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -3641,6 +3648,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
 
+        assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
         // semaphore isolated
@@ -3698,6 +3707,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE));
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
+
+        assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
@@ -3787,6 +3798,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.THREAD_POOL_REJECTED));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.TIMEOUT));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE));
+
+        assertEquals(0, circuitBreaker.metrics.getCurrentConcurrentExecutionCount());
 
         assertEquals(2, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
@@ -3890,6 +3903,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.TIMEOUT));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE));
 
+        assertEquals(0, circuitBreaker.metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(3, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
     }
 
@@ -3955,6 +3970,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertEquals(0, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
 
+        assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
         return results;
@@ -4017,6 +4034,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
 
+        assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
         return results;
@@ -4078,6 +4097,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE));
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
+
+        assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
@@ -4155,6 +4176,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE));
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
+
+        assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
@@ -4280,6 +4303,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
 
+        assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
         return results;
@@ -4359,6 +4384,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
 
+        assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
         return results;
@@ -4424,6 +4451,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE));
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
+
+        assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
 
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
@@ -4506,6 +4535,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertEquals(100, command.getBuilder().metrics.getHealthCounts().getErrorPercentage());
 
+        assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
+
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
 
         return results;
@@ -4520,7 +4551,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         final AtomicReference<Thread> observeOnThread = new AtomicReference<Thread>();
     }
 
-    /* *************************************** testSuccessfuleRequestContext *********************************** */
+    /* *************************************** testSuccessfulRequestContext *********************************** */
 
     /**
      * Synchronous Observable and semaphore isolation. Only [Main] thread is involved in this.
@@ -5489,6 +5520,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertTrue(command.getExecutionEvents().contains(HystrixEventType.SUCCESS));
             assertEquals(0, command.getNumberFallbackEmissions());
 
+            assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
+
             // semaphore isolated
             assertFalse(command.isExecutedInThread());
         } catch (Exception e) {
@@ -5544,6 +5577,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertTrue(command.getExecutionEvents().contains(HystrixEventType.FAILURE));
             assertEquals(0, command.getNumberFallbackEmissions());
 
+            assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
 
             // semaphore isolated
             assertFalse(command.isExecutedInThread());
@@ -5601,6 +5635,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertEquals(4, command.getNumberFallbackEmissions());
             assertTrue(command.getExecutionEvents().contains(HystrixEventType.FALLBACK_SUCCESS));
 
+            assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
+
             // semaphore isolated
             assertFalse(command.isExecutedInThread());
         } catch (Exception e) {
@@ -5657,6 +5693,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertEquals(1, command.getNumberFallbackEmissions());
             assertTrue(command.getExecutionEvents().contains(HystrixEventType.FALLBACK_SUCCESS));
 
+            assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
 
             // semaphore isolated
             assertFalse(command.isExecutedInThread());


### PR DESCRIPTION
This helps address #297.  It is a counter around per-JVM concurrent threads. Rather than forcing consumers to implement this via hooks, you now can get it directly.