### PR TITLE
Monitoring stream when pressing the enter key

### DIFF
--- a/hystrix-dashboard/src/main/webapp/index.html
+++ b/hystrix-dashboard/src/main/webapp/index.html
@@ -26,6 +26,13 @@
 				$('#message').html("The 'stream' value is required.");
 			}
 		}
+		$(document).ready(function() {
+			$('#stream').keypress(function(e) {
+				if(e.which == 13) {
+					sendToMonitor();
+				}
+			});
+		});
 	</script>
 </head>
 <body>


### PR DESCRIPTION
As suggested by @nurkiewicz during his GeeCON 2015 talk, pressing the enter key in the input field now directly starts the monitor.