### PR TITLE
Made commands run concurrently in HystrixCommandTimeoutConcurrencyTesting

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -926,6 +926,8 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
         return false;
     }
 
+    private static final HystrixTimeoutException TIMEOUT_EXCEPTION_INSTANCE = new HystrixTimeoutException();
+
     private static class HystrixObservableTimeoutOperator<R> implements Operator<R, R> {
 
         final AbstractCommand<R> originalCommand;
@@ -948,7 +950,7 @@ import com.netflix.hystrix.util.HystrixTimer.TimerListener;
 
                 @Override
                 public void run() {
-                    child.onError(new HystrixTimeoutException());
+                    child.onError(TIMEOUT_EXCEPTION_INSTANCE);
                 }
             });
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTimeoutConcurrencyTesting.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTimeoutConcurrencyTesting.java
@@ -91,7 +91,9 @@ public class HystrixCommandTimeoutConcurrencyTesting {
                             .withCircuitBreakerEnabled(false)
                             .withFallbackIsolationSemaphoreMaxConcurrentRequests(NUM_CONCURRENT_COMMANDS))
                     .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter()
-                            .withCoreSize(NUM_CONCURRENT_COMMANDS)));
+                            .withCoreSize(NUM_CONCURRENT_COMMANDS)
+                            .withMaxQueueSize(NUM_CONCURRENT_COMMANDS)
+                            .withQueueSizeRejectionThreshold(NUM_CONCURRENT_COMMANDS)));
         }
 
         @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTimeoutConcurrencyTesting.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTimeoutConcurrencyTesting.java
@@ -88,7 +88,8 @@ public class HystrixCommandTimeoutConcurrencyTesting {
                     .andCommandKey(HystrixCommandKey.Factory.asKey("testTimeoutConcurrencyCommand"))
                     .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
                             .withExecutionTimeoutInMilliseconds(3)
-                            .withCircuitBreakerEnabled(false))
+                            .withCircuitBreakerEnabled(false)
+                            .withFallbackIsolationSemaphoreMaxConcurrentRequests(NUM_CONCURRENT_COMMANDS))
                     .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter()
                             .withCoreSize(NUM_CONCURRENT_COMMANDS)));
         }


### PR DESCRIPTION
As described in #985.

When I adjust the number of concurrent commands upwards, I sporadically see failures.  Those seem exactly as described by @jojitj.

Now that I have a fairly-reliable repro, I'll investigate why this is happening and get a fix out.