### PR TITLE
Implementation for feature request #1013

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixTimerThreadPoolProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixTimerThreadPoolProperties.java
@@ -1,0 +1,79 @@
+package com.netflix.hystrix;
+
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesChainedArchaiusProperty;
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
+
+import static com.netflix.hystrix.strategy.properties.HystrixProperty.Factory.asProperty;
+
+/**
+ * Properties for Hystrix timer thread pool.
+ * <p>
+ * Default implementation of methods uses Archaius (https://github.com/Netflix/archaius)
+ */
+public abstract class HystrixTimerThreadPoolProperties {
+
+    private final HystrixProperty<Integer> corePoolSize;
+
+    protected HystrixTimerThreadPoolProperties() {
+        this(new Setter().withCoreSize(Runtime.getRuntime().availableProcessors()));
+    }
+
+    protected HystrixTimerThreadPoolProperties(Setter setter) {
+        this.corePoolSize = getProperty("hystrix", "coreSize", setter.getCoreSize());
+    }
+
+    private static HystrixProperty<Integer> getProperty(String propertyPrefix, String instanceProperty, Integer defaultValue) {
+        return asProperty(new HystrixPropertiesChainedArchaiusProperty.IntegerProperty(
+                new HystrixPropertiesChainedArchaiusProperty.DynamicIntegerProperty(propertyPrefix + ".timer.threadpool.default." + instanceProperty, defaultValue)));
+    }
+
+    public HystrixProperty<Integer> getCorePoolSize() {
+        return corePoolSize;
+    }
+
+    /**
+     * Factory method to retrieve the default Setter.
+     */
+    public static Setter Setter() {
+        return new Setter();
+    }
+
+    /**
+     * Fluent interface that allows chained setting of properties.
+     * <p>
+     * See {@link HystrixPropertiesStrategy} for more information on order of precedence.
+     * <p>
+     * Example:
+     * <p>
+     * <pre> {@code
+     * HystrixTimerThreadPoolProperties.Setter()
+     *           .withCoreSize(10);
+     * } </pre>
+     *
+     * @NotThreadSafe
+     */
+    public static class Setter {
+        private Integer coreSize = null;
+
+        private Setter() {
+        }
+
+        public Integer getCoreSize() {
+            return coreSize;
+        }
+
+        public Setter withCoreSize(int value) {
+            this.coreSize = value;
+            return this;
+        }
+
+        /**
+         * Base properties for unit testing.
+         */
+        /* package */
+        static Setter getUnitTestPropertiesBuilder() {
+            return new Setter().withCoreSize(10); // size of thread pool
+        }
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/properties/HystrixPropertiesStrategy.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/properties/HystrixPropertiesStrategy.java
@@ -24,6 +24,7 @@ import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.hystrix.HystrixThreadPool;
 import com.netflix.hystrix.HystrixThreadPoolKey;
 import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.HystrixTimerThreadPoolProperties;
 import com.netflix.hystrix.strategy.HystrixPlugins;
 
 /**
@@ -148,5 +149,18 @@ public abstract class HystrixPropertiesStrategy {
      */
     public String getCollapserPropertiesCacheKey(HystrixCollapserKey collapserKey, HystrixCollapserProperties.Setter builder) {
         return collapserKey.name();
+    }
+
+    /**
+     * Construct an implementation of {@link com.netflix.hystrix.HystrixTimerThreadPoolProperties} for configuration of the timer thread pool
+     * that handles timeouts and collapser logic.
+     * <p>
+     * Constructs instance of {@link HystrixPropertiesTimerThreadPoolDefault}.
+     *
+     *
+     * @return Implementation of {@link com.netflix.hystrix.HystrixTimerThreadPoolProperties}
+     */
+    public HystrixTimerThreadPoolProperties getTimerThreadPoolProperties() {
+        return new HystrixPropertiesTimerThreadPoolDefault();
     }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/properties/HystrixPropertiesTimerThreadPoolDefault.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/properties/HystrixPropertiesTimerThreadPoolDefault.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2012 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.strategy.properties;
+
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.HystrixTimerThreadPoolProperties;
+
+/**
+ * Default implementation of {@link HystrixTimerThreadPoolProperties} using Archaius (https://github.com/Netflix/archaius)
+ * 
+ * @ExcludeFromJavadoc
+ */
+public class HystrixPropertiesTimerThreadPoolDefault extends HystrixTimerThreadPoolProperties {
+
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,8 +36,6 @@ import com.netflix.hystrix.HystrixCommand;
  * Timer used by {@link HystrixCommand} to timeout async executions and {@link HystrixCollapser} to trigger batch executions.
  */
 public class HystrixTimer {
-
-    static final String SYS_PROP_TIMEOUT = "com.netflix.hystrix.util.HystrixTimer.timeoutThreadPoolSize";
 
     private static final Logger logger = LoggerFactory.getLogger(HystrixTimer.class);
 
@@ -150,14 +150,8 @@ public class HystrixTimer {
          */
         public void initialize() {
 
-            // System property can override the default ThreadPool size
-            final String coreSizePropertyValue = System.getProperty(SYS_PROP_TIMEOUT);
-            int coreSize;
-            if (coreSizePropertyValue != null) {
-                coreSize = Integer.valueOf(coreSizePropertyValue);
-            } else {
-                coreSize = Runtime.getRuntime().availableProcessors();
-            }
+            HystrixPropertiesStrategy propertiesStrategy = HystrixPlugins.getInstance().getPropertiesStrategy();
+            int coreSize = propertiesStrategy.getTimerThreadPoolProperties().getCorePoolSize().get();
 
             executor = new ScheduledThreadPoolExecutor(coreSize, new ThreadFactory() {
                 final AtomicInteger counter = new AtomicInteger();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
@@ -35,6 +35,8 @@ import com.netflix.hystrix.HystrixCommand;
  */
 public class HystrixTimer {
 
+    static final String SYS_PROP_TIMEOUT = "com.netflix.hystrix.util.HystrixTimer.timeoutThreadPoolSize";
+
     private static final Logger logger = LoggerFactory.getLogger(HystrixTimer.class);
 
     private static HystrixTimer INSTANCE = new HystrixTimer();
@@ -147,7 +149,17 @@ public class HystrixTimer {
          * We want this only done once when created in compareAndSet so use an initialize method
          */
         public void initialize() {
-            executor = new ScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), new ThreadFactory() {
+
+            // System property can override the default ThreadPool size
+            final String coreSizePropertyValue = System.getProperty(SYS_PROP_TIMEOUT);
+            int coreSize;
+            if (coreSizePropertyValue != null) {
+                coreSize = Integer.valueOf(coreSizePropertyValue);
+            } else {
+                coreSize = Runtime.getRuntime().availableProcessors();
+            }
+
+            executor = new ScheduledThreadPoolExecutor(coreSize, new ThreadFactory() {
                 final AtomicInteger counter = new AtomicInteger();
 
                 @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/util/HystrixTimerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/util/HystrixTimerTest.java
@@ -15,21 +15,25 @@
  */
 package com.netflix.hystrix.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import com.netflix.hystrix.util.HystrixTimer.ScheduledExecutor;
+import com.netflix.hystrix.util.HystrixTimer.TimerListener;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.lang.ref.Reference;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
-
-import com.netflix.hystrix.util.HystrixTimer.ScheduledExecutor;
-import com.netflix.hystrix.util.HystrixTimer.TimerListener;
+import static org.junit.Assert.*;
 
 
 public class HystrixTimerTest {
+
+    @Before
+    public void setUp() {
+        HystrixTimer timer = HystrixTimer.getInstance();
+        HystrixTimer.reset();
+        System.clearProperty(HystrixTimer.SYS_PROP_TIMEOUT);
+    }
 
     @Test
     public void testSingleCommandSingleInterval() {
@@ -163,6 +167,25 @@ public class HystrixTimerTest {
         HystrixTimer.reset();
     }
 
+    @Test
+    public void testThreadPoolSizeSystemProperty() {
+
+        System.setProperty(HystrixTimer.SYS_PROP_TIMEOUT, "42");
+        HystrixTimer hystrixTimer = HystrixTimer.getInstance();
+        hystrixTimer.startThreadIfNeeded();
+        System.clearProperty(HystrixTimer.SYS_PROP_TIMEOUT);
+
+        assertEquals(42, hystrixTimer.executor.get().getThreadPool().getCorePoolSize());
+    }
+
+    @Test
+    public void testThreadPoolSizeDefault() {
+
+        HystrixTimer hystrixTimer = HystrixTimer.getInstance();
+        hystrixTimer.startThreadIfNeeded();
+        assertEquals(Runtime.getRuntime().availableProcessors(), hystrixTimer.executor.get().getThreadPool().getCorePoolSize());
+    }
+
     private static class TestListener implements TimerListener {
 
         private final int interval;
@@ -235,5 +258,5 @@ public class HystrixTimerTest {
 
     }
 
-    
+
 }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/util/HystrixTimerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/util/HystrixTimerTest.java
@@ -15,11 +15,13 @@
  */
 package com.netflix.hystrix.util;
 
+import com.netflix.hystrix.Hystrix;
 import com.netflix.hystrix.HystrixTimerThreadPoolProperties;
 import com.netflix.hystrix.strategy.HystrixPlugins;
 import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
 import com.netflix.hystrix.util.HystrixTimer.ScheduledExecutor;
 import com.netflix.hystrix.util.HystrixTimer.TimerListener;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,6 +37,11 @@ public class HystrixTimerTest {
     public void setUp() {
         HystrixTimer timer = HystrixTimer.getInstance();
         HystrixTimer.reset();
+    }
+
+    @After
+    public void tearDown() {
+        HystrixPlugins.reset();
     }
 
     @Test
@@ -179,33 +186,6 @@ public class HystrixTimerTest {
 
     @Test
     public void testThreadPoolSizeConfiguredWithBuilder() {
-
-        HystrixPlugins.reset();
-
-        HystrixTimerThreadPoolProperties.Setter builder = HystrixTimerThreadPoolProperties.Setter().withCoreSize(1);
-        final HystrixTimerThreadPoolProperties props = new HystrixTimerThreadPoolProperties(builder) {
-        };
-
-        HystrixPropertiesStrategy strategy = new HystrixPropertiesStrategy() {
-            @Override
-            public HystrixTimerThreadPoolProperties getTimerThreadPoolProperties() {
-                return props;
-            }
-        };
-
-        HystrixPlugins.getInstance().registerPropertiesStrategy(strategy);
-
-        HystrixTimer hystrixTimer = HystrixTimer.getInstance();
-        hystrixTimer.startThreadIfNeeded();
-
-        assertEquals(1, hystrixTimer.executor.get().getThreadPool().getCorePoolSize());
-
-    }
-
-    @Test
-    public void testThreadPoolSizeConfiguredWithArchaius() {
-
-        HystrixPlugins.reset();
 
         HystrixTimerThreadPoolProperties.Setter builder = HystrixTimerThreadPoolProperties.Setter().withCoreSize(1);
         final HystrixTimerThreadPoolProperties props = new HystrixTimerThreadPoolProperties(builder) {


### PR DESCRIPTION
I implemented a simple way to configure the timeout thread pool core size via a system property. The default is still Runtime.getRuntime(). availableProcessors(). I also added test cases for this feature.