### PR TITLE
Deprecate getter and setter for unused collapsingEnabled property in Collapser Setter.

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapserProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapserProperties.java
@@ -213,7 +213,7 @@ public abstract class HystrixCollapserProperties {
      * @NotThreadSafe
      */
     public static class Setter {
-        private Boolean collapsingEnabled = null;
+        @Deprecated private Boolean collapsingEnabled = null;
         private Integer maxRequestsInBatch = null;
         private Integer timerDelayInMilliseconds = null;
         private Boolean requestCacheEnabled = null;
@@ -227,6 +227,10 @@ public abstract class HystrixCollapserProperties {
         private Setter() {
         }
 
+        /**
+         * Deprecated because the collapsingEnabled setting doesn't do anything.
+         */
+        @Deprecated
         public Boolean getCollapsingEnabled() {
             return collapsingEnabled;
         }
@@ -267,7 +271,10 @@ public abstract class HystrixCollapserProperties {
             return metricsRollingPercentileWindowBuckets;
         }
 
-
+        /**
+         * Deprecated because the collapsingEnabled setting doesn't do anything.
+         */
+        @Deprecated
         public Setter withCollapsingEnabled(boolean value) {
             this.collapsingEnabled = value;
             return this;


### PR DESCRIPTION
I might be mistaken, but it looks like the "collapsingEnabled" property in HystrixCollapserProperties.Setter doesn't ever get used, which is kind of confusing, since I had assumed it would actually enable/disable collapsing. So I figure a straightforward way to avoid people using it in the future is Deprecation in current versions and removing it 2.x or whatever. Thoughts? I can submit another pull request to remove it from the 2.x branch if that's a good idea.