### PR TITLE
Allow multiple values per request-arg in a HystrixObservableCollapser

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapser.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapser.java
@@ -507,14 +507,16 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
          * This corresponds in a OnNext(Response); OnCompleted pair of emissions.  It represents a single-value usecase.
          *
          * @throws IllegalStateException
-         *             if called more than once or after setException.
+         *             if called more than once or after setException/setComplete.
          * @param response
          *            ResponseType
          */
         public void setResponse(ResponseType response);
 
         /**
-         * When invoked, any Observer will be OnNExted this value
+         * When invoked, any Observer will be OnNexted this value
+         * @throws IllegalStateException
+         *             if called after setException/setResponse/setComplete.
          * @param response
          */
         public void emitResponse(ResponseType response);
@@ -524,12 +526,16 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
          * 
          * @param exception exception to set on response
          * @throws IllegalStateException
-         *             if called more than once or after setResponse.
+         *             if called more than once or after setResponse/setComplete.
          */
         public void setException(Exception exception);
 
         /**
-         * When set, any Observer will have an OnCompleted emitted
+         * When set, any Observer will have an OnCompleted emitted.
+         * The intent is to use if after a series of emitResponses
+         *
+         * Note that, unlike the other 3 methods above, this method does not throw an IllegalStateException.
+         * This allows Hystrix-core to unilaterally call it without knowing the internal state.
          */
         public void setComplete();
     }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixObservableCollapser.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixObservableCollapser.java
@@ -18,7 +18,9 @@ package com.netflix.hystrix;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisherFactory;
@@ -29,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Scheduler;
 import rx.functions.Action0;
+import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 import rx.subjects.ReplaySubject;
@@ -171,32 +174,33 @@ public abstract class HystrixObservableCollapser<K, BatchReturnType, ResponseTyp
                 // index the requests by key
                 final Map<K, CollapsedRequest<ResponseType, RequestArgumentType>> requestsByKey = new HashMap<K, CollapsedRequest<ResponseType, RequestArgumentType>>(requests.size());
                 for (CollapsedRequest<ResponseType, RequestArgumentType> cr : requests) {
-                    requestsByKey.put(requestKeySelector.call(cr.getArgument()), cr);
+                    K requestArg = requestKeySelector.call(cr.getArgument());
+                    requestsByKey.put(requestArg, cr);
                 }
+                final Set<K> seenKeys = new HashSet<K>();
 
                 // observe the responses and join with the requests by key
-                return batchResponse.flatMap(new Func1<BatchReturnType, Observable<Void>>() {
-
+                return batchResponse.doOnNext(new Action1<BatchReturnType>() {
                     @Override
-                    public Observable<Void> call(BatchReturnType r) {
-                        K responseKey = batchResponseKeySelector.call(r);
+                    public void call(BatchReturnType batchReturnType) {
+                        K responseKey = batchResponseKeySelector.call(batchReturnType);
                         CollapsedRequest<ResponseType, RequestArgumentType> requestForResponse = requestsByKey.get(responseKey);
-                        requestForResponse.setResponse(mapBatchTypeToResponseType.call(r));
-                        // now remove from map so we know what wasn't set at end
-                        requestsByKey.remove(responseKey);
-                        return Observable.empty();
+                        requestForResponse.emitResponse(mapBatchTypeToResponseType.call(batchReturnType));
+                        // now add this to seenKeys, so we can later check what was seen, and what was unseen
+                        seenKeys.add(responseKey);
                     }
-
                 }).doOnTerminate(new Action0() {
-
                     @Override
                     public void call() {
-                        for (CollapsedRequest<ResponseType, RequestArgumentType> cr : requestsByKey.values()) {
-                            onMissingResponse(cr);
+                        for (K key : requestsByKey.keySet()) {
+                            CollapsedRequest<ResponseType, RequestArgumentType> collapsedRequest = requestsByKey.get(key);
+                            if (!seenKeys.contains(key)) {
+                                onMissingResponse(collapsedRequest);
+                            }
+                            collapsedRequest.setComplete();
                         }
                     }
-
-                });
+                }).ignoreElements().cast(Void.class);
             }
 
             @Override

--- a/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestObservableFunction.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestObservableFunction.java
@@ -15,17 +15,24 @@
  */
 package com.netflix.hystrix.collapser;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import rx.Observable.OnSubscribe;
-import rx.Observer;
 import rx.Subscriber;
-import rx.subscriptions.BooleanSubscription;
+import rx.subjects.ReplaySubject;
+import rx.subjects.Subject;
 
 import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
 
 /**
- * The Observable that represents a collapsed request sent back to a user.
+ * The Observable that represents a collapsed request sent back to a user.  It gets used by Collapser implementations
+ * when receiving a batch response and emitting values/errors to collapsers.
+ *
+ * There are 4 methods that Collapser implementations may use:
+ *
+ * 1) {@link #setResponse(T)}: return a single-valued response.  equivalent to OnNext(T), OnCompleted()
+ * 2) {@link #emitResponse(T)}: emit a single value.  equivalent to OnNext(T)
+ * 3) {@link #setException(Exception)}: return an exception.  equivalent to OnError(Excception)
+ * 4) {@link #setComplete()}: mark that no more values will be emitted.  Should be used in conjunction with {@link #emitResponse(T)}.  equivalent to OnCompleted()
+ *
  * <p>
  * This is an internal implementation class that combines the Observable<T> and CollapsedRequest<T, R> functionality.
  * <p>
@@ -37,11 +44,20 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
  */
 /* package */class CollapsedRequestObservableFunction<T, R> implements CollapsedRequest<T, R>, OnSubscribe<T> {
     private final R argument;
-    private final AtomicReference<CollapsedRequestObservableFunction.ResponseHolder<T>> rh = new AtomicReference<ResponseHolder<T>>(new CollapsedRequestObservableFunction.ResponseHolder<T>());
-    private final BooleanSubscription subscription = new BooleanSubscription();
+    private final Subject<T, T> responseSubject = ReplaySubject.create();
 
     public CollapsedRequestObservableFunction(R arg) {
         this.argument = arg;
+    }
+
+    /**
+     * This is a passthrough that allows a Subscriber to receive values from the Subject that collapsers are writing values/errors into
+     * The one interesting bit is that they may do so in a completely unbounded way.  There's no way to express
+     * backpressure currently that makes sense other than to buffer this stream and allow it to grow unboundedly
+     */
+    @Override
+    public void call(Subscriber<? super T> observer) {
+        responseSubject.onBackpressureBuffer().subscribe(observer);
     }
 
     /**
@@ -55,7 +71,7 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
     }
 
     /**
-     * When set any client thread blocking on get() will immediately be unblocked and receive the response.
+     * When set any client thread blocking on get() will immediately be unblocked and receive the single-valued response.
      * 
      * @throws IllegalStateException
      *             if called more than once or after setException.
@@ -63,26 +79,33 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
      */
     @Override
     public void setResponse(T response) {
-        while (true) {
-            ResponseHolder<T> r = rh.get();
-            if (r.isResponseSet()) {
-                throw new IllegalStateException("setResponse can only be called once");
-            }
-            if (r.getException() != null) {
-                throw new IllegalStateException("Exception is already set so response can not be => Response: " + response + " subscription: " + subscription.isUnsubscribed() + "  observer: " + r.getObserver() + "  Exception: " + r.getException().getMessage(), r.getException());
-            }
+        if (!responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+            responseSubject.onNext(response);
+            responseSubject.onCompleted();
+        } else {
+            throw new IllegalStateException("Response has already terminated so response can not be set : " + response);
+        }
+    }
 
-            if (subscription.isUnsubscribed()) {
-                return;
-            }
-            ResponseHolder<T> nr = r.setResponse(response);
-            if (rh.compareAndSet(r, nr)) {
-                // success
-                sendResponseIfRequired(subscription, nr);
-                break;
-            } else {
-                // we'll retry
-            }
+    /**
+     * Emit a response that should be OnNexted to an Observer
+     * @param response response to emit to initial command
+     */
+    @Override
+    public void emitResponse(T response) {
+        if (!responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+            responseSubject.onNext(response);
+        } else {
+            throw new IllegalStateException("Response has already terminated so value can not be emitted : " + response);
+        }
+    }
+
+    @Override
+    public void setComplete() {
+        if (!responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+            responseSubject.onCompleted();
+        } else {
+            throw new IllegalStateException("Response has already terminated so completion can not be set");
         }
     }
 
@@ -92,25 +115,8 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
      * @param e synthetic error to set on initial command when no actual response is available
      */
     public void setExceptionIfResponseNotReceived(Exception e) {
-        while (true) {
-            if (subscription.isUnsubscribed()) {
-                return;
-            }
-            CollapsedRequestObservableFunction.ResponseHolder<T> r = rh.get();
-            // only proceed if neither response is set
-            if (!r.isResponseSet() && r.getException() == null) {
-                ResponseHolder<T> nr = r.setException(e);
-                if (rh.compareAndSet(r, nr)) {
-                    // success
-                    sendResponseIfRequired(subscription, nr);
-                    break;
-                } else {
-                    // we'll retry
-                }
-            } else {
-                // return quietly instead of throwing an exception
-                break;
-            }
+        if (!responseSubject.hasValue() && !responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+            responseSubject.onError(e);
         }
     }
 
@@ -122,10 +128,9 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
      */
     public Exception setExceptionIfResponseNotReceived(Exception e, String exceptionMessage) {
         Exception exception = e;
-        CollapsedRequestObservableFunction.ResponseHolder<T> r = rh.get();
-        // only proceed if neither response is set
-        if (!r.isResponseSet() && r.getException() == null) {
-            if(e == null) {
+
+        if (!responseSubject.hasValue() && !responseSubject.hasThrowable()) {
+            if (e == null) {
                 exception = new IllegalStateException(exceptionMessage);
             }
             setExceptionIfResponseNotReceived(exception);
@@ -143,118 +148,10 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
      */
     @Override
     public void setException(Exception e) {
-        while (true) {
-            CollapsedRequestObservableFunction.ResponseHolder<T> r = rh.get();
-            if (r.getException() != null) {
-                throw new IllegalStateException("setException can only be called once");
-            }
-            if (r.isResponseSet()) {
-                throw new IllegalStateException("Response is already set so exception can not be => Response: " + r.getResponse() + "  Exception: " + e.getMessage(), e);
-            }
-
-            if (subscription.isUnsubscribed()) {
-                return;
-            }
-            ResponseHolder<T> nr = r.setException(e);
-            if (rh.compareAndSet(r, nr)) {
-                // success
-                sendResponseIfRequired(subscription, nr);
-                break;
-            } else {
-                // we'll retry
-            }
+        if (!responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+            responseSubject.onError(e);
+        } else {
+            throw new IllegalStateException("Response has already terminated so exception can not be set", e);
         }
     }
-
-    @Override
-    public void call(Subscriber<? super T> observer) {
-        observer.add(subscription);
-        while (true) {
-            CollapsedRequestObservableFunction.ResponseHolder<T> r = rh.get();
-            if (r.getObserver() != null) {
-                throw new IllegalStateException("Only 1 Observer can subscribe. Use multicast/publish/cache/etc for multiple subscribers.");
-            }
-            ResponseHolder<T> nr = r.setObserver(observer);
-            if (rh.compareAndSet(r, nr)) {
-                // success
-                sendResponseIfRequired(subscription, nr);
-                break;
-            } else {
-                // we'll retry
-            }
-        }
-    }
-
-    private static <T> void sendResponseIfRequired(BooleanSubscription subscription, CollapsedRequestObservableFunction.ResponseHolder<T> r) {
-        if (!subscription.isUnsubscribed()) {
-            Observer<? super T> o = r.getObserver();
-            if (o == null || (r.getException() == null && !r.isResponseSet())) {
-                // not ready to send
-                return;
-            }
-
-            if (r.getException() != null) {
-                o.onError(r.getException());
-            } else {
-                o.onNext(r.getResponse());
-                o.onCompleted();
-            }
-        }
-    }
-
-    /**
-     * Used for atomic compound updates.
-     */
-    private static class ResponseHolder<T> {
-        // I'm using AtomicReference as if it's an Option monad instead of creating yet another object
-        // so I know if 'response' is null versus the value set being null so I can tell if a response is set
-        // even if the value set is null
-        private final AtomicReference<T> r;
-        private final Exception e;
-        private final Observer<? super T> o;
-
-        public ResponseHolder() {
-            this(null, null, null);
-        }
-
-        private ResponseHolder(AtomicReference<T> response, Exception exception, Observer<? super T> observer) {
-            this.o = observer;
-            this.r = response;
-            this.e = exception;
-        }
-
-        public ResponseHolder<T> setResponse(T response) {
-            return new ResponseHolder<T>(new AtomicReference<T>(response), e, o);
-        }
-
-        public ResponseHolder<T> setObserver(Observer<? super T> observer) {
-            return new ResponseHolder<T>(r, e, observer);
-        }
-
-        public ResponseHolder<T> setException(Exception exception) {
-            return new ResponseHolder<T>(r, exception, o);
-        }
-
-        public Observer<? super T> getObserver() {
-            return o;
-        }
-
-        public T getResponse() {
-            if (r == null) {
-                return null;
-            } else {
-                return r.get();
-            }
-        }
-
-        public boolean isResponseSet() {
-            return r != null;
-        }
-
-        public Exception getException() {
-            return e;
-        }
-
-    }
-
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestObservableFunction.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestObservableFunction.java
@@ -79,7 +79,7 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
      */
     @Override
     public void setResponse(T response) {
-        if (!responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+        if (!isTerminal()) {
             responseSubject.onNext(response);
             responseSubject.onCompleted();
         } else {
@@ -93,19 +93,15 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
      */
     @Override
     public void emitResponse(T response) {
-        if (!responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+        if (!isTerminal()) {
             responseSubject.onNext(response);
-        } else {
-            throw new IllegalStateException("Response has already terminated so value can not be emitted : " + response);
         }
     }
 
     @Override
     public void setComplete() {
-        if (!responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+        if (!isTerminal()) {
             responseSubject.onCompleted();
-        } else {
-            throw new IllegalStateException("Response has already terminated so completion can not be set");
         }
     }
 
@@ -115,7 +111,7 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
      * @param e synthetic error to set on initial command when no actual response is available
      */
     public void setExceptionIfResponseNotReceived(Exception e) {
-        if (!responseSubject.hasValue() && !responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+        if (!responseSubject.hasValue() && !isTerminal()) {
             responseSubject.onError(e);
         }
     }
@@ -148,10 +144,14 @@ import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
      */
     @Override
     public void setException(Exception e) {
-        if (!responseSubject.hasCompleted() && !responseSubject.hasThrowable()) {
+        if (!isTerminal()) {
             responseSubject.onError(e);
         } else {
             throw new IllegalStateException("Response has already terminated so exception can not be set", e);
         }
+    }
+
+    private boolean isTerminal() {
+        return (responseSubject.hasCompleted() || responseSubject.hasThrowable());
     }
 }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCollapserTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCollapserTest.java
@@ -18,9 +18,13 @@ package com.netflix.hystrix;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.netflix.hystrix.strategy.properties.HystrixPropertiesCollapserDefault;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
@@ -79,12 +83,69 @@ public class HystrixObservableCollapserTest {
     }
 
     @Test
-    public void stressTestRequestCollapser() throws Exception {
-        for(int i = 0; i < 100; i++) {
-            init();
-            testTwoRequests();
-            cleanup();
-        }
+    public void testTwoRequestsWhichShouldEachEmitTwice() throws Exception {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2);
+
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+
+        final AtomicInteger countOnNexts1 = new AtomicInteger(0);
+        final AtomicInteger countOnNexts2 = new AtomicInteger(0);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        result1.subscribe(new Subscriber<String>() {
+            @Override
+            public void onCompleted() {
+                System.out.println(Thread.currentThread().getName() + " : " + System.currentTimeMillis() + " 1 OnCompleted");
+                latch1.countDown();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                System.out.println(Thread.currentThread().getName() + " : " + System.currentTimeMillis() + " 1 OnError : " + e);
+                e.printStackTrace();
+                latch1.countDown();
+            }
+
+            @Override
+            public void onNext(String s) {
+                System.out.println(Thread.currentThread().getName() + " : " + System.currentTimeMillis() + " 1 OnNext : " + s);
+                countOnNexts1.getAndIncrement();
+            }
+        });
+
+        result2.subscribe(new Subscriber<String>() {
+            @Override
+            public void onCompleted() {
+                System.out.println(Thread.currentThread().getName() + " : " + System.currentTimeMillis() + " 2 OnCompleted");
+                latch2.countDown();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                System.out.println(Thread.currentThread().getName() + " : " + System.currentTimeMillis() + " 2 OnError : " + e);
+                latch2.countDown();
+            }
+
+            @Override
+            public void onNext(String s) {
+                System.out.println(Thread.currentThread().getName() + " : " + System.currentTimeMillis() + " 2 OnNext : " + s);
+                countOnNexts2.incrementAndGet();
+            }
+        });
+
+        latch1.await();
+        latch2.await();
+
+        assertEquals(3, countOnNexts1.get());
+        assertEquals(3, countOnNexts2.get());
     }
 
     private static class TestRequestCollapser extends HystrixObservableCollapser<String, String, String, String> {
@@ -239,5 +300,112 @@ public class HystrixObservableCollapserTest {
             }).subscribeOn(Schedulers.computation());
         }
 
+    }
+
+    private static class TestCollapserWithMultipleResponses extends HystrixObservableCollapser<String, String, String, String> {
+
+        private final String value;
+
+        public TestCollapserWithMultipleResponses(TestCollapserTimer timer, int i) {
+            super(collapserKeyFromString(timer), Scope.REQUEST, timer, HystrixCollapserProperties.Setter().withMaxRequestsInBatch(10).withTimerDelayInMilliseconds(10), createMetrics());
+            this.value = i + "";
+        }
+
+        private static HystrixCollapserMetrics createMetrics() {
+            HystrixCollapserKey key = HystrixCollapserKey.Factory.asKey("COLLAPSER_MULTI");
+            return HystrixCollapserMetrics.getInstance(key, new HystrixPropertiesCollapserDefault(key, HystrixCollapserProperties.Setter()));
+        }
+
+        @Override
+        public String getRequestArgument() {
+            return value;
+        }
+
+        @Override
+        protected HystrixObservableCommand<String> createCommand(Collection<CollapsedRequest<String, String>> collapsedRequests) {
+            List<Integer> args = new ArrayList<Integer>();
+
+            for (CollapsedRequest<String, String> collapsedRequest: collapsedRequests) {
+                String stringArg = collapsedRequest.getArgument();
+                int intArg = Integer.parseInt(stringArg);
+                args.add(intArg);
+            }
+
+            return new TestCollapserCommandWithMultipleResponsePerArgument(args);
+        }
+
+        //Data comes back in the form: 1:1, 1:2, 1:3, 2:2, 2:4, 2:6.
+        //This method should use the first half of that string as the request arg
+        @Override
+        protected Func1<String, String> getBatchReturnTypeKeySelector() {
+            return new Func1<String, String>() {
+
+                @Override
+                public String call(String s) {
+                    return s.substring(0, s.indexOf(":"));
+                }
+
+            };
+        }
+
+        @Override
+        protected Func1<String, String> getRequestArgumentKeySelector() {
+            return new Func1<String, String>() {
+
+                @Override
+                public String call(String s) {
+                    return s;
+                }
+
+            };
+        }
+
+        @Override
+        protected void onMissingResponse(CollapsedRequest<String, String> r) {
+
+        }
+
+        @Override
+        protected Func1<String, String> getBatchReturnTypeToResponseTypeMapper() {
+            return new Func1<String, String>() {
+
+                @Override
+                public String call(String s) {
+                    return s;
+                }
+
+            };
+        }
+    }
+
+    private static class TestCollapserCommandWithMultipleResponsePerArgument extends TestHystrixObservableCommand<String> {
+
+        private final List<Integer> args;
+
+        TestCollapserCommandWithMultipleResponsePerArgument(List<Integer> args) {
+            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(500)));
+            this.args = args;
+        }
+
+        @Override
+        protected Observable<String> construct() {
+            return Observable.create(new OnSubscribe<String>() {
+                @Override
+                public void call(Subscriber<? super String> subscriber) {
+                    try {
+                        Thread.sleep(100);
+                        for (int arg : args) {
+                            subscriber.onNext(arg + ":" + arg);
+                            subscriber.onNext(arg + ":" + (arg * 2));
+                            subscriber.onNext(arg + ":" + (arg * 3));
+                            Thread.sleep(10);
+                        }
+                    } catch (Throwable ex) {
+                        subscriber.onError(ex);
+                    }
+                    subscriber.onCompleted();
+                }
+            }).subscribeOn(Schedulers.computation());
+        }
     }
 }


### PR DESCRIPTION
Addresses #865

I'm not ready to merge this yet, but wanted a few eyes on the general approach. 
/cc @benjchristensen 

Prior to this fix, there was a single-valued ResponseHolder object that prevented multiple values from being emitted per-request argument.  Now the stream of values is directly represented as a Subject, which may be subscribed to.

Within CollapsedRequestObservableFunction, the semantics of `setResponse` may not change, as this is used in user-defined HystrixCollapsers already.  Therefore, I was forced to add `emitResponse` and `setComplete` methods to allow multiple values to flow through.  These names will be public, so any thoughts on naming would be helpful.

Before I merge, I'll beef up test coverage on this class to include tests for :
* Error in ObservableCommand
* Error in mapping response to request-args
* Empty overall response
* Empty response for specific request-args