### PR TITLE
Modify logic to only check the dynamic maxQueueSize property on creation of a threadPool

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolProperties.java
@@ -107,6 +107,9 @@ public abstract class HystrixThreadPoolProperties {
 
     /**
      * Max queue size that gets passed to {@link BlockingQueue} in {@link HystrixConcurrencyStrategy#getBlockingQueue(int)}
+     *
+     * This should only affect the instantiation of a threadpool - it is not eliglible to change a queue size on the fly.
+     * For that, use {@link #queueSizeRejectionThreshold()}.
      * 
      * @return {@code HystrixProperty<Integer>}
      */


### PR DESCRIPTION
Fixes #817 