### PR TITLE
Remove unused method 

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapserProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapserProperties.java
@@ -88,14 +88,6 @@ public abstract class HystrixCollapserProperties {
                 .build();
     }
 
-    @SuppressWarnings("unused")
-    private static HystrixProperty<String> getProperty(String propertyPrefix, HystrixCollapserKey key, String instanceProperty, String builderOverrideValue, String defaultValue) {
-        return forString()
-                .add(propertyPrefix + ".collapser." + key.name() + "." + instanceProperty, builderOverrideValue)
-                .add(propertyPrefix + ".collapser.default." + instanceProperty, defaultValue)
-                .build();
-    }
-
     /**
      * Whether request caching is enabled for {@link HystrixCollapser#execute} and {@link HystrixCollapser#queue} invocations.
      *


### PR DESCRIPTION
HystrixCollapserProperties.getProperty(String, HystrixCollapserKey, String, String, String)

Brought up in #1150 