### PR TITLE
HystrixMetricsStreamServlet rejects requests after servlet shutdown (fixes #786)

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/build.gradle
+++ b/hystrix-contrib/hystrix-metrics-event-stream/build.gradle
@@ -3,4 +3,5 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-core:2.5.2'
     provided 'javax.servlet:servlet-api:2.5'
     testCompile 'junit:junit-dep:4.10'
+    testCompile 'org.mockito:mockito-all:1.9.5'
 }

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
@@ -84,7 +84,11 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        handleRequest(request, response);
+        if (isDestroyed) {
+            response.sendError(503, "Service has been shut down.");
+        } else {
+            handleRequest(request, response);
+        }
     }
     
     /**

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/test/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServletUnitTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/test/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServletUnitTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.hystrix.contrib.metrics.eventstream;
 
 import org.junit.Test;

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/test/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServletUnitTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/test/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServletUnitTest.java
@@ -1,0 +1,30 @@
+package com.netflix.hystrix.contrib.metrics.eventstream;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class HystrixMetricsStreamServletUnitTest {
+
+    @Test
+    public void shutdownServletShouldRejectRequests() throws ServletException, IOException {
+
+        final HystrixMetricsStreamServlet servlet = new HystrixMetricsStreamServlet();
+        servlet.shutdown();
+
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        servlet.doGet(mock(HttpServletRequest.class), response);
+
+        verify(response).sendError(503, "Service has been shut down.");
+
+    }
+
+}


### PR DESCRIPTION
Reject requests with a 503 status code when the servlet has been shutdown. This prevents a new HystrixMetricsPoller to be started, defeating the original reason shutdown has been added (cf. #346).