### PR TITLE
Multiple responses per collapser arg

### DIFF
--- a/hystrix-core/src/jmh/java/com/netflix/hystrix/perf/ObservableCollapserPerfTest.java
+++ b/hystrix-core/src/jmh/java/com/netflix/hystrix/perf/ObservableCollapserPerfTest.java
@@ -61,7 +61,7 @@ public class ObservableCollapserPerfTest {
         @Param({"1", "10", "100", "1000"})
         int numToCollapse;
 
-        @Param({"1"}) //until bugfix for https://github.com/Netflix/Hystrix/issues/865, 1 is only value that works as expected
+        @Param({"1", "10", "100"})
         int numResponsesPerArg;
 
         @Param({"1", "1000", "1000000"})

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapser.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapser.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import rx.Observable;
 import rx.Scheduler;
-import rx.functions.Func1;
+import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 import rx.subjects.ReplaySubject;
 
@@ -163,16 +163,13 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
 
             @Override
             public Observable<Void> mapResponseToRequests(Observable<BatchReturnType> batchResponse, final Collection<CollapsedRequest<ResponseType, RequestArgumentType>> requests) {
-                return batchResponse.single().flatMap(new Func1<BatchReturnType, Observable<Void>>() {
-
+                return batchResponse.single().doOnNext(new Action1<BatchReturnType>() {
                     @Override
-                    public Observable<Void> call(BatchReturnType response) {
+                    public void call(BatchReturnType batchReturnType) {
                         // this is a blocking call in HystrixCollapser
-                        self.mapResponseToRequests(response, requests);
-                        return Observable.empty();
+                        self.mapResponseToRequests(batchReturnType, requests);
                     }
-
-                });
+                }).ignoreElements().cast(Void.class);
             }
 
             @Override
@@ -509,23 +506,40 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
         public RequestArgumentType getArgument();
 
         /**
-         * When set any client thread blocking on get() will immediately be unblocked and receive the response.
-         * 
+         * This corresponds in a OnNext(Response); OnCompleted pair of emissions.  It represents a single-value usecase.
+         *
          * @throws IllegalStateException
-         *             if called more than once or after setException.
+         *             if called more than once or after setException/setComplete.
          * @param response
          *            ResponseType
          */
         public void setResponse(ResponseType response);
 
         /**
-         * When set any client thread blocking on get() will immediately be unblocked and receive the exception.
+         * When invoked, any Observer will be OnNexted this value
+         * @throws IllegalStateException
+         *             if called after setException/setResponse/setComplete.
+         * @param response
+         */
+        public void emitResponse(ResponseType response);
+
+        /**
+         * When set, any Observer will be OnErrored this exception
          * 
          * @param exception exception to set on response
          * @throws IllegalStateException
-         *             if called more than once or after setResponse.
+         *             if called more than once or after setResponse/setComplete.
          */
         public void setException(Exception exception);
+
+        /**
+         * When set, any Observer will have an OnCompleted emitted.
+         * The intent is to use if after a series of emitResponses
+         *
+         * Note that, unlike the other 3 methods above, this method does not throw an IllegalStateException.
+         * This allows Hystrix-core to unilaterally call it without knowing the internal state.
+         */
+        public void setComplete();
     }
 
     /**

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCollapserTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCollapserTest.java
@@ -18,9 +18,15 @@ package com.netflix.hystrix;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.netflix.hystrix.strategy.properties.HystrixPropertiesCollapserDefault;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
@@ -31,7 +37,9 @@ import org.junit.Test;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
+import rx.functions.Action1;
 import rx.functions.Func1;
+import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 
 import com.netflix.hystrix.HystrixCollapser.CollapsedRequest;
@@ -39,6 +47,74 @@ import com.netflix.hystrix.HystrixCollapserTest.TestCollapserTimer;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 
 public class HystrixObservableCollapserTest {
+    private static Action1<CollapsedRequest<String, String>> onMissingError = new Action1<CollapsedRequest<String, String>>() {
+        @Override
+        public void call(CollapsedRequest<String, String> collapsedReq) {
+            collapsedReq.setException(new IllegalStateException("must have a value"));
+        }
+    };
+
+     private static Action1<CollapsedRequest<String, String>> onMissingThrow = new Action1<CollapsedRequest<String, String>>() {
+         @Override
+         public void call(CollapsedRequest<String, String> collapsedReq) {
+            throw new RuntimeException("synchronous error in onMissingResponse handler");
+         }
+     };
+
+    private static Action1<CollapsedRequest<String, String>> onMissingComplete = new Action1<CollapsedRequest<String, String>>() {
+        @Override
+        public void call(CollapsedRequest<String, String> collapsedReq) {
+            collapsedReq.setComplete();
+        }
+    };
+
+    private static Action1<CollapsedRequest<String, String>> onMissingIgnore = new Action1<CollapsedRequest<String, String>>() {
+        @Override
+        public void call(CollapsedRequest<String, String> collapsedReq) {
+            //do nothing
+        }
+    };
+
+    private static Action1<CollapsedRequest<String, String>> onMissingFillIn = new Action1<CollapsedRequest<String, String>>() {
+        @Override
+        public void call(CollapsedRequest<String, String> collapsedReq) {
+            collapsedReq.setResponse("fillin");
+        }
+    };
+
+    private static Func1<String, String> prefixMapper = new Func1<String, String>() {
+
+        @Override
+        public String call(String s) {
+            return s.substring(0, s.indexOf(":"));
+        }
+
+    };
+
+    private static Func1<String, String> map1To3And2To2 = new Func1<String, String>() {
+        @Override
+        public String call(String s) {
+            String prefix = s.substring(0, s.indexOf(":"));
+            if (prefix.equals("2")) {
+                return "2";
+            } else {
+                return "3";
+            }
+        }
+    };
+
+    private static Func1<String, String> mapWithErrorOn1 = new Func1<String, String>() {
+        @Override
+        public String call(String s) {
+            String prefix = s.substring(0, s.indexOf(":"));
+            if (prefix.equals("1")) {
+                throw new RuntimeException("poorly implemented demultiplexer");
+            } else {
+                return "2";
+            }
+        }
+    };
+
     @Before
     public void init() {
         // since we're going to modify properties of the same class between tests, wipe the cache each time
@@ -79,12 +155,399 @@ public class HystrixObservableCollapserTest {
     }
 
     @Test
-    public void stressTestRequestCollapser() throws Exception {
-        for(int i = 0; i < 100; i++) {
-            init();
-            testTwoRequests();
-            cleanup();
-        }
+    public void testTwoRequestsWhichShouldEachEmitTwice() throws Exception {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 3, false, prefixMapper, onMissingComplete);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 3, false, prefixMapper, onMissingComplete);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertCompleted();
+        testSubscriber1.assertNoErrors();
+        testSubscriber1.assertValues("1:1", "1:2", "1:3");
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("2:2", "2:4", "2:6");
+    }
+
+    @Test
+    public void testTwoRequestsWithErrorProducingBatchCommand() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 3, true);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 3, true);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertError(RuntimeException.class);
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertError(RuntimeException.class);
+        testSubscriber2.assertNoValues();
+    }
+
+    @Test
+    public void testTwoRequestsWithErrorInDemultiplex() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 3, false, mapWithErrorOn1, onMissingError);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 3, false, mapWithErrorOn1, onMissingError);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertError(RuntimeException.class);
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("2:2", "2:4", "2:6");
+    }
+
+    @Test
+    public void testTwoRequestsWithEmptyResponseAndOnMissingError() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingError);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 0, onMissingError);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertError(IllegalStateException.class);
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertError(IllegalStateException.class);
+        testSubscriber2.assertNoValues();
+    }
+
+    @Test
+    public void testTwoRequestsWithEmptyResponseAndOnMissingThrow() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingThrow);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 0, onMissingThrow);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertError(RuntimeException.class);
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertError(RuntimeException.class);
+        testSubscriber2.assertNoValues();
+    }
+
+    @Test
+    public void testTwoRequestsWithEmptyResponseAndOnMissingComplete() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingComplete);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 0, onMissingComplete);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertCompleted();
+        testSubscriber1.assertNoErrors();
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertNoValues();
+    }
+
+    @Test
+    public void testTwoRequestsWithEmptyResponseAndOnMissingIgnore() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingIgnore);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 0, onMissingIgnore);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertCompleted();
+        testSubscriber1.assertNoErrors();
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertNoValues();
+    }
+
+    @Test
+    public void testTwoRequestsWithEmptyResponseAndOnMissingFillInStaticValue() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingFillIn);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 0, onMissingFillIn);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertCompleted();
+        testSubscriber1.assertNoErrors();
+        testSubscriber1.assertValues("fillin");
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("fillin");
+    }
+
+    @Test
+    public void testTwoRequestsWithValuesForOneArgOnlyAndOnMissingComplete() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingComplete);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 5, onMissingComplete);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertCompleted();
+        testSubscriber1.assertNoErrors();
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("2:2", "2:4", "2:6", "2:8", "2:10");
+    }
+
+    @Test
+    public void testTwoRequestsWithValuesForOneArgOnlyAndOnMissingFillInStaticValue() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingFillIn);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 5, onMissingFillIn);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertCompleted();
+        testSubscriber1.assertNoErrors();
+        testSubscriber1.assertValues("fillin");
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("2:2", "2:4", "2:6", "2:8", "2:10");
+    }
+
+    @Test
+    public void testTwoRequestsWithValuesForOneArgOnlyAndOnMissingIgnore() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingIgnore);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 5, onMissingIgnore);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertCompleted();
+        testSubscriber1.assertNoErrors();
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("2:2", "2:4", "2:6", "2:8", "2:10");
+    }
+
+    @Test
+    public void testTwoRequestsWithValuesForOneArgOnlyAndOnMissingError() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingError);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 5, onMissingError);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertError(IllegalStateException.class);
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("2:2", "2:4", "2:6", "2:8", "2:10");
+    }
+
+    @Test
+    public void testTwoRequestsWithValuesForOneArgOnlyAndOnMissingThrow() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 0, onMissingThrow);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 5, onMissingThrow);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertError(RuntimeException.class);
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("2:2", "2:4", "2:6", "2:8", "2:10");
+    }
+
+    @Test
+    public void testTwoRequestsWithValuesForWrongArgs() {
+        TestCollapserTimer timer = new TestCollapserTimer();
+        HystrixObservableCollapser<String, String, String, String> collapser1 = new TestCollapserWithMultipleResponses(timer, 1, 3, false, map1To3And2To2, onMissingError);
+        HystrixObservableCollapser<String, String, String, String> collapser2 = new TestCollapserWithMultipleResponses(timer, 2, 3, false, map1To3And2To2, onMissingError);
+
+        System.out.println("Starting to observe collapser1");
+        Observable<String> result1 = collapser1.observe();
+        Observable<String> result2 = collapser2.observe();
+
+        timer.incrementTime(10); // let time pass that equals the default delay/period
+
+        TestSubscriber<String> testSubscriber1 = new TestSubscriber<String>();
+        result1.subscribe(testSubscriber1);
+
+        TestSubscriber<String> testSubscriber2 = new TestSubscriber<String>();
+        result2.subscribe(testSubscriber2);
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        testSubscriber1.assertError(RuntimeException.class);
+        testSubscriber1.assertNoValues();
+        testSubscriber2.assertCompleted();
+        testSubscriber2.assertNoErrors();
+        testSubscriber2.assertValues("2:2", "2:4", "2:6");
     }
 
     private static class TestRequestCollapser extends HystrixObservableCollapser<String, String, String, String> {
@@ -188,7 +651,6 @@ public class HystrixObservableCollapserTest {
         protected void onMissingResponse(CollapsedRequest<String, String> r) {
             r.setException(new RuntimeException("missing value!"));
         }
-
     }
 
     private static HystrixCollapserKey collapserKeyFromString(final Object o) {
@@ -239,5 +701,139 @@ public class HystrixObservableCollapserTest {
             }).subscribeOn(Schedulers.computation());
         }
 
+    }
+
+    private static class TestCollapserWithMultipleResponses extends HystrixObservableCollapser<String, String, String, String> {
+
+        private final String arg;
+        private final static Map<String, Integer> emitsPerArg;
+        private final boolean commandConstructionFails;
+        private final Func1<String, String> keyMapper;
+        private final Action1<CollapsedRequest<String, String>> onMissingResponseHandler;
+
+        static {
+            emitsPerArg = new HashMap<String, Integer>();
+        }
+
+        public TestCollapserWithMultipleResponses(TestCollapserTimer timer, int arg, int numEmits, boolean commandConstructionFails) {
+            this(timer, arg, numEmits, commandConstructionFails, prefixMapper, onMissingComplete);
+        }
+
+        public TestCollapserWithMultipleResponses(TestCollapserTimer timer, int arg, int numEmits, Action1<CollapsedRequest<String, String>> onMissingHandler) {
+            this(timer, arg, numEmits, false, prefixMapper, onMissingHandler);
+        }
+
+        public TestCollapserWithMultipleResponses(TestCollapserTimer timer, int arg, int numEmits, Func1<String, String> keyMapper) {
+            this(timer, arg, numEmits, false, keyMapper, onMissingComplete);
+        }
+
+        public TestCollapserWithMultipleResponses(TestCollapserTimer timer, int arg, int numEmits, boolean commandConstructionFails, Func1<String, String> keyMapper, Action1<CollapsedRequest<String, String>> onMissingResponseHandler) {
+            super(collapserKeyFromString(timer), Scope.REQUEST, timer, HystrixCollapserProperties.Setter().withMaxRequestsInBatch(10).withTimerDelayInMilliseconds(10), createMetrics());
+            this.arg = arg + "";
+            emitsPerArg.put(this.arg, numEmits);
+            this.commandConstructionFails = commandConstructionFails;
+            this.keyMapper = keyMapper;
+            this.onMissingResponseHandler = onMissingResponseHandler;
+        }
+
+        private static HystrixCollapserMetrics createMetrics() {
+            HystrixCollapserKey key = HystrixCollapserKey.Factory.asKey("COLLAPSER_MULTI");
+            return HystrixCollapserMetrics.getInstance(key, new HystrixPropertiesCollapserDefault(key, HystrixCollapserProperties.Setter()));
+        }
+
+        @Override
+        public String getRequestArgument() {
+            return arg;
+        }
+
+        @Override
+        protected HystrixObservableCommand<String> createCommand(Collection<CollapsedRequest<String, String>> collapsedRequests) {
+            if (commandConstructionFails) {
+                throw new RuntimeException("Exception thrown in command construction");
+            } else {
+                List<Integer> args = new ArrayList<Integer>();
+
+                for (CollapsedRequest<String, String> collapsedRequest : collapsedRequests) {
+                    String stringArg = collapsedRequest.getArgument();
+                    int intArg = Integer.parseInt(stringArg);
+                    args.add(intArg);
+                }
+
+                return new TestCollapserCommandWithMultipleResponsePerArgument(args, emitsPerArg);
+            }
+        }
+
+        //Data comes back in the form: 1:1, 1:2, 1:3, 2:2, 2:4, 2:6.
+        //This method should use the first half of that string as the request arg
+        @Override
+        protected Func1<String, String> getBatchReturnTypeKeySelector() {
+            return keyMapper;
+
+        }
+
+        @Override
+        protected Func1<String, String> getRequestArgumentKeySelector() {
+            return new Func1<String, String>() {
+
+                @Override
+                public String call(String s) {
+                    return s;
+                }
+
+            };
+        }
+
+        @Override
+        protected void onMissingResponse(CollapsedRequest<String, String> r) {
+            onMissingResponseHandler.call(r);
+
+        }
+
+        @Override
+        protected Func1<String, String> getBatchReturnTypeToResponseTypeMapper() {
+            return new Func1<String, String>() {
+
+                @Override
+                public String call(String s) {
+                    return s;
+                }
+
+            };
+        }
+    }
+
+    private static class TestCollapserCommandWithMultipleResponsePerArgument extends TestHystrixObservableCommand<String> {
+
+        private final List<Integer> args;
+        private final Map<String, Integer> emitsPerArg;
+
+        TestCollapserCommandWithMultipleResponsePerArgument(List<Integer> args, Map<String, Integer> emitsPerArg) {
+            super(testPropsBuilder().setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter().withExecutionTimeoutInMilliseconds(500)));
+            this.args = args;
+            this.emitsPerArg = emitsPerArg;
+        }
+
+        @Override
+        protected Observable<String> construct() {
+            return Observable.create(new OnSubscribe<String>() {
+                @Override
+                public void call(Subscriber<? super String> subscriber) {
+                    try {
+                        Thread.sleep(100);
+                        for (Integer arg: args) {
+                            int numEmits = emitsPerArg.get(arg.toString());
+                            for (int j = 1; j < numEmits + 1; j++) {
+                                subscriber.onNext(arg + ":" + (arg * j));
+                                Thread.sleep(1);
+                            }
+                            Thread.sleep(10);
+                        }
+                    } catch (Throwable ex) {
+                        subscriber.onError(ex);
+                    }
+                    subscriber.onCompleted();
+                }
+            }).subscribeOn(Schedulers.computation());
+        }
     }
 }


### PR DESCRIPTION
Replaces #881.  Fixed memory consumption issue by replacing `ReplaySubject` with `PublishSubject` and adding an `AtomicBoolean` to `CollapsedRequestObservableFunction` to track if a value has been set on the response yet