### PR TITLE
More precise solution to #771

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -1360,7 +1360,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                     try {
                         executionHook.onExecutionSuccess(cmd);
                     } catch (Throwable hookEx) {
-                        logger.warn("Error calling HystrixCommandExecutionHook.onError", hookEx);
+                        logger.warn("Error calling HystrixCommandExecutionHook.onExecutionSuccess", hookEx);
                     }
                     subscriber.onCompleted();
                 }
@@ -1395,7 +1395,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                     try {
                         executionHook.onFallbackSuccess(cmd);
                     } catch (Throwable hookEx) {
-                        logger.warn("Error calling HystrixCommandExecutionHook.onError", hookEx);
+                        logger.warn("Error calling HystrixCommandExecutionHook.onFallbackSuccess", hookEx);
                     }
                     subscriber.onCompleted();
                 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -604,8 +604,8 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
                         } else {
                             logger.warn("ExecutionHook.onError returned an exception that was not an instance of HystrixBadRequestException so will be ignored.", decorated);
                         }
-                    } catch (Exception hookException) {
-                        logger.warn("Error calling ExecutionHook.onError", hookException);
+                    } catch (Exception hookEx) {
+                        logger.warn("Error calling ExecutionHook.onError", hookEx);
                     }
                     /*
                      * HystrixBadRequestException is treated differently and allowed to propagate without any stats tracking or fallback logic

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixRollingPercentile.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixRollingPercentile.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.ReentrantLock;

--- a/hystrix-core/src/test/java/com/netflix/hystrix/TestHystrixCommand.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/TestHystrixCommand.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.hystrix;
 
+import com.netflix.hystrix.strategy.executionhook.HystrixCommandExecutionHook;
+
 abstract public class TestHystrixCommand<T> extends HystrixCommand<T> implements AbstractTestHystrixCommand<T> {
 
     private final TestCommandBuilder builder;
@@ -23,6 +25,13 @@ abstract public class TestHystrixCommand<T> extends HystrixCommand<T> implements
         super(builder.owner, builder.dependencyKey, builder.threadPoolKey, builder.circuitBreaker, builder.threadPool,
                 builder.commandPropertiesDefaults, builder.threadPoolPropertiesDefaults, builder.metrics,
                 builder.fallbackSemaphore, builder.executionSemaphore, TEST_PROPERTIES_FACTORY, builder.executionHook);
+        this.builder = builder;
+    }
+
+    public TestHystrixCommand(TestCommandBuilder builder, HystrixCommandExecutionHook executionHook) {
+        super(builder.owner, builder.dependencyKey, builder.threadPoolKey, builder.circuitBreaker, builder.threadPool,
+                builder.commandPropertiesDefaults, builder.threadPoolPropertiesDefaults, builder.metrics,
+                builder.fallbackSemaphore, builder.executionSemaphore, TEST_PROPERTIES_FACTORY, executionHook);
         this.builder = builder;
     }
 


### PR DESCRIPTION
Instead of try-catching all hook errors, follow this pattern:

* For a hook at the beginning of an event, assume that a thrown exception replaces the surrounded event.  For example, `onExecutionStart()` throwing implies that the `run()`/`construct()` method does not get run, but it looks from the outside as if it threw an exception.

* For a hook at the end of an event, there is no such ability to replace a value, so just try-catch and log.

This allows for hooks to influence behavior without having to subclass `HystrixCommand`.  I've also added a unit test that asserts state is properly maintained when hooks throw Exceptions