### PR TITLE
Deflaked test of semaphore concurrency

### DIFF
--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -3124,7 +3124,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
                         if (acquired) {
                             try {
                                 numAcquired.incrementAndGet();
-                                Thread.sleep(10);
+                                Thread.sleep(100);
                             } catch (InterruptedException ex) {
                                 ex.printStackTrace();
                             } finally {


### PR DESCRIPTION
Multiple acquisition was the result of 1 command finishing before the last had been invoked.  Increasing the time spent in the command should eliminate this condition