### PR TITLE
Fix generated arglists

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
+++ b/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
@@ -410,7 +410,7 @@
         group-key           (str *ns*)
         [m [params & body]] (split-def-meta opts)
         m                   (if-not (contains? m :arglists)
-                              (assoc m :arglists `(list (quote ~params)))
+                              (assoc m :arglists (list 'quote `(~params)))
                               m)]
     `(let [meta-options# (#'com.netflix.hystrix.core/extract-hystrix-command-options ~m)
            run-fn#       (fn ~name ~params ~@body)


### PR DESCRIPTION
This is a fix for issue #831 (https://github.com/Netflix/Hystrix/issues/831) which
is a blocker for http://dev.clojure.org/jira/browse/CLJ-1232. Instead of generating
:arglists as (list (quote [..])*), generate (quote ([..]*)). Tests still
pass and (doc command) works as intended. I have not directly tested
this with Clojure patched with CLJ-1232.