### PR TITLE
upgrade to commons-collections 3.2.2

### DIFF
--- a/hystrix-contrib/hystrix-javanica/build.gradle
+++ b/hystrix-contrib/hystrix-javanica/build.gradle
@@ -100,7 +100,7 @@ dependencies {
     compile "org.aspectj:aspectjrt:$aspectjVersion"
 
     compile 'com.google.guava:guava:15.0'
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
     compile 'org.apache.commons:commons-lang3:3.1'
     compile 'com.google.code.findbugs:jsr305:2.0.0'
     compile 'org.ow2.asm:asm:5.0.4'


### PR DESCRIPTION
Upgrade commons collections since there is a bit of hysteria around the security issue (and it won't be dragged in transitively by end-users).
Always good to stay current anyways.