### PR TITLE
Added AbstractCommand.getExecutionException to solve #998

### DIFF
--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -15,15 +15,7 @@
  */
 package com.netflix.hystrix;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -63,6 +55,8 @@ import com.netflix.hystrix.strategy.concurrency.HystrixContextScheduler;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 import com.netflix.hystrix.strategy.properties.HystrixProperty;
 import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+
+import static org.junit.Assert.*;
 
 public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCommand<?>> {
 
@@ -105,6 +99,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
 
             assertEquals(null, command.getFailedExecutionException());
+            assertNull(command.getExecutionException());
 
             assertTrue(command.getExecutionTimeInMilliseconds() > -1);
             assertTrue(command.isSuccessfulExecution());
@@ -144,6 +139,8 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertTrue(command.isExecutedInThread());
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isSuccessfulExecution());
+        assertNull(command.getExecutionException());
+
         try {
             // second should fail
             command.execute();
@@ -188,6 +185,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         }
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(1, command.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
         assertEquals(0, command.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
@@ -230,6 +228,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -268,6 +267,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -307,6 +307,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -345,6 +346,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isSuccessfulExecution());
+        assertNull(command.getExecutionException());
 
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -389,6 +391,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -432,6 +435,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -470,6 +474,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -512,6 +517,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -552,6 +558,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
             assertTrue(command.getExecutionTimeInMilliseconds() > -1);
             assertTrue(command.isSuccessfulExecution());
+            assertNull(command.getExecutionException());
 
             assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.BAD_REQUEST));
             assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1068,6 +1075,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertTrue(command.isResponseTimedOut());
         assertFalse(command.isResponseFromFallback());
         assertFalse(command.isResponseRejected());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1107,6 +1115,8 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             e.printStackTrace();
             fail("We should have received a response from the fallback.");
         }
+
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1149,6 +1159,9 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
                 fail("the exception should be HystrixRuntimeException");
             }
         }
+
+        assertNotNull(command.getExecutionException());
+
         // the time should be 50+ since we timeout at 50ms
         assertTrue("Execution Time is: " + command.getExecutionTimeInMilliseconds(), command.getExecutionTimeInMilliseconds() >= 50);
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
@@ -1191,6 +1204,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             assertTrue(command.getExecutionTimeInMilliseconds() > -1);
             assertTrue(command.isResponseTimedOut());
             assertFalse(command.isSuccessfulExecution());
+            assertNotNull(command.getExecutionException());
 
             /* failure and timeout count should be the same as 'testCircuitBreakerOnExecutionTimeout' */
             assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -1252,6 +1266,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isResponseTimedOut());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1288,6 +1303,8 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             e.printStackTrace();
             fail("We should have received a response from the fallback.");
         }
+
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1333,6 +1350,8 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
                 fail("the exception should be ExecutionException with cause as HystrixRuntimeException");
             }
         }
+
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1382,6 +1401,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isResponseTimedOut());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1418,6 +1438,8 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             e.printStackTrace();
             fail("We should have received a response from the fallback.");
         }
+
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1464,6 +1486,8 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             }
         }
 
+        assertNotNull(command.getExecutionException());
+
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -1503,6 +1527,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             assertTrue(command.getExecutionTimeInMilliseconds() == -1);
             assertTrue(command.isResponseShortCircuited());
             assertFalse(command.isResponseTimedOut());
+            assertNotNull(command.getExecutionException());
 
             // because it was short-circuited to a fallback we don't count an error
             assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -1573,6 +1598,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             assertTrue(command.isResponseRejected());
             assertFalse(command.isResponseShortCircuited());
             assertFalse(command.isResponseTimedOut());
+            assertNotNull(command.getExecutionException());
 
             assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.THREAD_POOL_REJECTED));
             assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SHORT_CIRCUITED));
@@ -1652,8 +1678,10 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
             assertFalse(command1.isResponseRejected());
             assertFalse(command1.isResponseFromFallback());
+            assertNull(command1.getExecutionException());
             assertTrue(command2.isResponseRejected());
             assertTrue(command2.isResponseFromFallback());
+            assertNotNull(command2.getExecutionException());
         } catch (Exception e) {
             e.printStackTrace();
             fail("We should have received a response from the fallback.");
@@ -1797,6 +1825,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             assertTrue(command.isResponseRejected());
             assertFalse(command.isResponseShortCircuited());
             assertFalse(command.isResponseTimedOut());
+            assertNotNull(command.getExecutionException());
 
             assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.THREAD_POOL_REJECTED));
             if (e instanceof HystrixRuntimeException && e.getCause() instanceof RejectedExecutionException) {
@@ -1928,6 +1957,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertEquals(true, result);
         assertFalse(cmd.isResponseTimedOut());
+        assertNull(cmd.getExecutionException());
         System.out.println("CMD : " + cmd.currentRequestLog.getExecutedCommandsAsString());
         assertTrue(cmd.executionResult.getExecutionTime() >= 900);
     }
@@ -2530,12 +2560,14 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         // the execution log for command1 should show a SUCCESS
         assertEquals(1, command1.getExecutionEvents().size());
         assertTrue(command1.getExecutionEvents().contains(HystrixEventType.SUCCESS));
+        assertNull(command1.getExecutionException());
 
         // the execution log for command2 should show a SUCCESS
         assertEquals(1, command2.getExecutionEvents().size());
         assertTrue(command2.getExecutionEvents().contains(HystrixEventType.SUCCESS));
         assertTrue(command2.getExecutionTimeInMilliseconds() > -1);
         assertFalse(command2.isResponseFromCache());
+        assertNull(command2.getExecutionException());
 
         assertEquals(2, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -3087,6 +3119,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertTrue(c.isResponseTimedOut());
         assertFalse(c.isFailedExecution());
         assertFalse(c.isResponseShortCircuited());
+        assertNotNull(c.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -3349,8 +3382,9 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
     @Test
     public void testBadRequestExceptionViaQueueInThread() {
         TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+        TestHystrixCommand<?> command = new BadRequestCommand(circuitBreaker, ExecutionIsolationStrategy.THREAD);
         try {
-            new BadRequestCommand(circuitBreaker, ExecutionIsolationStrategy.THREAD).queue().get();
+            command.queue().get();
             fail("we expect to receive a " + HystrixBadRequestException.class.getSimpleName());
         } catch (ExecutionException e) {
             e.printStackTrace();
@@ -3363,6 +3397,8 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             e.printStackTrace();
             fail();
         }
+
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -3489,6 +3525,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -3546,6 +3583,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -3568,6 +3606,8 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             cmd.execute();
             fail("Should throw");
         } catch (Throwable t) {
+            assertNotNull(cmd.getExecutionException());
+
             System.out.println("Unsuccessful Execution took : " + (System.currentTimeMillis() - timeMillis));
             assertEquals(0, cmd.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
             assertEquals(1, cmd.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -3611,6 +3651,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -3633,6 +3674,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -3662,6 +3704,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -3690,6 +3733,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -4019,6 +4063,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
         assertEquals("we failed with a simulated issue", commandDisabled.getFailedExecutionException().getMessage());
 
         assertTrue(commandDisabled.isFailedExecution());
+        assertNotNull(commandDisabled.getExecutionException());
 
         assertEquals(0, commandDisabled.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, commandDisabled.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -4115,6 +4160,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isResponseTimedOut());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -166,6 +166,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertTrue(command.getExecutionTimeInMilliseconds() > -1);
             assertTrue(command.isSuccessfulExecution());
             assertFalse(command.isResponseFromFallback());
+            assertNull(command.getExecutionException());
 
             assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
             assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.FALLBACK_REJECTION));
@@ -218,6 +219,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isSuccessfulExecution());
         assertFalse(command.isResponseFromFallback());
+        assertNull(command.getExecutionException());
+
         try {
             // second should fail
             command.observe().toBlocking().single();
@@ -298,6 +301,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
         assertFalse(command.isResponseFromFallback());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
@@ -373,6 +377,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
         assertFalse(command.isResponseFromFallback());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -445,6 +450,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
         assertTrue(command.isResponseFromFallback());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -551,6 +557,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
         assertFalse(command.isResponseFromFallback());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -621,6 +628,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         }
 
         assertNull(command.getFailedExecutionException());
+        assertNotNull(command.getExecutionException());
 
         System.out.println("Command time : " + command.getExecutionTimeInMilliseconds());
         System.out.println("Observed command time : " + observedCommandDuration);
@@ -718,6 +726,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         // semaphore isolated
         assertFalse(command.isExecutedInThread());
 
+        assertNull(command.getExecutionException());
         assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
         assertEquals(0, command.getBuilder().metrics.getCurrentConcurrentExecutionCount());
 
@@ -944,6 +953,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             fail("We received an exception.");
         }
 
+        assertNull(command.getExecutionException());
+
         // we'll still get metrics ... just not the circuit breaker opening/closing
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -992,6 +1003,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command.isResponseTimedOut());
         assertFalse(command.isResponseFromFallback());
         assertFalse(command.isResponseRejected());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1027,6 +1039,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertTrue("Execution Time is: " + command.getExecutionTimeInMilliseconds(), command.getExecutionTimeInMilliseconds() >= 50);
             assertTrue(command.isResponseTimedOut());
             assertTrue(command.isResponseFromFallback());
+            assertNotNull(command.getExecutionException());
         } catch (Exception e) {
             e.printStackTrace();
             fail("We should have received a response from the fallback.");
@@ -1072,6 +1085,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                 assertNotNull(de.getImplementingClass());
                 assertNotNull(de.getCause());
                 assertTrue(de.getCause() instanceof TimeoutException);
+                assertNotNull(command.getExecutionException());
             } else {
                 fail("the exception should be HystrixRuntimeException");
             }
@@ -1140,6 +1154,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command.isResponseTimedOut());
         assertFalse(command.isResponseFromFallback());
         assertFalse(command.isResponseRejected());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -1186,6 +1201,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertTrue("Execution Time is: " + command.getExecutionTimeInMilliseconds(), command.getExecutionTimeInMilliseconds() >= 50);
             assertTrue(command.isResponseTimedOut());
             assertTrue(command.isResponseFromFallback());
+            assertNotNull(command.getExecutionException());
         } catch (Exception e) {
             e.printStackTrace();
             fail("We should have received a response from the fallback.");
@@ -1256,6 +1272,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                 assertNotNull(de.getImplementingClass());
                 assertNotNull(de.getCause());
                 assertTrue(de.getCause() instanceof TimeoutException);
+                assertNotNull(command.getExecutionException());
             } else {
                 fail("the exception should be HystrixRuntimeException");
             }
@@ -1297,6 +1314,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertTrue(command.isResponseFromFallback());
             assertFalse(command.isCircuitBreakerOpen());
             assertFalse(command.isResponseShortCircuited());
+            assertNotNull(command.getExecutionException());
 
             assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
             assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.TIMEOUT));
@@ -1353,6 +1371,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertTrue(command.getExecutionTimeInMilliseconds() > -1);
             assertTrue(command.isResponseTimedOut());
             assertFalse(command.isSuccessfulExecution());
+            assertNotNull(command.getExecutionException());
 
             /* failure and timeout count should be the same as 'testCircuitBreakerOnExecutionTimeout' */
             assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -1407,6 +1426,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             assertEquals(-1, command.getExecutionTimeInMilliseconds());
             assertTrue(command.isResponseShortCircuited());
             assertFalse(command.isResponseTimedOut());
+            assertNotNull(command.getExecutionException());
 
             // because it was short-circuited to a fallback we don't count an error
             assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -1857,6 +1877,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command1.getExecutionEvents().contains(HystrixEventType.SUCCESS));
         assertTrue(command1.getExecutionTimeInMilliseconds() > -1);
         assertFalse(command1.isResponseFromCache());
+        assertNull(command1.getExecutionException());
 
         // the execution log for command2 should show it came from cache
         assertEquals(3, command2.getExecutionEvents().size()); // it will include the EMIT + SUCCESS + RESPONSE_FROM_CACHE
@@ -1865,6 +1886,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(command2.getExecutionEvents().contains(HystrixEventType.RESPONSE_FROM_CACHE));
         assertTrue(command2.getExecutionTimeInMilliseconds() == -1);
         assertTrue(command2.isResponseFromCache());
+        assertNull(command2.getExecutionException());
 
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -2514,6 +2536,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertTrue(c.isResponseTimedOut());
         assertFalse(c.isFailedExecution());
         assertFalse(c.isResponseShortCircuited());
+        assertNotNull(c.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -2562,6 +2585,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             fail("expected a timeout");
         } catch (HystrixRuntimeException e) {
             assertTrue(r1.isResponseTimedOut());
+            assertNotNull(r1.getExecutionException());
             // what we want
         }
 
@@ -2572,6 +2596,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             fail("expected a timeout");
         } catch (HystrixRuntimeException e) {
             assertTrue(r2.isResponseTimedOut());
+            assertNotNull(r2.getExecutionException());
             // what we want
         }
 
@@ -2584,6 +2609,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         } catch (ExecutionException e) {
             e.printStackTrace();
             assertTrue(r3.isResponseTimedOut());
+            assertNotNull(r3.getExecutionException());
             // what we want
         }
 
@@ -2597,7 +2623,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         } catch (HystrixRuntimeException e) {
             assertTrue(r4.isResponseTimedOut());
             assertFalse(r4.isResponseFromFallback());
-            // what we want
+            assertNotNull(r4.getExecutionException());
         }
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
@@ -2631,6 +2657,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         } catch (HystrixRuntimeException e) {
             e.printStackTrace();
             assertTrue(r1.isResponseRejected());
+            assertNotNull(r1.getExecutionException());
             // what we want
         }
 
@@ -2642,6 +2669,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         } catch (HystrixRuntimeException e) {
             //                e.printStackTrace();
             assertTrue(r2.isResponseRejected());
+            assertNotNull(r2.getExecutionException());
             // what we want
         }
 
@@ -2653,6 +2681,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         } catch (ExecutionException e) {
             assertTrue(r3.isResponseRejected());
             assertTrue(e.getCause() instanceof HystrixRuntimeException);
+            assertNotNull(r3.getExecutionException());
         }
 
         // let the command finish (only 1 should actually be blocked on this due to the response cache)
@@ -2668,6 +2697,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             //                e.printStackTrace();
             assertTrue(r4.isResponseRejected());
             assertFalse(r4.isResponseFromFallback());
+            assertNotNull(r4.getExecutionException());
             // what we want
         }
 
@@ -2712,6 +2742,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
             // semaphore isolated
             assertFalse(command.isExecutedInThread());
+            assertNull(command.getExecutionException());
         } catch (Exception e) {
             e.printStackTrace();
             fail("We received an exception => " + e.getMessage());
@@ -2741,6 +2772,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
             // semaphore isolated
             assertFalse(command.isExecutedInThread());
+            assertNull(command.getExecutionException());
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -2780,8 +2812,9 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
     private void testBadRequestExceptionObserve(ExecutionIsolationStrategy isolationStrategy, boolean asyncException) {
         TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+        TestHystrixObservableCommand<?> command = new KnownHystrixBadRequestFailureTestCommand(circuitBreaker, isolationStrategy, asyncException);
         try {
-            new KnownHystrixBadRequestFailureTestCommand(circuitBreaker, isolationStrategy, asyncException).observe().toBlocking().single();
+            command.observe().toBlocking().single();
             fail("we expect to receive a " + HystrixBadRequestException.class.getSimpleName());
         } catch (HystrixBadRequestException e) {
             // success
@@ -2790,6 +2823,8 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             e.printStackTrace();
             fail("We expect a " + HystrixBadRequestException.class.getSimpleName() + " but got a " + e.getClass().getSimpleName());
         }
+
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -2831,18 +2866,21 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
     public void testAsyncBadRequestExceptionOnResponseFromCacheInThread() {
         testBadRequestExceptionOnResponseFromCache(ExecutionIsolationStrategy.THREAD, KnownHystrixBadRequestFailureTestCommand.ASYNC_EXCEPTION);
     }
+
     private void testBadRequestExceptionOnResponseFromCache(ExecutionIsolationStrategy isolationStrategy, boolean asyncException) {
         TestCircuitBreaker circuitBreaker = new TestCircuitBreaker();
+        TestHystrixObservableCommand<?> command1 = new KnownHystrixBadRequestFailureTestCommand(circuitBreaker, isolationStrategy, asyncException);
+        TestHystrixObservableCommand<?> command2 = new KnownHystrixBadRequestFailureTestCommand(circuitBreaker, isolationStrategy, asyncException);
 
         // execute once to cache the value
         try {
-            new KnownHystrixBadRequestFailureTestCommand(circuitBreaker, isolationStrategy, asyncException).observe().toBlocking().single();
+            command1.observe().toBlocking().single();
         } catch (Throwable e) {
             // ignore
         }
 
         try {
-            new KnownHystrixBadRequestFailureTestCommand(circuitBreaker, isolationStrategy, asyncException).observe().toBlocking().toFuture().get();
+            command2.observe().toBlocking().toFuture().get();
             fail("we expect to receive a " + HystrixBadRequestException.class.getSimpleName());
         } catch (ExecutionException e) {
             e.printStackTrace();
@@ -2855,6 +2893,9 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             e.printStackTrace();
             fail();
         }
+
+        assertNotNull(command1.getExecutionException());
+        assertNotNull(command2.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(2, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -2883,6 +2924,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -2938,6 +2980,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -2998,6 +3041,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isFailedExecution());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, circuitBreaker.metrics.getRollingCount(HystrixRollingNumberEvent.FAILURE));
@@ -3441,6 +3485,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals("we failed with a simulated issue", commandDisabled.getFailedExecutionException().getMessage());
 
         assertTrue(commandDisabled.isFailedExecution());
+        assertNotNull(commandDisabled.getExecutionException());
 
         assertEquals(0, commandDisabled.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, commandDisabled.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -3512,6 +3557,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         // Thread isolated
         assertTrue(command.isExecutedInThread());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
 
@@ -3561,6 +3607,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         // Thread isolated
         assertTrue(command.isExecutedInThread());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
 
@@ -3610,6 +3657,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         // semaphore isolated
         assertFalse(command.isExecutedInThread());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());
 
@@ -3661,6 +3709,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isResponseTimedOut());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(1, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));
@@ -3722,6 +3771,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         assertTrue(command.getExecutionTimeInMilliseconds() > -1);
         assertTrue(command.isResponseTimedOut());
+        assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.SUCCESS));
         assertEquals(0, command.getBuilder().metrics.getRollingCount(HystrixRollingNumberEvent.EXCEPTION_THROWN));


### PR DESCRIPTION
From the Javadoc:

```
/**
     * Get the Throwable/Exception emitted by this command instance prior to checking the fallback.
     * This exception instance may have been generated via a number of mechanisms:
     * 1) failed execution (in this case, same result as {@link #getFailedExecutionException()}.
     * 2) timeout
     * 3) short-circuit
     * 4) rejection
     * 5) bad request
     *
     * If the command execution was successful, then this exception instance is null (there was no exception)
     *
     * Note that the caller of the command may not receive this exception, as fallbacks may be served as a response to
     * the exception.
     *
     * @return Throwable or null
     */
```