### PR TITLE
Remove commons-collections dependency. (Backport of #899)

### DIFF
--- a/hystrix-contrib/hystrix-javanica/build.gradle
+++ b/hystrix-contrib/hystrix-javanica/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile "org.aspectj:aspectjrt:$aspectjVersion"
 
     compile 'com.google.guava:guava:15.0'
-    compile 'commons-collections:commons-collections:3.2.1'
     compile 'org.apache.commons:commons-lang3:3.1'
     compile 'com.google.code.findbugs:jsr305:2.0.0'
     testCompile 'junit:junit-dep:4.10'

--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/cache/CacheInvocationContext.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/cache/CacheInvocationContext.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.netflix.hystrix.contrib.javanica.command.ExecutionType;
 import com.netflix.hystrix.contrib.javanica.command.MethodExecutionAction;
-import org.apache.commons.collections.CollectionUtils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -142,7 +141,7 @@ public class CacheInvocationContext<A extends Annotation> {
      * @return true if at least one method argument with {@link com.netflix.hystrix.contrib.javanica.cache.annotation.CacheKey} annotation
      */
     public boolean hasKeyParameters() {
-        return CollectionUtils.isNotEmpty(keyParameters);
+        return !keyParameters.isEmpty();
     }
 
     /**

--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/conf/HystrixPropertiesManager.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/conf/HystrixPropertiesManager.java
@@ -23,7 +23,6 @@ import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixProperty;
 import java.text.MessageFormat;
 import java.util.Map;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.Validate;
 
 /**
@@ -85,7 +84,7 @@ public final class HystrixPropertiesManager {
     }
 
     private static void setProperties(Map<String, Object> properties, String propTemplate, String commandKey) {
-        if(MapUtils.isNotEmpty(properties)) {
+        if(properties != null && !properties.isEmpty()) {
             for(Map.Entry<String, Object> property : properties.entrySet()) {
                 String propName = MessageFormat.format(propTemplate, commandKey, property.getKey());
                 ConfigurationManager.getConfigInstance().setProperty(propName, property.getValue());


### PR DESCRIPTION
This library was only used in two places:
- HystrixPropertiesManager.java: A simple null check works in its place.
- CacheInvocationContext.java: The field keyParameters will not be null so
  calling isEmpty directly will not result in a NullPointerException.

This is one less dependency to manage and avoids bringing in a ~500k jar for
null checks.