### PR TITLE
Javanica HystrixRequestCacheManager should use the concurrency strategy from HystrixPlugins

### DIFF
--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/cache/HystrixRequestCacheManager.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/cache/HystrixRequestCacheManager.java
@@ -18,7 +18,7 @@ package com.netflix.hystrix.contrib.javanica.cache;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixRequestCache;
 import com.netflix.hystrix.contrib.javanica.cache.annotation.CacheRemove;
-import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategyDefault;
+import com.netflix.hystrix.strategy.HystrixPlugins;
 
 
 /**
@@ -50,6 +50,6 @@ public final class HystrixRequestCacheManager {
                 defaultCacheKeyGenerator.generateCacheKey(context);
         String key = hystrixGeneratedCacheKey.getCacheKey();
         HystrixRequestCache.getInstance(HystrixCommandKey.Factory.asKey(cacheName),
-                HystrixConcurrencyStrategyDefault.getInstance()).clear(key);
+                HystrixPlugins.getInstance().getConcurrencyStrategy()).clear(key);
     }
 }


### PR DESCRIPTION
This can result in unexpected results if the concurrency strategy has overridden getRequestVariable. In my case this resulted in a NPE when clearing the cache entry