### PR TITLE
fix(title-xss): escaping text acquired from parameters to avoid any xss attacks

### DIFF
--- a/hystrix-dashboard/src/main/webapp/monitor/monitor.html
+++ b/hystrix-dashboard/src/main/webapp/monitor/monitor.html
@@ -94,9 +94,9 @@
 			}
 
 			if(getUrlVars()["title"] != undefined) {
-				$('#title_name').html("Hystrix Stream: " + decodeURIComponent(getUrlVars()["title"]))
+				$('#title_name').text("Hystrix Stream: " + decodeURIComponent(getUrlVars()["title"]))
 			} else {
-				$('#title_name').html("Hystrix Stream: " + decodeURIComponent(stream))
+				$('#title_name').text("Hystrix Stream: " + decodeURIComponent(stream))
 			}
 
             //do not show authorization in stream title


### PR DESCRIPTION
Backport of #921 from @xscreach 