### PR TITLE
Deprecate methods to retrieve userThreadLatency, and remove it from standard metrics being published

### DIFF
--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
@@ -339,55 +339,6 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
             }
         });
 
-        metricRegistry.register(createMetricName("latencyTotal_mean"), new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return metrics.getTotalTimeMean();
-            }
-        });
-        metricRegistry.register(createMetricName("latencyTotal_percentile_5"), new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return metrics.getTotalTimePercentile(5);
-            }
-        });
-        metricRegistry.register(createMetricName("latencyTotal_percentile_25"), new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return metrics.getTotalTimePercentile(25);
-            }
-        });
-        metricRegistry.register(createMetricName("latencyTotal_percentile_50"), new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return metrics.getTotalTimePercentile(50);
-            }
-        });
-        metricRegistry.register(createMetricName("latencyTotal_percentile_75"), new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return metrics.getTotalTimePercentile(75);
-            }
-        });
-        metricRegistry.register(createMetricName("latencyTotal_percentile_90"), new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return metrics.getTotalTimePercentile(90);
-            }
-        });
-        metricRegistry.register(createMetricName("latencyTotal_percentile_99"), new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return metrics.getTotalTimePercentile(99);
-            }
-        });
-        metricRegistry.register(createMetricName("latencyTotal_percentile_995"), new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return metrics.getTotalTimePercentile(99.5);
-            }
-        });
-
         // group
         metricRegistry.register(createMetricName("commandGroup"), new Gauge<String>() {
             @Override

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
@@ -337,19 +337,6 @@ public class HystrixMetricsPoller {
             json.writeNumberField("99.5", commandMetrics.getExecutionTimePercentile(99.5));
             json.writeNumberField("100", commandMetrics.getExecutionTimePercentile(100));
             json.writeEndObject();
-            //
-            json.writeNumberField("latencyTotal_mean", commandMetrics.getTotalTimeMean());
-            json.writeObjectFieldStart("latencyTotal");
-            json.writeNumberField("0", commandMetrics.getTotalTimePercentile(0));
-            json.writeNumberField("25", commandMetrics.getTotalTimePercentile(25));
-            json.writeNumberField("50", commandMetrics.getTotalTimePercentile(50));
-            json.writeNumberField("75", commandMetrics.getTotalTimePercentile(75));
-            json.writeNumberField("90", commandMetrics.getTotalTimePercentile(90));
-            json.writeNumberField("95", commandMetrics.getTotalTimePercentile(95));
-            json.writeNumberField("99", commandMetrics.getTotalTimePercentile(99));
-            json.writeNumberField("99.5", commandMetrics.getTotalTimePercentile(99.5));
-            json.writeNumberField("100", commandMetrics.getTotalTimePercentile(100));
-            json.writeEndObject();
 
             // property values for reporting what is actually seen by the command rather than what was set somewhere
             HystrixCommandProperties commandProperties = commandMetrics.getProperties();

--- a/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/JsonMappers.java
+++ b/hystrix-contrib/hystrix-rx-netty-metrics-stream/src/main/java/com/netflix/hystrix/contrib/rxnetty/metricsstream/JsonMappers.java
@@ -201,19 +201,6 @@ final class JsonMappers {
         json.writeNumberField("99.5", commandMetrics.getExecutionTimePercentile(99.5));
         json.writeNumberField("100", commandMetrics.getExecutionTimePercentile(100));
         json.writeEndObject();
-        //
-        json.writeNumberField("latencyTotal_mean", commandMetrics.getTotalTimeMean());
-        json.writeObjectFieldStart("latencyTotal");
-        json.writeNumberField("0", commandMetrics.getTotalTimePercentile(0));
-        json.writeNumberField("25", commandMetrics.getTotalTimePercentile(25));
-        json.writeNumberField("50", commandMetrics.getTotalTimePercentile(50));
-        json.writeNumberField("75", commandMetrics.getTotalTimePercentile(75));
-        json.writeNumberField("90", commandMetrics.getTotalTimePercentile(90));
-        json.writeNumberField("95", commandMetrics.getTotalTimePercentile(95));
-        json.writeNumberField("99", commandMetrics.getTotalTimePercentile(99));
-        json.writeNumberField("99.5", commandMetrics.getTotalTimePercentile(99.5));
-        json.writeNumberField("100", commandMetrics.getTotalTimePercentile(100));
-        json.writeEndObject();
 
         // property values for reporting what is actually seen by the command rather than what was set somewhere
         HystrixCommandProperties commandProperties = commandMetrics.getProperties();

--- a/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java
@@ -507,16 +507,6 @@ public class HystrixServoMetricsPublisherCommand extends HystrixServoMetricsPubl
         monitors.add(getExecutionLatencyPercentileMonitor("latencyExecute_percentile_99", 99));
         monitors.add(getExecutionLatencyPercentileMonitor("latencyExecute_percentile_995", 99.5));
 
-        // total latency metrics
-        monitors.add(getTotalLatencyMeanMonitor("latencyTotal_mean"));
-        monitors.add(getTotalLatencyPercentileMonitor("latencyTotal_percentile_5", 5));
-        monitors.add(getTotalLatencyPercentileMonitor("latencyTotal_percentile_25", 25));
-        monitors.add(getTotalLatencyPercentileMonitor("latencyTotal_percentile_50", 50));
-        monitors.add(getTotalLatencyPercentileMonitor("latencyTotal_percentile_75", 75));
-        monitors.add(getTotalLatencyPercentileMonitor("latencyTotal_percentile_90", 90));
-        monitors.add(getTotalLatencyPercentileMonitor("latencyTotal_percentile_99", 99));
-        monitors.add(getTotalLatencyPercentileMonitor("latencyTotal_percentile_995", 995));
-
         // group
         monitors.add(new InformationalMetric<String>(MonitorConfig.builder("commandGroup").build()) {
             @Override

--- a/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherCommand.java
@@ -280,16 +280,6 @@ public class HystrixYammerMetricsPublisherCommand implements HystrixMetricsPubli
         createExecutionLatencyPercentileGauge("latencyExecute_percentile_99", 99);
         createExecutionLatencyPercentileGauge("latencyExecute_percentile_995", 99.5);
 
-        createTotalLatencyMeanGauge("latencyTotal_mean");
-
-        createTotalLatencyPercentileGauge("latencyTotal_percentile_5", 5);
-        createTotalLatencyPercentileGauge("latencyTotal_percentile_25", 25);
-        createTotalLatencyPercentileGauge("latencyTotal_percentile_50", 50);
-        createTotalLatencyPercentileGauge("latencyTotal_percentile_75", 75);
-        createTotalLatencyPercentileGauge("latencyTotal_percentile_90", 90);
-        createTotalLatencyPercentileGauge("latencyTotal_percentile_99", 99);
-        createTotalLatencyPercentileGauge("latencyTotal_percentile_995", 99.5);
-
         // group
         metricsRegistry.newGauge(createMetricName("commandGroup"), new Gauge<String>() {
             @Override

--- a/hystrix-core/src/main/java/com/netflix/hystrix/ExecutionResult.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/ExecutionResult.java
@@ -251,6 +251,13 @@ public class ExecutionResult {
                 failedExecutionException, executionException, executionOccurred, isExecutedInThread, collapserKey);
     }
 
+    /**
+     * Sets the user-observed latency on this result
+     * @param userThreadLatency user-visible latency
+     * @return updated {@link ExecutionResult}
+     * @deprecated will eventually go away with no replacement, as execution time is now practically identical to this value
+     */
+    @Deprecated
     public ExecutionResult markUserThreadCompletion(long userThreadLatency) {
         if (startTimestamp > 0 && !isResponseRejected()) {
             /* execution time (must occur before terminal state otherwise a race condition can occur if requested by client) */

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
@@ -309,7 +309,9 @@ public class HystrixCommandMetrics extends HystrixMetrics {
      * @param percentile
      *            Percentile such as 50, 99, or 99.5.
      * @return int time in milliseconds
+     * @deprecated since 1.5.0, this metrics is practically identical to {@link #getExecutionTimePercentile(double)}/
      */
+    @Deprecated
     public int getTotalTimePercentile(double percentile) {
         return rollingCommandUserLatencyDistributionStream.getLatestPercentile(percentile);
     }
@@ -320,7 +322,9 @@ public class HystrixCommandMetrics extends HystrixMetrics {
      * This uses the same backing data as {@link #getTotalTimePercentile};
      * 
      * @return int time in milliseconds
+     * @deprecated since 1.5.0, this metrics is practically identical to {@link #getExecutionTimeMean()}/
      */
+    @Deprecated
     public int getTotalTimeMean() {
         return rollingCommandUserLatencyDistributionStream.getLatestMean();
     }


### PR DESCRIPTION
Addresses #1074 