### PR TITLE
[hystrix-dashboard] isCircuitBreakerOpen is assumed to be a boolean

### DIFF
--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/templates/hystrixCircuit.html
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/templates/hystrixCircuit.html
@@ -43,7 +43,7 @@
 			<% } else {
 				/* We have some circuits that are open */  
 			%>
-				Circuit <font color="orange"><%= isCircuitBreakerOpen.replace("true", "Open").replace("false", "Closed") %>)</font>
+				Circuit <font color="orange"><%= isCircuitBreakerOpen.toString().replace("true", "Open").replace("false", "Closed") %></font>
 			<% }  %>
 		<% } %>
 		</div>


### PR DESCRIPTION
isCircuitBreakeropen is assumed to be a boolean from the HystrixStream servlet, however these replace() operations assume that it is a string. There are certain instances where Turbine does not return back a String when isCircuitBreakerOpen is aggregated. This enforces the boolean to be a string first, regardless of what Turbine may/may not do.