### PR TITLE
#1109 Make queue size of MetricJsonListener configurable

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
@@ -135,7 +135,17 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
                 response.setHeader("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate");
                 response.setHeader("Pragma", "no-cache");
 
-                MetricJsonListener jsonListener = new MetricJsonListener();
+                int queueSize = 1000;
+                try {
+                    String q = request.getParameter("queueSize");
+                    if (q != null) {
+                        queueSize = Math.max(Integer.parseInt(q), queueSize);
+                    }
+                } catch (Exception e) {
+                    // ignore if it's not a number
+                }
+
+                MetricJsonListener jsonListener = new MetricJsonListener(queueSize);
                 poller = new HystrixMetricsPoller(jsonListener, delay);
                 // start polling and it will write directly to the output stream
                 poller.start();
@@ -207,7 +217,11 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
          * <p>
          * This is a safety check against a runaway poller causing memory leaks.
          */
-        private final LinkedBlockingQueue<String> jsonMetrics = new LinkedBlockingQueue<String>(1000);
+        private LinkedBlockingQueue<String> jsonMetrics;
+
+        public MetricJsonListener(int queueSize) {
+            jsonMetrics = new LinkedBlockingQueue<String>(queueSize);
+        }
 
         /**
          * Store JSON messages in a queue.

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
@@ -15,22 +15,20 @@
  */
 package com.netflix.hystrix.contrib.metrics.eventstream;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicInteger;
+import com.netflix.config.DynamicIntProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.netflix.config.DynamicIntProperty;
-import com.netflix.config.DynamicPropertyFactory;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Streams Hystrix metrics in text/event-stream format.
@@ -137,14 +135,6 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
                 response.setHeader("Pragma", "no-cache");
 
                 int queueSize = defaultMetricListenerQueueSize.get();
-                try {
-                    String q = request.getParameter("queueSize");
-                    if (q != null) {
-                        queueSize = Integer.parseInt(q);
-                    }
-                } catch (Exception e) {
-                    // ignore if it's not a number
-                }
 
                 MetricJsonListener jsonListener = new MetricJsonListener(queueSize);
                 poller = new HystrixMetricsPoller(jsonListener, delay);

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsStreamServlet.java
@@ -62,6 +62,7 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
     /* used to track number of connections and throttle */
     private static AtomicInteger concurrentConnections = new AtomicInteger(0);
     private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.stream.maxConcurrentConnections", 5);
+    private static DynamicIntProperty defaultMetricListenerQueueSize = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.stream.defaultMetricListenerQueueSize", 1000);
 
     private static volatile boolean isDestroyed = false;
     
@@ -135,11 +136,11 @@ public class HystrixMetricsStreamServlet extends HttpServlet {
                 response.setHeader("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate");
                 response.setHeader("Pragma", "no-cache");
 
-                int queueSize = 1000;
+                int queueSize = defaultMetricListenerQueueSize.get();
                 try {
                     String q = request.getParameter("queueSize");
                     if (q != null) {
-                        queueSize = Math.max(Integer.parseInt(q), queueSize);
+                        queueSize = Integer.parseInt(q);
                     }
                 } catch (Exception e) {
                     // ignore if it's not a number


### PR DESCRIPTION
The queue size of the MetricJsonListener used by the HystrixMetricsStreamServlet has been made configurable in two ways:

- new property "hystrix.stream.defaultMetricListenerQueueSize", which if unspecified will be set to 1000
- optional request parameter "queueSize", which can override the default queue size for each request

The changes have been made on the 1.4.x, but can also be propagated to the 1.5.x RC branch. Please let me know if you need any further information or would like to suggest changes. 