### PR TITLE
Remove validation error message when adding a stream to monitor

### DIFF
--- a/hystrix-dashboard/src/main/webapp/index.html
+++ b/hystrix-dashboard/src/main/webapp/index.html
@@ -26,6 +26,8 @@
 				$('#streams').html('<table>' + _.reduce(streams, function(html, s) {
 					return html + '<tr><td>' + s.name + '</td><td>' + s.stream + '</td></tr>';
 				}, '') + '</table>');
+
+				$('#message').html("");
 			} else {
 				$('#message').html("The 'stream' value is required.");
 			}


### PR DESCRIPTION
Clicking on Add Stream button should reset any error messages that were
displayed on the previous failed attempt.

See #991 for more details.