### PR TITLE
Demonstrate circuit-breaker sleep window property does not get reset

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
@@ -49,6 +49,8 @@ public interface HystrixCircuitBreaker {
      */
     /* package */void markSuccess();
 
+    int getCurrentSleepWindowInMilliseconds();
+
     /**
      * @ExcludeFromJavadoc
      * @ThreadSafe
@@ -145,6 +147,11 @@ public interface HystrixCircuitBreaker {
         }
 
         @Override
+        public int getCurrentSleepWindowInMilliseconds() {
+            return properties.circuitBreakerSleepWindowInMilliseconds().get();
+        }
+
+        @Override
         public boolean allowRequest() {
             if (properties.circuitBreakerForceOpen().get()) {
                 // properties have asked us to force the circuit open so we will allow NO requests
@@ -230,6 +237,11 @@ public interface HystrixCircuitBreaker {
         @Override
         public void markSuccess() {
 
+        }
+
+        @Override
+        public int getCurrentSleepWindowInMilliseconds() {
+            return 0;
         }
 
     }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
@@ -15,10 +15,6 @@
  */
 package com.netflix.hystrix;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.Random;
 
 import org.junit.Ignore;
@@ -29,6 +25,8 @@ import com.netflix.hystrix.strategy.HystrixPlugins;
 import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifierDefault;
 import com.netflix.hystrix.strategy.executionhook.HystrixCommandExecutionHook;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+
+import static org.junit.Assert.*;
 
 public class HystrixCircuitBreakerTest {
 
@@ -64,6 +62,11 @@ public class HystrixCircuitBreakerTest {
         @Override
         public void markSuccess() {
             // we don't need to do anything since we're going to permanently trip the circuit
+        }
+
+        @Override
+        public int getCurrentSleepWindowInMilliseconds() {
+            return Integer.MAX_VALUE;
         }
 
         @Override
@@ -288,6 +291,8 @@ public class HystrixCircuitBreakerTest {
             HystrixCommandMetrics metrics = getMetrics(properties);
             HystrixCircuitBreaker cb = getCircuitBreaker(key, CommandOwnerForUnitTest.OWNER_TWO, metrics, properties);
 
+            assertEquals(sleepWindow, HystrixCircuitBreaker.Factory.getInstance(key).getCurrentSleepWindowInMilliseconds());
+
             // fail
             metrics.markFailure(1000);
             metrics.markFailure(1000);
@@ -297,6 +302,8 @@ public class HystrixCircuitBreakerTest {
             // everything has failed in the test window so we should return false now
             assertFalse(cb.allowRequest());
             assertTrue(cb.isOpen());
+
+            assertEquals(sleepWindow, HystrixCircuitBreaker.Factory.getInstance(key).getCurrentSleepWindowInMilliseconds());
 
             // wait for sleepWindow to pass
             Thread.sleep(sleepWindow + 50);
@@ -308,9 +315,13 @@ public class HystrixCircuitBreakerTest {
             // and further requests are still blocked
             assertFalse(cb.allowRequest());
 
+            assertEquals(sleepWindow, HystrixCircuitBreaker.Factory.getInstance(key).getCurrentSleepWindowInMilliseconds());
+
             // the 'singleTest' succeeds so should cause the circuit to be closed
             metrics.markSuccess(500);
             cb.markSuccess();
+
+            assertEquals(sleepWindow, HystrixCircuitBreaker.Factory.getInstance(key).getCurrentSleepWindowInMilliseconds());
 
             // all requests should be open again
             assertTrue(cb.allowRequest());
@@ -318,7 +329,7 @@ public class HystrixCircuitBreakerTest {
             assertTrue(cb.allowRequest());
             // and the circuit should be closed again
             assertFalse(cb.isOpen());
-
+            assertEquals(sleepWindow, HystrixCircuitBreaker.Factory.getInstance(key).getCurrentSleepWindowInMilliseconds());
         } catch (Exception e) {
             e.printStackTrace();
             fail("Error occurred: " + e.getMessage());
@@ -501,7 +512,7 @@ public class HystrixCircuitBreakerTest {
      * Utility method for creating {@link HystrixCircuitBreaker} for unit tests.
      */
     private static HystrixCircuitBreaker getCircuitBreaker(HystrixCommandKey key, HystrixCommandGroupKey commandGroup, HystrixCommandMetrics metrics, HystrixCommandProperties.Setter properties) {
-        return new HystrixCircuitBreakerImpl(key, commandGroup, HystrixCommandPropertiesTest.asMock(properties), metrics);
+        return HystrixCircuitBreaker.Factory.getInstance(key, commandGroup, HystrixCommandPropertiesTest.asMock(properties), metrics);
     }
 
     private static enum CommandOwnerForUnitTest implements HystrixCommandGroupKey {


### PR DESCRIPTION
Brought up in: https://groups.google.com/forum/#!topic/hystrixoss/X_NnKfx3io0.

This shows that sleep window remains the same during all phases of a circuit-breaker lifecycle.