### PR TITLE
Update metrics to the latest version

### DIFF
--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/build.gradle
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':hystrix-core')
-    compile 'com.codahale.metrics:metrics-core:3.0.2'
+    compile 'io.dropwizard.metrics:metrics-core:3.1.2'
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-all:1.9.5'
 }


### PR DESCRIPTION
Latest version changed groupId to `io.dropwizard.metrics` from `com.codahale.metrics`