### PR TITLE
Move all reads of Histograms to a single-threaded path

### DIFF
--- a/hystrix-core/build.gradle
+++ b/hystrix-core/build.gradle
@@ -37,7 +37,7 @@ jar {
 jmh {
 	fork = 10
 	iterations = 3
-	jmhVersion = '1.9'
+	jmhVersion = '1.9.3'
 	profilers = ['gc']
 	threads = 8
 	warmup = '1s'

--- a/hystrix-core/src/jmh/java/com/netflix/hystrix/perf/MultiThreadedMetricsTest.java
+++ b/hystrix-core/src/jmh/java/com/netflix/hystrix/perf/MultiThreadedMetricsTest.java
@@ -2,6 +2,7 @@ package com.netflix.hystrix.perf;
 
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandMetrics;
 import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.hystrix.HystrixThreadPoolProperties;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -72,7 +73,8 @@ public class MultiThreadedMetricsTest {
     @BenchmarkMode({Mode.Throughput})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public Integer writeHeavyReadMetrics(CommandState state) {
-        return state.command.getMetrics().getCurrentConcurrentExecutionCount();
+        HystrixCommandMetrics metrics = state.command.getMetrics();
+        return metrics.getExecutionTimeMean() + metrics.getExecutionTimePercentile(50) + metrics.getExecutionTimePercentile(75) + metrics.getExecutionTimePercentile(99);
     }
 
     @Benchmark
@@ -90,7 +92,8 @@ public class MultiThreadedMetricsTest {
     @BenchmarkMode({Mode.Throughput})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public Integer evenSplitOfWritesAndReadsReadMetrics(CommandState state) {
-        return state.command.getMetrics().getCurrentConcurrentExecutionCount();
+        HystrixCommandMetrics metrics = state.command.getMetrics();
+        return metrics.getExecutionTimeMean() + metrics.getExecutionTimePercentile(50) + metrics.getExecutionTimePercentile(75) + metrics.getExecutionTimePercentile(99);
     }
 
     @Benchmark
@@ -108,6 +111,7 @@ public class MultiThreadedMetricsTest {
     @BenchmarkMode({Mode.Throughput})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public Integer readHeavyReadMetrics(CommandState state) {
-        return state.command.getMetrics().getCurrentConcurrentExecutionCount();
+        HystrixCommandMetrics metrics = state.command.getMetrics();
+        return metrics.getExecutionTimeMean() + metrics.getExecutionTimePercentile(50) + metrics.getExecutionTimePercentile(75) + metrics.getExecutionTimePercentile(99);
     }
 }


### PR DESCRIPTION
Either cache the commonly-accessed summaries at construction, or support arbitrary calculations via a synchronized path

Addresses #788 