### PR TITLE
fix half hidden mean metric because of container height

### DIFF
--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.css
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.css
@@ -110,7 +110,7 @@
 
 .dependencies div.monitor {
 	width: 245px; /* we want a fixed width instead of percentage as I want the boxes to be a set size and then fill in as many as can fit in each row ... this allows 3 columns on an iPad */
-	height: 150px;
+	height: 155px;
 }
 
 .dependencies .success {

--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/templates/hystrixCircuitContainer.html
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/templates/hystrixCircuitContainer.html
@@ -9,7 +9,7 @@
 	%>
 	
 	<div id="chart_CIRCUIT_<%= name %>" class="chart" style="position:absolute;top:0px;left:0; float:left; width:100%; height:100%;"></div>
-    <div style="position:absolute;top:0x;width:100%;height:15px;opacity:0.8; background:white;">
+    <div style="position:absolute;top:0;width:100%;height:15px;opacity:0.8; background:white;">
     	<% if(includeDetailIcon) { %>
     	<p class="name" <%= toolTip %> style="padding-right:16px">
     		<%= displayName %>

--- a/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/templates/hystrixThreadPoolContainer.html
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/templates/hystrixThreadPoolContainer.html
@@ -10,7 +10,7 @@
 	%>
 	
 	<div id="chart_THREAD_POOL_<%= name %>" class="chart" style="position:absolute;top:0px;left:0; float:left; width:100%; height:100%;"></div>
-	<div style="position:absolute;top:0x;width:100%;height:15px;opacity:0.8; background:white;"><p class="name" <%= toolTip %>><%= displayName %></p></div>
+	<div style="position:absolute;top:0;width:100%;height:15px;opacity:0.8; background:white;"><p class="name" <%= toolTip %>><%= displayName %></p></div>
 	<div style="position:absolute;top:15px;; opacity:0.8; background:white; width:100%; height:95%;">
 		<div class="monitor_data"></div>
 	</div>

--- a/hystrix-dashboard/src/main/webapp/monitor/monitor.html
+++ b/hystrix-dashboard/src/main/webapp/monitor/monitor.html
@@ -59,8 +59,7 @@
 		<div id="dependencies" class="row dependencies"><span class="loading">Loading ...</span></div>
 		
 		<div class="spacer"></div>
-		<div class="spacer"></div>
-		
+
 		<div class="row">
 			<div class="menubar">
 				<div class="title">


### PR DESCRIPTION
Browsers hide the half of the mean metric in every command-monitor. I have fixed that. Later on we should maybe think about a solution based on percentages.