### PR TITLE
Backport of #896

### DIFF
--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/cache/HystrixCacheKeyGenerator.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/cache/HystrixCacheKeyGenerator.java
@@ -58,7 +58,7 @@ public class HystrixCacheKeyGenerator {
                 StringBuilder cacheKeyBuilder = new StringBuilder();
                 for (CacheInvocationParameter parameter : cacheInvocationContext.getKeyParameters()) {
                     CacheKey cacheKey = parameter.getCacheKeyAnnotation();
-                    if (StringUtils.isNotBlank(cacheKey.value())) {
+                    if (cacheKey != null && StringUtils.isNotBlank(cacheKey.value())) {
                         appendPropertyValue(cacheKeyBuilder, Arrays.asList(StringUtils.split(cacheKey.value(), ".")), parameter.getValue());
                     } else {
                         cacheKeyBuilder.append(parameter.getValue());


### PR DESCRIPTION
From @fredboutin:
When no @CacheKey are specified, a null pointer occurred. This fixes it.