### PR TITLE
Safely handle negative input on the delay input to metrics-stream

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
@@ -124,7 +124,7 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
                 try {
                     String d = request.getParameter("delay");
                     if (d != null) {
-                        delay = Integer.parseInt(d);
+                        delay = Math.max(Integer.parseInt(d), 1);
                     }
                 } catch (Exception e) {
                     // ignore if it's not a number


### PR DESCRIPTION
Reported in #820 