### PR TITLE
Merge fix 851

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
+++ b/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
@@ -413,7 +413,7 @@
                               (list (first body))
                               (map first body))
         m                   (if-not (contains? m :arglists)
-                              (assoc m :arglists (list 'quote `(~params)))
+                              (assoc m :arglists ('quote `(~params)))
                               m)]
     `(let [meta-options# (#'com.netflix.hystrix.core/extract-hystrix-command-options ~m)
            run-fn#       (fn ~name ~@body)


### PR DESCRIPTION
From @daveray:

This is a fix for issue #831 (https://github.com/Netflix/Hystrix/issues/831) which
is a blocker for http://dev.clojure.org/jira/browse/CLJ-1232. Instead of generating
:arglists as (list (quote [..])*), generate (quote ([..]*)). Tests still
pass and (doc command) works as intended. I have not directly tested
this with Clojure patched with CLJ-1232.