### PR TITLE
Fixed NPE on request cache when HystrixRequestContext is not initialized

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixRequestCache.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixRequestCache.java
@@ -102,7 +102,7 @@ public class HystrixRequestCache {
         ValueCacheKey key = getRequestCacheKey(cacheKey);
         if (key != null) {
             if (!HystrixRequestContext.isCurrentThreadInitialized()) {
-                throw new IllegalStateException("Failed to get HystrixRequestVariable. Maybe you need to initialize the HystrixRequestContext?");
+                throw new IllegalStateException("Request caching is not available. Maybe you need to initialize the HystrixRequestContext?");
             }
             /* look for the stored value */
             return (Observable<T>) requestVariableForCache.get(concurrencyStrategy).get(key);

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixRequestCache.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixRequestCache.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 
 import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableDefault;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableHolder;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableLifecycle;
@@ -100,6 +101,9 @@ public class HystrixRequestCache {
     /* package */<T> Observable<T> get(String cacheKey) {
         ValueCacheKey key = getRequestCacheKey(cacheKey);
         if (key != null) {
+            if (!HystrixRequestContext.isCurrentThreadInitialized()) {
+                throw new IllegalStateException("Failed to get HystrixRequestVariable. Maybe you need to initialize the HystrixRequestContext?");
+            }
             /* look for the stored value */
             return (Observable<T>) requestVariableForCache.get(concurrencyStrategy).get(key);
         }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixRequestVariableHolder.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixRequestVariableHolder.java
@@ -65,11 +65,7 @@ public class HystrixRequestVariableHolder<T> {
             }
         }
 
-        T result = (T) requestVariableInstance.get(key).get();
-        if (result == null) {
-            throw new IllegalStateException("Failed to get HystrixRequestVariable. Maybe you need to initialize the HystrixRequestContext?");
-        }
-        return result;
+        return (T) requestVariableInstance.get(key).get();
     }
 
     private static class RVCacheKey {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixRequestVariableHolder.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixRequestVariableHolder.java
@@ -65,7 +65,11 @@ public class HystrixRequestVariableHolder<T> {
             }
         }
 
-        return (T) requestVariableInstance.get(key).get();
+        T result = (T) requestVariableInstance.get(key).get();
+        if (result == null) {
+            throw new IllegalStateException("Failed to get HystrixRequestVariable. Maybe you need to initialize the HystrixRequestContext?");
+        }
+        return result;
     }
 
     private static class RVCacheKey {

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixRequestCacheTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixRequestCacheTest.java
@@ -66,6 +66,14 @@ public class HystrixRequestCacheTest {
         }
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testCacheWithoutContext() {
+        HystrixRequestCache.getInstance(
+            HystrixCommandKey.Factory.asKey("command1"),
+            HystrixConcurrencyStrategyDefault.getInstance()
+        ).get("any");
+    }
+
     @Test
     public void testClearCache() {
         HystrixConcurrencyStrategy strategy = HystrixConcurrencyStrategyDefault.getInstance();


### PR DESCRIPTION
I'm new to Hystrix, so I'm not sure this is the ideal implementation.

This might fix https://github.com/Netflix/Hystrix/issues/995 .