### PR TITLE
Proposal: HystrixRequestContext junit rule

### DIFF
--- a/hystrix-contrib/hystrix-junit/build.gradle
+++ b/hystrix-contrib/hystrix-junit/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+  compile project(':hystrix-core')
+  compile "junit:junit:4.11"
+}

--- a/hystrix-contrib/hystrix-junit/src/main/java/com/hystrix/junit/HystrixRequestContextRule.java
+++ b/hystrix-contrib/hystrix-junit/src/main/java/com/hystrix/junit/HystrixRequestContextRule.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hystrix.junit;
+
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
+import org.junit.rules.ExternalResource;
+
+/**
+ * JUnit rule to be used to simplify tests that require a HystrixRequestContext.
+ *
+ * Example of usage:
+ *
+ * <blockquote>
+ * <pre>
+ *     @Rule
+ *     public HystrixRequestContextRule context = new HystrixRequestContextRule();
+ * </pre>
+ * </blockquote>
+ *
+ */
+public final class HystrixRequestContextRule extends ExternalResource {
+    private HystrixRequestContext context;
+
+    @Override
+    protected void before() throws Throwable {
+        this.context = HystrixRequestContext.initializeContext();
+    }
+
+    @Override
+    protected void after() {
+        if (this.context != null) {
+            this.context.shutdown();
+        }
+    }
+
+    public HystrixRequestContext context() {
+        return this.context;
+    }
+}

--- a/hystrix-contrib/hystrix-junit/src/main/java/com/hystrix/junit/HystrixRequestContextRule.java
+++ b/hystrix-contrib/hystrix-junit/src/main/java/com/hystrix/junit/HystrixRequestContextRule.java
@@ -43,6 +43,7 @@ public final class HystrixRequestContextRule extends ExternalResource {
     protected void after() {
         if (this.context != null) {
             this.context.shutdown();
+            this.context = null;
         }
     }
 

--- a/hystrix-contrib/hystrix-junit/src/test/java/com/hystrix/junit/HystrixRequestContextRuleTest.java
+++ b/hystrix-contrib/hystrix-junit/src/test/java/com/hystrix/junit/HystrixRequestContextRuleTest.java
@@ -1,0 +1,21 @@
+package com.hystrix.junit;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class HystrixRequestContextRuleTest {
+    @Rule
+    public HystrixRequestContextRule request = new HystrixRequestContextRule();
+
+    @Test
+    public void initsContext() {
+        MatcherAssert.assertThat(this.request.context(), CoreMatchers.notNullValue());
+    }
+
+    @Test
+    public void manuallyShutdownContextDontBreak() {
+        this.request.after();
+    }
+}

--- a/hystrix-contrib/hystrix-junit/src/test/java/com/hystrix/junit/HystrixRequestContextRuleTest.java
+++ b/hystrix-contrib/hystrix-junit/src/test/java/com/hystrix/junit/HystrixRequestContextRuleTest.java
@@ -17,5 +17,7 @@ public final class HystrixRequestContextRuleTest {
     @Test
     public void manuallyShutdownContextDontBreak() {
         this.request.after();
+        this.request.after();
+        MatcherAssert.assertThat(this.request.context(), CoreMatchers.nullValue());
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,8 @@ include 'hystrix-core', \
 'hystrix-contrib/hystrix-yammer-metrics-publisher', \
 'hystrix-contrib/hystrix-network-auditor-agent', \
 'hystrix-contrib/hystrix-javanica', \
-'hystrix-dashboard'
+'hystrix-contrib/hystrix-junit', \
+  'hystrix-dashboard'
 
 project(':hystrix-contrib/hystrix-clj').name = 'hystrix-clj'
 project(':hystrix-contrib/hystrix-request-servlet').name = 'hystrix-request-servlet'
@@ -22,3 +23,4 @@ project(':hystrix-contrib/hystrix-codahale-metrics-publisher').name = 'hystrix-c
 project(':hystrix-contrib/hystrix-yammer-metrics-publisher').name = 'hystrix-yammer-metrics-publisher'
 project(':hystrix-contrib/hystrix-network-auditor-agent').name = 'hystrix-network-auditor-agent'
 project(':hystrix-contrib/hystrix-javanica').name = 'hystrix-javanica'
+project(':hystrix-contrib/hystrix-junit').name = 'hystrix-junit'

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@ include 'hystrix-core', \
 'hystrix-contrib/hystrix-network-auditor-agent', \
 'hystrix-contrib/hystrix-javanica', \
 'hystrix-contrib/hystrix-junit', \
-  'hystrix-dashboard'
+'hystrix-dashboard'
 
 project(':hystrix-contrib/hystrix-clj').name = 'hystrix-clj'
 project(':hystrix-contrib/hystrix-request-servlet').name = 'hystrix-request-servlet'


### PR DESCRIPTION
This will make testing commands that requires a `HystrixRequestContext`
easier in JUnit by using its Rule feature.

An example of usage would be something like:

```java
    @Rule
    public HystrixRequestContextRule request = new HystrixRequestContextRule();

    @Test
    public void blah() {
       // exec a HystrixCommand that requires some kind of caching, for example
    }
```

I put it in the `hystrix-contrib` folder, let me know if this is the right thing to do, please.