### PR TITLE
Make hystrix metrics abstract

### DIFF
--- a/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/test/java/com/netflix/hystrix/HystrixCommandMetricsSamples.java
+++ b/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/test/java/com/netflix/hystrix/HystrixCommandMetricsSamples.java
@@ -15,8 +15,6 @@
  */
 package com.netflix.hystrix;
 
-import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifierDefault;
-
 /**
  * Not very elegant, but there is no other way to create this data directly for testing
  * purposes, as {@link com.netflix.hystrix.HystrixCommandMetrics} has no public constructors,
@@ -57,7 +55,7 @@ public class HystrixCommandMetricsSamples {
 
     static {
         HystrixCommandKey key = new MyHystrixCommandKey();
-        SAMPLE_1 = new HystrixCommandMetrics(key, new MyHystrixCommandGroupKey(), new MyHystrixThreadPoolKey(),
-                new MyHystrixCommandProperties(key), HystrixEventNotifierDefault.getInstance());
+        SAMPLE_1 = HystrixCommandMetrics.getInstance(key, new MyHystrixCommandGroupKey(), new MyHystrixThreadPoolKey(),
+                new MyHystrixCommandProperties(key));
     }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -16,7 +16,6 @@
 package com.netflix.hystrix;
 
 import java.lang.ref.Reference;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapserMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapserMetrics.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
  */
 public class HystrixCollapserMetrics extends HystrixMetrics {
 
+    private final HystrixRollingNumber counter;
+
     @SuppressWarnings("unused")
     private static final Logger logger = LoggerFactory.getLogger(HystrixCollapserMetrics.class);
 
@@ -88,7 +90,7 @@ public class HystrixCollapserMetrics extends HystrixMetrics {
     private final HystrixRollingPercentile percentileShardSize;
 
     /* package */HystrixCollapserMetrics(HystrixCollapserKey key, HystrixCollapserProperties properties) {
-        super(new HystrixRollingNumber(properties.metricsRollingStatisticalWindowInMilliseconds().get(), properties.metricsRollingStatisticalWindowBuckets().get()));
+        counter = new HystrixRollingNumber(properties.metricsRollingStatisticalWindowInMilliseconds().get(), properties.metricsRollingStatisticalWindowBuckets().get());
         this.key = key;
         this.properties = properties;
 
@@ -161,4 +163,13 @@ public class HystrixCollapserMetrics extends HystrixMetrics {
     }
 
 
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return counter.getCumulativeSum(event);
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return counter.getRollingSum(event);
+    }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapserMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapserMetrics.java
@@ -27,7 +27,17 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Used by {@link HystrixCollapser} to record metrics.
- * {@link com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier} not hooked up yet.  It may be in the future.
+ * This is an abstract class that provides a home for statics that manage caching of HystrixCollapserMetrics instances.
+ * It also provides a limited surface-area for concrete subclasses to implement.  This allows different data structures
+ * to be used in the actual storage of metrics.
+ *
+ * For instance, you may drop all metrics.  You may also keep references to all collapser events that pass through
+ * the JVM.  The default is to take a middle ground and summarize collapser metrics into counts of events and
+ * percentiles of batch/shard size.
+ *
+ * Note that {@link com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier} is not hooked up yet.  It may be in the future.
+ *
+ * As in {@link HystrixMetrics}, all read methods are public and write methods are package-private or protected.
  */
 public abstract class HystrixCollapserMetrics extends HystrixMetrics {
 
@@ -104,7 +114,7 @@ public abstract class HystrixCollapserMetrics extends HystrixMetrics {
     }
 
     /**
-     * Retrieve the batch size for the {@link HystrixCollapser} being invoked at a given percentile.
+     * Retrieve the batch size for the {@link HystrixCollapser} being invoked at a given percentile over a rolling window.
      * <p>
      * Percentile capture and calculation is configured via {@link HystrixCollapserProperties#metricsRollingStatisticalWindowInMilliseconds()} and other related properties.
      *
@@ -114,12 +124,22 @@ public abstract class HystrixCollapserMetrics extends HystrixMetrics {
      */
     public abstract int getBatchSizePercentile(double percentile);
 
+    /**
+     * Mean of batch size over rolling window.
+     *
+     * @return batch size mean
+     */
     public abstract int getBatchSizeMean();
 
+    /**
+     * Add a batch size to the batch size metrics data structure
+     *
+     * @param batchSize batch size to add
+     */
     protected abstract void addBatchSize(int batchSize);
 
     /**
-     * Retrieve the shard size for the {@link HystrixCollapser} being invoked at a given percentile.
+     * Retrieve the shard size for the {@link HystrixCollapser} being invoked at a given percentile for a rolling window.
      * <p>
      * Percentile capture and calculation is configured via {@link HystrixCollapserProperties#metricsRollingStatisticalWindowInMilliseconds()} and other related properties.
      *
@@ -129,24 +149,54 @@ public abstract class HystrixCollapserMetrics extends HystrixMetrics {
      */
     public abstract int getShardSizePercentile(double percentile);
 
+    /**
+     * Mean of shard size over rolling window.
+     *
+     * @return shard size mean
+     */
     public abstract int getShardSizeMean();
 
+    /**
+     * Add a shard size to the shard size metrics data structure.
+     *
+     * @param shardSize shard size to add
+     */
     protected abstract void addShardSize(int shardSize);
 
-    public void markRequestBatched() {
+    /**
+     * Called when a {@link HystrixCollapser} has been invoked.  This does not directly execute work, just places the
+     * args in a queue to be batched at a later point.  Keeping track of this value will allow us to determine
+     * the effectiveness of batching over executing each command individually.
+     */
+    /* package */ void markRequestBatched() {
         addEvent(HystrixRollingNumberEvent.COLLAPSER_REQUEST_BATCHED);
     }
 
-    public void markResponseFromCache() {
+    /**
+     * Called when a {@link HystrixCollapser} has been invoked and the response is returned directly from the
+     * {@link HystrixRequestCache}.
+     */
+    /* package */ void markResponseFromCache() {
         addEvent(HystrixRollingNumberEvent.RESPONSE_FROM_CACHE);
     }
 
-    public void markBatch(int batchSize) {
+    /**
+     * Called when a batch {@link HystrixCommand} has been executed.  Tracking this event allows us to determine the
+     * effectiveness of collapsing by getting the distribution of batch sizes.
+     *
+     * @param batchSize number of request arguments in the batch
+     */
+    /* package */ void markBatch(int batchSize) {
         addBatchSize(batchSize);
         addEvent(HystrixRollingNumberEvent.COLLAPSER_BATCH);
     }
 
-    public void markShards(int numShards) {
+    /**
+     * Called when a batch of request arguments has been divided into shards for separate execution.
+     *
+     * @param numShards number of shards in the batch
+     */
+    /* package */ void markShards(int numShards) {
         addShardSize(numShards);
     }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
@@ -408,8 +408,7 @@ public abstract class HystrixCommandMetrics extends HystrixMetrics {
      * 
      * @return {@link HealthCounts}
      */
-    //TODO Should this be final?
-    public HealthCounts getHealthCounts() {
+    public final HealthCounts getHealthCounts() {
         // we put an interval between snapshots so high-volume commands don't 
         // spend too much unnecessary time calculating metrics in very small time periods
         long lastTime = lastHealthCountsSnapshot.get();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
@@ -414,6 +414,9 @@ public abstract class HystrixCommandMetrics extends HystrixMetrics {
 
     /**
      * Retrieve a snapshot of total requests, error count and error percentage.
+     *
+     * Marked final so that concrete implementation may vary how to implement {@link #getRollingCount(HystrixRollingNumberEvent)}
+     * and the health check (used for opening a {@link HystrixCircuitBreaker} is constant
      * 
      * @return {@link HealthCounts}
      */

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetricsSummary.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetricsSummary.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2012 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.hystrix.exception.HystrixBadRequestException;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+import com.netflix.hystrix.util.HystrixRollingNumber;
+import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+import com.netflix.hystrix.util.HystrixRollingPercentile;
+
+/**
+ * Used by {@link HystrixCommand} to record metrics.
+ */
+public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
+
+    private final HystrixRollingNumber counter;
+    private final HystrixRollingPercentile percentileExecution;
+    private final HystrixRollingPercentile percentileTotal;
+    private final AtomicInteger concurrentExecutionCount = new AtomicInteger();
+
+    public HystrixCommandMetricsSummary(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey threadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier) {
+        super(key, commandGroup, threadPoolKey, properties, eventNotifier);
+        this.counter = new HystrixRollingNumber(properties.metricsRollingStatisticalWindowInMilliseconds().get(), properties.metricsRollingStatisticalWindowBuckets().get());
+        this.percentileExecution = new HystrixRollingPercentile(properties.metricsRollingPercentileWindowInMilliseconds().get(), properties.metricsRollingPercentileWindowBuckets().get(), properties.metricsRollingPercentileBucketSize().get(), properties.metricsRollingPercentileEnabled());
+        this.percentileTotal = new HystrixRollingPercentile(properties.metricsRollingPercentileWindowInMilliseconds().get(), properties.metricsRollingPercentileWindowBuckets().get(), properties.metricsRollingPercentileBucketSize().get(), properties.metricsRollingPercentileEnabled());
+    }
+
+    /**
+     * Retrieve the execution time (in milliseconds) for the {@link HystrixCommand#run()} method being invoked at a given percentile.
+     * <p>
+     * Percentile capture and calculation is configured via {@link HystrixCommandProperties#metricsRollingStatisticalWindowInMilliseconds()} and other related properties.
+     * 
+     * @param percentile
+     *            Percentile such as 50, 99, or 99.5.
+     * @return int time in milliseconds
+     */
+    public int getExecutionTimePercentile(double percentile) {
+        return percentileExecution.getPercentile(percentile);
+    }
+
+    /**
+     * The mean (average) execution time (in milliseconds) for the {@link HystrixCommand#run()}.
+     * <p>
+     * This uses the same backing data as {@link #getExecutionTimePercentile};
+     * 
+     * @return int time in milliseconds
+     */
+    public int getExecutionTimeMean() {
+        return percentileExecution.getMean();
+    }
+
+    /**
+     * Retrieve the total end-to-end execution time (in milliseconds) for {@link HystrixCommand#execute()} or {@link HystrixCommand#queue()} at a given percentile.
+     * <p>
+     * When execution is successful this would include time from {@link #getExecutionTimePercentile} but when execution
+     * is being rejected, short-circuited, or timed-out then the time will differ.
+     * <p>
+     * This time can be lower than {@link #getExecutionTimePercentile} when a timeout occurs and the backing
+     * thread that calls {@link HystrixCommand#run()} is still running.
+     * <p>
+     * When rejections or short-circuits occur then {@link HystrixCommand#run()} will not be executed and thus
+     * not contribute time to {@link #getExecutionTimePercentile} but time will still show up in this metric for the end-to-end time.
+     * <p>
+     * This metric gives visibility into the total cost of {@link HystrixCommand} execution including
+     * the overhead of queuing, executing and waiting for a thread to invoke {@link HystrixCommand#run()} .
+     * <p>
+     * Percentile capture and calculation is configured via {@link HystrixCommandProperties#metricsRollingStatisticalWindowInMilliseconds()} and other related properties.
+     * 
+     * @param percentile
+     *            Percentile such as 50, 99, or 99.5.
+     * @return int time in milliseconds
+     */
+    public int getTotalTimePercentile(double percentile) {
+        return percentileTotal.getPercentile(percentile);
+    }
+
+    /**
+     * The mean (average) execution time (in milliseconds) for {@link HystrixCommand#execute()} or {@link HystrixCommand#queue()}.
+     * <p>
+     * This uses the same backing data as {@link #getTotalTimePercentile};
+     * 
+     * @return int time in milliseconds
+     */
+    public int getTotalTimeMean() {
+        return percentileTotal.getMean();
+    }
+
+    @Override
+    /* package */void clear() {
+        // TODO can we do without this somehow?
+        counter.reset();
+    }
+
+    /**
+     * Current number of concurrent executions of {@link HystrixCommand#run()};
+     * 
+     * @return int
+     */
+    public int getCurrentConcurrentExecutionCount() {
+        return concurrentExecutionCount.get();
+    }
+
+    @Override
+    protected void addEvent(HystrixRollingNumberEvent event) {
+        counter.increment(event);
+    }
+
+    @Override
+    protected void addEventWithValue(HystrixRollingNumberEvent event, int count) {
+        counter.add(event, count);
+    }
+
+    @Override
+    protected long getRollingSum(HystrixRollingNumberEvent event) {
+        return counter.getRollingSum(event);
+    }
+
+    /**
+     * Increment concurrent requests counter.
+     */
+    /* package */void incrementConcurrentExecutionCount() {
+        int numConcurrent = concurrentExecutionCount.incrementAndGet();
+        counter.updateRollingMax(HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE, (long) numConcurrent);
+    }
+    
+    /**
+     * Decrement concurrent requests counter.
+     */
+    /* package */void decrementConcurrentExecutionCount() {
+        concurrentExecutionCount.decrementAndGet();
+    }
+
+    public long getRollingMaxConcurrentExecutions() {
+        return counter.getRollingMaxValue(HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE);
+    }
+
+    /**
+     * Execution time of {@link HystrixCommand#run()}.
+     */
+    @Override
+    /* package */void addCommandExecutionTime(long duration) {
+        percentileExecution.addValue((int) duration);
+    }
+
+    /**
+     * Complete execution time of {@link HystrixCommand#execute()} or {@link HystrixCommand#queue()} (queue is considered complete once the work is finished and {@link Future#get} is capable of
+     * retrieving the value.
+     * <p>
+     * This differs from {@link #addCommandExecutionTime} in that this covers all of the threading and scheduling overhead, not just the execution of the {@link HystrixCommand#run()} method.
+     */
+    @Override
+    /* package */void addUserThreadExecutionTime(long duration) {
+        percentileTotal.addValue((int) duration);
+    }
+
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return counter.getCumulativeSum(event);
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return counter.getCumulativeSum(event);
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixMetrics.java
@@ -19,14 +19,16 @@ import com.netflix.hystrix.util.HystrixRollingNumberEvent;
 
 /**
  * Abstract base class for Hystrix metrics
+ *
+ * Read methods are public, as they may get called by arbitrary metrics consumers in other projects
+ * Write methods are protected, so that only internals may trigger them.
  */
 public abstract class HystrixMetrics {
 
     /**
      * Get the cumulative count since the start of the application for the given {@link HystrixRollingNumberEvent}.
      * 
-     * @param event
-     *            {@link HystrixRollingNumberEvent} of the event to retrieve a sum for
+     * @param event {@link HystrixRollingNumberEvent} of the event to retrieve a sum for
      * @return long cumulative count
      */
     public abstract long getCumulativeCount(HystrixRollingNumberEvent event);
@@ -36,17 +38,42 @@ public abstract class HystrixMetrics {
      * <p>
      * The rolling window is defined by {@link HystrixCommandProperties#metricsRollingStatisticalWindowInMilliseconds()}.
      * 
-     * @param event
-     *            {@link HystrixRollingNumberEvent} of the event to retrieve a sum for
+     * @param event {@link HystrixRollingNumberEvent} of the event to retrieve a sum for
      * @return long rolling count
      */
     public abstract long getRollingCount(HystrixRollingNumberEvent event);
 
+    /**
+     * Get the rolling max for the given {@link HystrixRollingNumberEvent}. This number is the high-water mark
+     * that the metric has observed in the rolling window.
+     * <p>
+     * The rolling window is defined by {@link HystrixCommandProperties#metricsRollingStatisticalWindowInMilliseconds()}.
+     *
+     * @param event {@link HystrixRollingNumberEvent} of the event to retrieve a rolling max for
+     * @return long rolling max
+     */
+    public abstract long getRollingMax(HystrixRollingNumberEvent event);
+
+    /**
+     * Increment the count of an {@link HystrixRollingNumberEvent}.
+     *
+     * @param event event type to increment
+     */
     protected abstract void addEvent(HystrixRollingNumberEvent event);
 
+    /**
+     * Add a count of {@link HystrixRollingNumberEvent}s
+     *
+     * @param event event type to add to
+     * @param value count to add
+     */
     protected abstract void addEventWithValue(HystrixRollingNumberEvent event, long value);
 
+    /**
+     * Set the observed value of a {@link HystrixRollingNumberEvent} into a counter that keeps track of maximum values
+     *
+     * @param event event type to observe count of
+     * @param value count observed
+     */
     protected abstract void updateRollingMax(HystrixRollingNumberEvent event, long value);
-
-    protected abstract long getRollingMax(HystrixRollingNumberEvent event);
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixMetrics.java
@@ -41,4 +41,12 @@ public abstract class HystrixMetrics {
      * @return long rolling count
      */
     public abstract long getRollingCount(HystrixRollingNumberEvent event);
+
+    protected abstract void addEvent(HystrixRollingNumberEvent event);
+
+    protected abstract void addEventWithValue(HystrixRollingNumberEvent event, long value);
+
+    protected abstract void updateRollingMax(HystrixRollingNumberEvent event, long value);
+
+    protected abstract long getRollingMax(HystrixRollingNumberEvent event);
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixMetrics.java
@@ -15,7 +15,6 @@
  */
 package com.netflix.hystrix;
 
-import com.netflix.hystrix.util.HystrixRollingNumber;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
 
 /**
@@ -23,11 +22,6 @@ import com.netflix.hystrix.util.HystrixRollingNumberEvent;
  */
 public abstract class HystrixMetrics {
 
-    protected final HystrixRollingNumber counter;
-
-    protected HystrixMetrics(HystrixRollingNumber counter) {
-        this.counter = counter;
-    }
     /**
      * Get the cumulative count since the start of the application for the given {@link HystrixRollingNumberEvent}.
      * 
@@ -35,9 +29,7 @@ public abstract class HystrixMetrics {
      *            {@link HystrixRollingNumberEvent} of the event to retrieve a sum for
      * @return long cumulative count
      */
-    public long getCumulativeCount(HystrixRollingNumberEvent event) {
-        return counter.getCumulativeSum(event);
-    }
+    public abstract long getCumulativeCount(HystrixRollingNumberEvent event);
 
     /**
      * Get the rolling count for the given {@link HystrixRollingNumberEvent}.
@@ -48,8 +40,5 @@ public abstract class HystrixMetrics {
      *            {@link HystrixRollingNumberEvent} of the event to retrieve a sum for
      * @return long rolling count
      */
-    public long getRollingCount(HystrixRollingNumberEvent event) {
-        return counter.getRollingSum(event);
-    }
-
+    public abstract long getRollingCount(HystrixRollingNumberEvent event);
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolMetrics.java
@@ -23,14 +23,20 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import com.netflix.hystrix.strategy.HystrixPlugins;
 import com.netflix.hystrix.strategy.metrics.HystrixMetricsCollection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.netflix.hystrix.util.HystrixRollingNumber;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
 
 /**
- * Used by {@link HystrixThreadPool} to record metrics.
+ * Metrics class to track usage of {@link HystrixThreadPool}s.
+ *
+ * This is an abstract class that provides a home for statics that manage caching of HystrixThreadPoolMetrics instances.
+ * It also provides a limited surface-area for concrete subclasses to implement.  This allows different data structures
+ * to be used in the actual storage of metrics.
+ *
+ * For instance, you may drop all metrics.  You may also keep references to all threadpool events that pass through
+ * the JVM.  The default is to take a middle ground and summarize threadpool metrics into counts of events and
+ * percentiles of batch/shard size.
+ *
+ * As in {@link HystrixMetrics}, all read methods are public and write methods are package-private or protected.
  */
 public abstract class HystrixThreadPoolMetrics extends HystrixMetrics {
 
@@ -210,7 +216,7 @@ public abstract class HystrixThreadPoolMetrics extends HystrixMetrics {
     /**
      * Invoked each time a thread is executed.
      */
-    public void markThreadExecution() {
+    protected void markThreadExecution() {
         // increment the count
         addEvent(HystrixRollingNumberEvent.THREAD_EXECUTION);
         setMaxActiveThreads();
@@ -239,7 +245,7 @@ public abstract class HystrixThreadPoolMetrics extends HystrixMetrics {
     /**
      * Invoked each time a thread completes.
      */
-    public void markThreadCompletion() {
+    protected void markThreadCompletion() {
         setMaxActiveThreads();
     }
 
@@ -254,6 +260,10 @@ public abstract class HystrixThreadPoolMetrics extends HystrixMetrics {
         return getRollingMax(HystrixRollingNumberEvent.THREAD_MAX_ACTIVE);
     }
 
+    /**
+     * Update the rolling max counter of active threads
+     *
+     */
     private void setMaxActiveThreads() {
         updateRollingMax(HystrixRollingNumberEvent.THREAD_MAX_ACTIVE, threadPool.getActiveCount());
     }
@@ -261,7 +271,7 @@ public abstract class HystrixThreadPoolMetrics extends HystrixMetrics {
     /**
      * Invoked each time a command is rejected from the thread-pool
      */
-    public void markThreadRejection() {
+    protected void markThreadRejection() {
         addEvent(HystrixRollingNumberEvent.THREAD_POOL_REJECTED);
     }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolMetrics.java
@@ -32,6 +32,8 @@ import com.netflix.hystrix.util.HystrixRollingNumberEvent;
  */
 public class HystrixThreadPoolMetrics extends HystrixMetrics {
 
+    private final HystrixRollingNumber counter;
+
     @SuppressWarnings("unused")
     private static final Logger logger = LoggerFactory.getLogger(HystrixThreadPoolMetrics.class);
 
@@ -103,7 +105,7 @@ public class HystrixThreadPoolMetrics extends HystrixMetrics {
     private final HystrixThreadPoolProperties properties;
 
     private HystrixThreadPoolMetrics(HystrixThreadPoolKey threadPoolKey, ThreadPoolExecutor threadPool, HystrixThreadPoolProperties properties) {
-        super(new HystrixRollingNumber(properties.metricsRollingStatisticalWindowInMilliseconds().get(), properties.metricsRollingStatisticalWindowBuckets().get()));
+        this.counter = new HystrixRollingNumber(properties.metricsRollingStatisticalWindowInMilliseconds().get(), properties.metricsRollingStatisticalWindowBuckets().get());
         this.threadPoolKey = threadPoolKey;
         this.threadPool = threadPool;
         this.properties = properties;
@@ -264,5 +266,15 @@ public class HystrixThreadPoolMetrics extends HystrixMetrics {
      */
     public void markThreadRejection() {
         counter.increment(HystrixRollingNumberEvent.THREAD_POOL_REJECTED);
+    }
+
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return 0;
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return 0;
     }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixCollapserMetricsSummary.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixCollapserMetricsSummary.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.metrics;
+
+import com.netflix.hystrix.HystrixCollapser;
+import com.netflix.hystrix.HystrixCollapserKey;
+import com.netflix.hystrix.HystrixCollapserMetrics;
+import com.netflix.hystrix.HystrixCollapserProperties;
+import com.netflix.hystrix.util.HystrixRollingNumber;
+import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+import com.netflix.hystrix.util.HystrixRollingPercentile;
+
+/**
+ * Used by {@link HystrixCollapser} to record metrics.
+ * {@link com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier} not hooked up yet.  It may be in the future.
+ */
+public class HystrixCollapserMetricsSummary extends HystrixCollapserMetrics {
+
+    private final HystrixRollingNumber counter;
+    private final HystrixRollingPercentile percentileBatchSize;
+    private final HystrixRollingPercentile percentileShardSize;
+
+    /* package */HystrixCollapserMetricsSummary(HystrixCollapserKey key, HystrixCollapserProperties properties) {
+        super(key, properties);
+        this.counter = new HystrixRollingNumber(properties.metricsRollingStatisticalWindowInMilliseconds().get(), properties.metricsRollingStatisticalWindowBuckets().get());
+        this.percentileBatchSize = new HystrixRollingPercentile(properties.metricsRollingPercentileWindowInMilliseconds().get(), properties.metricsRollingPercentileWindowBuckets().get(), properties.metricsRollingPercentileBucketSize().get(), properties.metricsRollingPercentileEnabled());
+        this.percentileShardSize = new HystrixRollingPercentile(properties.metricsRollingPercentileWindowInMilliseconds().get(), properties.metricsRollingPercentileWindowBuckets().get(), properties.metricsRollingPercentileBucketSize().get(), properties.metricsRollingPercentileEnabled());
+    }
+
+    /**
+     * Retrieve the batch size for the {@link HystrixCollapser} being invoked at a given percentile.
+     * <p>
+     * Percentile capture and calculation is configured via {@link HystrixCollapserProperties#metricsRollingStatisticalWindowInMilliseconds()} and other related properties.
+     *
+     * @param percentile
+     *            Percentile such as 50, 99, or 99.5.
+     * @return batch size
+     */
+    @Override
+    public int getBatchSizePercentile(double percentile) {
+        return percentileBatchSize.getPercentile(percentile);
+    }
+
+    @Override
+    public int getBatchSizeMean() {
+        return percentileBatchSize.getMean();
+    }
+
+    @Override
+    protected void addBatchSize(int batchSize) {
+        percentileBatchSize.addValue(batchSize);
+    }
+
+    /**
+     * Retrieve the shard size for the {@link HystrixCollapser} being invoked at a given percentile.
+     * <p>
+     * Percentile capture and calculation is configured via {@link HystrixCollapserProperties#metricsRollingStatisticalWindowInMilliseconds()} and other related properties.
+     *
+     * @param percentile
+     *            Percentile such as 50, 99, or 99.5.
+     * @return batch size
+     */
+    @Override
+    public int getShardSizePercentile(double percentile) {
+        return percentileShardSize.getPercentile(percentile);
+    }
+
+    @Override
+    public int getShardSizeMean() {
+        return percentileShardSize.getMean();
+    }
+
+    @Override
+    protected void addShardSize(int shardSize) {
+        percentileShardSize.addValue(shardSize);
+    }
+
+    public void markShards(int numShards) {
+        percentileShardSize.addValue(numShards);
+    }
+
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return counter.getCumulativeSum(event);
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return counter.getRollingSum(event);
+    }
+
+    @Override
+    protected void addEvent(HystrixRollingNumberEvent event) {
+        counter.increment(event);
+    }
+
+    @Override
+    protected void addEventWithValue(HystrixRollingNumberEvent event, long value) {
+        counter.add(event, value);
+    }
+
+    @Override
+    protected void updateRollingMax(HystrixRollingNumberEvent event, long value) {
+        counter.updateRollingMax(event, value);
+    }
+
+    @Override
+    protected long getRollingMax(HystrixRollingNumberEvent event) {
+        return counter.getRollingMaxValue(event);
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixCommandMetricsSummary.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixCommandMetricsSummary.java
@@ -13,34 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.hystrix;
+package com.netflix.hystrix.strategy.metrics;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.netflix.hystrix.exception.HystrixBadRequestException;
-import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandMetrics;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolKey;
 import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
 import com.netflix.hystrix.util.HystrixRollingNumber;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
 import com.netflix.hystrix.util.HystrixRollingPercentile;
 
 /**
- * Used by {@link HystrixCommand} to record metrics.
+ * Used by {@link HystrixCommand} to record metrics into {@link HystrixRollingNumber} and {@link HystrixRollingPercentile} summary data structures.
  */
 public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
 
     private final HystrixRollingNumber counter;
     private final HystrixRollingPercentile percentileExecution;
     private final HystrixRollingPercentile percentileTotal;
-    private final AtomicInteger concurrentExecutionCount = new AtomicInteger();
 
     public HystrixCommandMetricsSummary(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey threadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier) {
         super(key, commandGroup, threadPoolKey, properties, eventNotifier);
@@ -49,11 +42,70 @@ public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
         this.percentileTotal = new HystrixRollingPercentile(properties.metricsRollingPercentileWindowInMilliseconds().get(), properties.metricsRollingPercentileWindowBuckets().get(), properties.metricsRollingPercentileBucketSize().get(), properties.metricsRollingPercentileEnabled());
     }
 
+
+    @Override
+    protected void clear() {
+        // TODO can we do without this somehow?
+        counter.reset();
+    }
+
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return counter.getCumulativeSum(event);
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return counter.getRollingSum(event);
+    }
+
+    @Override
+    protected void addEvent(HystrixRollingNumberEvent event) {
+        counter.increment(event);
+    }
+
+    @Override
+    protected void addEventWithValue(HystrixRollingNumberEvent event, long value) {
+        counter.add(event, value);
+    }
+
+    @Override
+    protected void updateRollingMax(HystrixRollingNumberEvent event, long value) {
+        counter.updateRollingMax(event, value);
+    }
+
+    @Override
+    protected long getRollingMax(HystrixRollingNumberEvent event) {
+        return counter.getRollingMaxValue(event);
+    }
+
+    public long getRollingMaxConcurrentExecutions() {
+        return counter.getRollingMaxValue(HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE);
+    }
+
+    /**
+     * Execution time of {@link HystrixCommand#run()}.
+     */
+    @Override
+    protected void addCommandExecutionTime(long duration) {
+        percentileExecution.addValue((int) duration);
+    }
+
+    /**
+     * Complete HystrixCommand execution (either via completion of Hystrix work / timeout / failure / fail-fast
+     * <p>
+     * This differs from {@link #addCommandExecutionTime} in that this covers all of the threading and scheduling overhead, not just the execution of the {@link HystrixCommand#run()} method.
+     */
+    @Override
+    protected void addUserThreadExecutionTime(long duration) {
+        percentileTotal.addValue((int) duration);
+    }
+
     /**
      * Retrieve the execution time (in milliseconds) for the {@link HystrixCommand#run()} method being invoked at a given percentile.
      * <p>
      * Percentile capture and calculation is configured via {@link HystrixCommandProperties#metricsRollingStatisticalWindowInMilliseconds()} and other related properties.
-     * 
+     *
      * @param percentile
      *            Percentile such as 50, 99, or 99.5.
      * @return int time in milliseconds
@@ -66,7 +118,7 @@ public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
      * The mean (average) execution time (in milliseconds) for the {@link HystrixCommand#run()}.
      * <p>
      * This uses the same backing data as {@link #getExecutionTimePercentile};
-     * 
+     *
      * @return int time in milliseconds
      */
     public int getExecutionTimeMean() {
@@ -89,7 +141,7 @@ public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
      * the overhead of queuing, executing and waiting for a thread to invoke {@link HystrixCommand#run()} .
      * <p>
      * Percentile capture and calculation is configured via {@link HystrixCommandProperties#metricsRollingStatisticalWindowInMilliseconds()} and other related properties.
-     * 
+     *
      * @param percentile
      *            Percentile such as 50, 99, or 99.5.
      * @return int time in milliseconds
@@ -102,88 +154,10 @@ public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
      * The mean (average) execution time (in milliseconds) for {@link HystrixCommand#execute()} or {@link HystrixCommand#queue()}.
      * <p>
      * This uses the same backing data as {@link #getTotalTimePercentile};
-     * 
+     *
      * @return int time in milliseconds
      */
     public int getTotalTimeMean() {
         return percentileTotal.getMean();
-    }
-
-    @Override
-    /* package */void clear() {
-        // TODO can we do without this somehow?
-        counter.reset();
-    }
-
-    /**
-     * Current number of concurrent executions of {@link HystrixCommand#run()};
-     * 
-     * @return int
-     */
-    public int getCurrentConcurrentExecutionCount() {
-        return concurrentExecutionCount.get();
-    }
-
-    @Override
-    protected void addEvent(HystrixRollingNumberEvent event) {
-        counter.increment(event);
-    }
-
-    @Override
-    protected void addEventWithValue(HystrixRollingNumberEvent event, int count) {
-        counter.add(event, count);
-    }
-
-    @Override
-    protected long getRollingSum(HystrixRollingNumberEvent event) {
-        return counter.getRollingSum(event);
-    }
-
-    /**
-     * Increment concurrent requests counter.
-     */
-    /* package */void incrementConcurrentExecutionCount() {
-        int numConcurrent = concurrentExecutionCount.incrementAndGet();
-        counter.updateRollingMax(HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE, (long) numConcurrent);
-    }
-    
-    /**
-     * Decrement concurrent requests counter.
-     */
-    /* package */void decrementConcurrentExecutionCount() {
-        concurrentExecutionCount.decrementAndGet();
-    }
-
-    public long getRollingMaxConcurrentExecutions() {
-        return counter.getRollingMaxValue(HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE);
-    }
-
-    /**
-     * Execution time of {@link HystrixCommand#run()}.
-     */
-    @Override
-    /* package */void addCommandExecutionTime(long duration) {
-        percentileExecution.addValue((int) duration);
-    }
-
-    /**
-     * Complete execution time of {@link HystrixCommand#execute()} or {@link HystrixCommand#queue()} (queue is considered complete once the work is finished and {@link Future#get} is capable of
-     * retrieving the value.
-     * <p>
-     * This differs from {@link #addCommandExecutionTime} in that this covers all of the threading and scheduling overhead, not just the execution of the {@link HystrixCommand#run()} method.
-     */
-    @Override
-    /* package */void addUserThreadExecutionTime(long duration) {
-        percentileTotal.addValue((int) duration);
-    }
-
-    @Override
-    public long getCumulativeCount(HystrixRollingNumberEvent event) {
-        return counter.getCumulativeSum(event);
-    }
-
-    @Override
-    public long getRollingCount(HystrixRollingNumberEvent event) {
-        return counter.getCumulativeSum(event);
     }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixCommandMetricsSummary.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixCommandMetricsSummary.java
@@ -79,10 +79,6 @@ public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
         counter.updateRollingMax(event, value);
     }
 
-    public long getRollingMaxConcurrentExecutions() {
-        return counter.getRollingMaxValue(HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE);
-    }
-
     /**
      * Execution time of {@link HystrixCommand#run()}.
      */

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixCommandMetricsSummary.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixCommandMetricsSummary.java
@@ -60,6 +60,11 @@ public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
     }
 
     @Override
+    public long getRollingMax(HystrixRollingNumberEvent event) {
+        return counter.getRollingMaxValue(event);
+    }
+
+    @Override
     protected void addEvent(HystrixRollingNumberEvent event) {
         counter.increment(event);
     }
@@ -72,11 +77,6 @@ public class HystrixCommandMetricsSummary extends HystrixCommandMetrics {
     @Override
     protected void updateRollingMax(HystrixRollingNumberEvent event, long value) {
         counter.updateRollingMax(event, value);
-    }
-
-    @Override
-    protected long getRollingMax(HystrixRollingNumberEvent event) {
-        return counter.getRollingMaxValue(event);
     }
 
     public long getRollingMaxConcurrentExecutions() {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsCollection.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsCollection.java
@@ -15,17 +15,28 @@
  */
 package com.netflix.hystrix.strategy.metrics;
 
+import com.netflix.hystrix.HystrixCollapserKey;
+import com.netflix.hystrix.HystrixCollapserMetrics;
+import com.netflix.hystrix.HystrixCollapserProperties;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixCommandMetrics;
 import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolMetrics;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
 import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+
+import java.util.concurrent.ThreadPoolExecutor;
 
 public abstract class HystrixMetricsCollection {
 
     /**
      * Generate an instance of {@link HystrixCommandMetrics}
      */
-    public abstract HystrixCommandMetrics getCommandMetricsInstance(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey nonNullThreadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier);
+    public abstract HystrixCommandMetrics getCommandMetricsInstance(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey threadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier);
+
+    public abstract HystrixThreadPoolMetrics getThreadPoolMetricsInstance(HystrixThreadPoolKey key, ThreadPoolExecutor threadPool, HystrixThreadPoolProperties properties);
+
+    public abstract HystrixCollapserMetrics getCollapserMetricsInstance(HystrixCollapserKey key, HystrixCollapserProperties properties);
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsCollection.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsCollection.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.metrics;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandMetrics;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+
+public abstract class HystrixMetricsCollection {
+
+    /**
+     * Generate an instance of {@link HystrixCommandMetrics}
+     */
+    public abstract HystrixCommandMetrics getCommandMetricsInstance(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey nonNullThreadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier);
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsCollectionDefault.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsCollectionDefault.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.metrics;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandMetrics;
+import com.netflix.hystrix.HystrixCommandMetricsSummary;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+
+/**
+ * Default implementation of {@link HystrixMetricsCollection}.
+ * <p>
+ * See <a href="https://github.com/Netflix/Hystrix/wiki/Plugins">Wiki docs</a> about plugins for more information.
+ * 
+ * @ExcludeFromJavadoc
+ */
+public class HystrixMetricsCollectionDefault extends HystrixMetricsCollection {
+
+    private static HystrixMetricsCollectionDefault INSTANCE = new HystrixMetricsCollectionDefault();
+
+    public static HystrixMetricsCollection getInstance() {
+        return INSTANCE;
+    }
+
+    private HystrixMetricsCollectionDefault() {
+    }
+
+    @Override
+    public HystrixCommandMetrics getCommandMetricsInstance(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey nonNullThreadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier) {
+        return new HystrixCommandMetricsSummary(key, commandGroup, nonNullThreadPoolKey, properties, eventNotifier);
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsCollectionDefault.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsCollectionDefault.java
@@ -15,13 +15,19 @@
  */
 package com.netflix.hystrix.strategy.metrics;
 
+import com.netflix.hystrix.HystrixCollapserKey;
+import com.netflix.hystrix.HystrixCollapserMetrics;
+import com.netflix.hystrix.HystrixCollapserProperties;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixCommandMetrics;
-import com.netflix.hystrix.HystrixCommandMetricsSummary;
 import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolMetrics;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
 import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+
+import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * Default implementation of {@link HystrixMetricsCollection}.
@@ -42,7 +48,17 @@ public class HystrixMetricsCollectionDefault extends HystrixMetricsCollection {
     }
 
     @Override
-    public HystrixCommandMetrics getCommandMetricsInstance(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey nonNullThreadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier) {
-        return new HystrixCommandMetricsSummary(key, commandGroup, nonNullThreadPoolKey, properties, eventNotifier);
+    public HystrixCommandMetrics getCommandMetricsInstance(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey threadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier) {
+        return new HystrixCommandMetricsSummary(key, commandGroup, threadPoolKey, properties, eventNotifier);
+    }
+
+    @Override
+    public HystrixThreadPoolMetrics getThreadPoolMetricsInstance(HystrixThreadPoolKey key, ThreadPoolExecutor threadPool, HystrixThreadPoolProperties properties) {
+        return new HystrixThreadPoolMetricsSummary(key, threadPool, properties);
+    }
+
+    @Override
+    public HystrixCollapserMetrics getCollapserMetricsInstance(HystrixCollapserKey key, HystrixCollapserProperties properties) {
+        return new HystrixCollapserMetricsSummary(key, properties);
     }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixThreadPoolMetricsSummary.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixThreadPoolMetricsSummary.java
@@ -48,6 +48,11 @@ public class HystrixThreadPoolMetricsSummary extends HystrixThreadPoolMetrics {
     }
 
     @Override
+    public long getRollingMax(HystrixRollingNumberEvent event) {
+        return counter.getRollingMaxValue(event);
+    }
+
+    @Override
     protected void addEvent(HystrixRollingNumberEvent event) {
         counter.increment(event);
     }
@@ -60,10 +65,5 @@ public class HystrixThreadPoolMetricsSummary extends HystrixThreadPoolMetrics {
     @Override
     protected void updateRollingMax(HystrixRollingNumberEvent event, long value) {
         counter.updateRollingMax(event, value);
-    }
-
-    @Override
-    protected long getRollingMax(HystrixRollingNumberEvent event) {
-        return counter.getRollingMaxValue(event);
     }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixThreadPoolMetricsSummary.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixThreadPoolMetricsSummary.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.metrics;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import com.netflix.hystrix.HystrixThreadPool;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolMetrics;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.util.HystrixRollingNumber;
+import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+
+/**
+ * Used by {@link HystrixThreadPool} to record metrics.
+ */
+public class HystrixThreadPoolMetricsSummary extends HystrixThreadPoolMetrics {
+
+    private final HystrixRollingNumber counter;
+
+    /* package */HystrixThreadPoolMetricsSummary(HystrixThreadPoolKey threadPoolKey, ThreadPoolExecutor threadPool, HystrixThreadPoolProperties properties) {
+        super(threadPoolKey, threadPool, properties);
+        this.counter = new HystrixRollingNumber(properties.metricsRollingStatisticalWindowInMilliseconds().get(), properties.metricsRollingStatisticalWindowBuckets().get());
+    }
+
+
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return counter.getCumulativeSum(event);
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return counter.getRollingSum(event);
+    }
+
+    @Override
+    protected void addEvent(HystrixRollingNumberEvent event) {
+        counter.increment(event);
+    }
+
+    @Override
+    protected void addEventWithValue(HystrixRollingNumberEvent event, long value) {
+        counter.add(event, value);
+    }
+
+    @Override
+    protected void updateRollingMax(HystrixRollingNumberEvent event, long value) {
+        counter.updateRollingMax(event, value);
+    }
+
+    @Override
+    protected long getRollingMax(HystrixRollingNumberEvent event) {
+        return counter.getRollingMaxValue(event);
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/noop/HystrixCollapserMetricsNoOp.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/noop/HystrixCollapserMetricsNoOp.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.metrics.noop;
+
+import com.netflix.hystrix.HystrixCollapserKey;
+import com.netflix.hystrix.HystrixCollapserMetrics;
+import com.netflix.hystrix.HystrixCollapserProperties;
+import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+
+/**
+ * Not needed for health check - so it's fine to just drop all collapser metrics on the floor if you're not interested in them
+ */
+public class HystrixCollapserMetricsNoOp extends HystrixCollapserMetrics {
+
+    HystrixCollapserMetricsNoOp(HystrixCollapserKey key, HystrixCollapserProperties properties) {
+        super(key, properties);
+    }
+
+    @Override
+    public int getBatchSizePercentile(double percentile) {
+        return 0;
+    }
+
+    @Override
+    public int getBatchSizeMean() {
+        return 0;
+    }
+
+    @Override
+    protected void addBatchSize(int batchSize) {
+
+    }
+
+    @Override
+    public int getShardSizePercentile(double percentile) {
+        return 0;
+    }
+
+    @Override
+    public int getShardSizeMean() {
+        return 0;
+    }
+
+    @Override
+    protected void addShardSize(int shardSize) {
+
+    }
+
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return 0;
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return 0;
+    }
+
+    @Override
+    public long getRollingMax(HystrixRollingNumberEvent event) {
+        return 0;
+    }
+
+    @Override
+    protected void addEvent(HystrixRollingNumberEvent event) {
+
+    }
+
+    @Override
+    protected void addEventWithValue(HystrixRollingNumberEvent event, long value) {
+
+    }
+
+    @Override
+    protected void updateRollingMax(HystrixRollingNumberEvent event, long value) {
+
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/noop/HystrixCommandMetricsCountsOnly.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/noop/HystrixCommandMetricsCountsOnly.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.metrics.noop;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandMetrics;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+import com.netflix.hystrix.util.HystrixRollingNumber;
+import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+
+/**
+ * We need to track counts accurately to properly calculate circuit health.  We can ignore latency, though
+ */
+public class HystrixCommandMetricsCountsOnly extends HystrixCommandMetrics {
+
+    private final HystrixRollingNumber counter;
+
+    public HystrixCommandMetricsCountsOnly(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey threadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier) {
+        super(key, commandGroup, threadPoolKey, properties, eventNotifier);
+        this.counter = new HystrixRollingNumber(properties.metricsRollingStatisticalWindowInMilliseconds().get(), properties.metricsRollingStatisticalWindowBuckets().get());
+    }
+
+    /**
+     * COUNT measurements that must be implemented
+     */
+
+
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return counter.getCumulativeSum(event);
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return counter.getRollingSum(event);
+    }
+
+    @Override
+    public long getRollingMax(HystrixRollingNumberEvent event) {
+        return counter.getRollingMaxValue(event);
+    }
+
+    @Override
+    protected void addEvent(HystrixRollingNumberEvent event) {
+        counter.increment(event);
+    }
+
+    @Override
+    protected void addEventWithValue(HystrixRollingNumberEvent event, long value) {
+        counter.add(event, value);
+    }
+
+    @Override
+    protected void updateRollingMax(HystrixRollingNumberEvent event, long value) {
+        counter.updateRollingMax(event, value);
+    }
+
+    @Override
+    protected void clear() {
+        counter.reset();
+    }
+
+    /**
+     * LATENCY measurements that may be ignored
+     */
+
+    @Override
+    public int getExecutionTimePercentile(double percentile) {
+        return 0;
+    }
+
+    @Override
+    public int getExecutionTimeMean() {
+        return 0;
+    }
+
+    @Override
+    public int getTotalTimePercentile(double percentile) {
+        return 0;
+    }
+
+    @Override
+    public int getTotalTimeMean() {
+        return 0;
+    }
+
+    @Override
+    protected void addCommandExecutionTime(long duration) {
+
+    }
+
+    @Override
+    protected void addUserThreadExecutionTime(long duration) {
+
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/noop/HystrixMetricsCollectionMinimal.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/noop/HystrixMetricsCollectionMinimal.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.metrics.noop;
+
+import com.netflix.hystrix.HystrixCollapserKey;
+import com.netflix.hystrix.HystrixCollapserMetrics;
+import com.netflix.hystrix.HystrixCollapserProperties;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandMetrics;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolMetrics;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsCollection;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class HystrixMetricsCollectionMinimal extends HystrixMetricsCollection {
+
+    @Override
+    public HystrixCommandMetrics getCommandMetricsInstance(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixThreadPoolKey threadPoolKey, HystrixCommandProperties properties, HystrixEventNotifier eventNotifier) {
+        return new HystrixCommandMetricsCountsOnly(key, commandGroup, threadPoolKey, properties, eventNotifier);
+    }
+
+    @Override
+    public HystrixThreadPoolMetrics getThreadPoolMetricsInstance(HystrixThreadPoolKey key, ThreadPoolExecutor threadPool, HystrixThreadPoolProperties properties) {
+        return new HystrixThreadPoolMetricsNoOp(key, threadPool, properties);
+    }
+
+    @Override
+    public HystrixCollapserMetrics getCollapserMetricsInstance(HystrixCollapserKey key, HystrixCollapserProperties properties) {
+        return new HystrixCollapserMetricsNoOp(key, properties);
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/noop/HystrixThreadPoolMetricsNoOp.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/noop/HystrixThreadPoolMetricsNoOp.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.metrics.noop;
+
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolMetrics;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Thread pool metrics not used in health checks, so these may be dropped on the floor if you're not interested in them
+ */
+public class HystrixThreadPoolMetricsNoOp extends HystrixThreadPoolMetrics {
+
+    public HystrixThreadPoolMetricsNoOp(HystrixThreadPoolKey key, ThreadPoolExecutor threadPool, HystrixThreadPoolProperties properties) {
+        super(key, threadPool, properties);
+    }
+
+    @Override
+    public long getCumulativeCount(HystrixRollingNumberEvent event) {
+        return 0;
+    }
+
+    @Override
+    public long getRollingCount(HystrixRollingNumberEvent event) {
+        return 0;
+    }
+
+    @Override
+    public long getRollingMax(HystrixRollingNumberEvent event) {
+        return 0;
+    }
+
+    @Override
+    protected void addEvent(HystrixRollingNumberEvent event) {
+
+    }
+
+    @Override
+    protected void addEventWithValue(HystrixRollingNumberEvent event, long value) {
+
+    }
+
+    @Override
+    protected void updateRollingMax(HystrixRollingNumberEvent event, long value) {
+
+    }
+}

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Random;
 
+import com.netflix.hystrix.strategy.metrics.HystrixCommandMetricsSummary;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
@@ -494,7 +494,7 @@ public class HystrixCircuitBreakerTest {
      * Utility method for creating {@link HystrixCommandMetrics} for unit tests.
      */
     private static HystrixCommandMetrics getMetrics(HystrixCommandProperties.Setter properties) {
-        return new HystrixCommandMetrics(CommandKeyForUnitTest.KEY_ONE, CommandOwnerForUnitTest.OWNER_ONE, ThreadPoolKeyForUnitTest.THREAD_POOL_ONE, HystrixCommandPropertiesTest.asMock(properties), HystrixEventNotifierDefault.getInstance());
+        return new HystrixCommandMetricsSummary(CommandKeyForUnitTest.KEY_ONE, CommandOwnerForUnitTest.OWNER_ONE, ThreadPoolKeyForUnitTest.THREAD_POOL_ONE, HystrixCommandPropertiesTest.asMock(properties), HystrixEventNotifierDefault.getInstance());
     }
 
     /**

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandMetricsTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandMetricsTest.java
@@ -18,6 +18,7 @@ package com.netflix.hystrix;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import com.netflix.hystrix.strategy.metrics.HystrixCommandMetricsSummary;
 import org.junit.Test;
 
 import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifierDefault;

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandMetricsTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandMetricsTest.java
@@ -129,7 +129,7 @@ public class HystrixCommandMetricsTest {
      * Utility method for creating {@link HystrixCommandMetrics} for unit tests.
      */
     private static HystrixCommandMetrics getMetrics(HystrixCommandProperties.Setter properties) {
-        return new HystrixCommandMetrics(InspectableBuilder.CommandKeyForUnitTest.KEY_ONE, InspectableBuilder.CommandGroupForUnitTest.OWNER_ONE, InspectableBuilder.ThreadPoolKeyForUnitTest.THREAD_POOL_ONE, HystrixCommandPropertiesTest.asMock(properties), HystrixEventNotifierDefault.getInstance());
+        return new HystrixCommandMetricsSummary(InspectableBuilder.CommandKeyForUnitTest.KEY_ONE, InspectableBuilder.CommandGroupForUnitTest.OWNER_ONE, InspectableBuilder.ThreadPoolKeyForUnitTest.THREAD_POOL_ONE, HystrixCommandPropertiesTest.asMock(properties), HystrixEventNotifierDefault.getInstance());
     }
 
 }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolMetricsTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolMetricsTest.java
@@ -22,21 +22,6 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * Copyright 2013 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 public class HystrixThreadPoolMetricsTest {
 
 	@Before


### PR DESCRIPTION
This addresses the concern of #333.  This PR is intended to be a PoC to demonstrate that there can be varying implementations of metric collection (command/thread pool/collapser).  The version which summarizes via HystrixRollingNumber/HystrixRollingPercentile is one such concrete implementation.

This PR is not ready for merging - I still would like to:
* Clean up the Javadoc
* Add Wiki documentation around the new plugin
* Add no-op metrics strategies to evaluate perf impact
* Make sure I didn't impact any public methods
* Convince myself that new abstract methods are the proper set for concrete impls

If anyone has feedback along those lines, it would be appreciated.