### PR TITLE
Added threshold under which errorPercentage is kept at zero

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
@@ -462,7 +462,10 @@ public class HystrixCommandMetrics extends HystrixMetrics {
                 long errorCount = failure + timeout + threadPoolRejected + shortCircuited + semaphoreRejected;
                 int errorPercentage = 0;
 
-                if (totalCount > 0) {
+                // Only set errorPercentage as non-zero if totalCount is above configured threshold.
+                // This allows this to be configured so that very low usage circuits that often fail can be
+                // more easily ignored in monitoring/alerting.
+                if (totalCount > properties.metricsErrorPercentageTotalThreshold().get()) {
                     errorPercentage = (int) ((double) errorCount / totalCount * 100);
                 }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandMetricsTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandMetricsTest.java
@@ -125,6 +125,35 @@ public class HystrixCommandMetricsTest {
         assertEquals(NUM_CMDS, metrics.getCurrentConcurrentExecutionCount());
     }
 
+    @Test
+    public void testMetricsErrorPercentageTotalThreshold() {
+
+        try {
+            HystrixCommandProperties.Setter properties = HystrixCommandPropertiesTest.getUnitTestPropertiesSetter();
+
+            // set threshold of 2 total before errorPercentage should be non-zero.
+            properties = properties.withCircuitBreakerTotalThresholdForErrorPercentage(3);
+            HystrixCommandMetrics metrics = getMetrics(properties);
+
+            metrics.markFailure(100);
+            assertEquals(0, metrics.getHealthCounts().getErrorPercentage());
+
+            metrics.markFailure(100);
+            assertEquals(0, metrics.getHealthCounts().getErrorPercentage());
+
+            metrics.markSuccess(100);
+            assertEquals(0, metrics.getHealthCounts().getErrorPercentage());
+
+            metrics.markSuccess(100);
+            assertEquals(50, metrics.getHealthCounts().getErrorPercentage());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Error occurred: " + e.getMessage());
+        }
+
+    }
+
     /**
      * Utility method for creating {@link HystrixCommandMetrics} for unit tests.
      */

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
@@ -38,6 +38,7 @@ public class HystrixCommandPropertiesTest {
                 .withExecutionIsolationThreadInterruptOnTimeout(true)
                 .withCircuitBreakerForceOpen(false) // we don't want short-circuiting by default
                 .withCircuitBreakerErrorThresholdPercentage(40) // % of 'marks' that must be failed to trip the circuit
+                .withCircuitBreakerTotalThresholdForErrorPercentage(0)
                 .withMetricsRollingStatisticalWindowInMilliseconds(5000)// milliseconds back that will be tracked
                 .withMetricsRollingStatisticalWindowBuckets(5) // buckets
                 .withCircuitBreakerRequestVolumeThreshold(0) // in testing we will not have a threshold unless we're specifically testing that feature
@@ -169,6 +170,11 @@ public class HystrixCommandPropertiesTest {
             @Override
             public HystrixProperty<Integer> metricsRollingStatisticalWindowBuckets() {
                 return HystrixProperty.Factory.asProperty(builder.getMetricsRollingStatisticalWindowBuckets());
+            }
+
+            @Override
+            public HystrixProperty<Integer> metricsErrorPercentageTotalThreshold() {
+                return HystrixProperty.Factory.asProperty(builder.getCircuitBreakerTotalThresholdForErrorPercentage());
             }
 
             @Override


### PR DESCRIPTION
Added a property that can be used to configure a threshold  for total count, below which errorPercentage is kept a zero.

This allows circuits to be configured so that if they are very infrequently used, but often fail, then the produced metrics can be more easily ignored in monitoring/alerting.
