### PR TITLE
Add test cases for unsubscribe of Hystrix commands before terminal events

### DIFF
--- a/hystrix-core/src/test/java/com/netflix/hystrix/CommonHystrixCommandTests.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/CommonHystrixCommandTests.java
@@ -807,9 +807,9 @@ public abstract class CommonHystrixCommandTests<C extends AbstractTestHystrixCom
                     @Override
                     public void call(C command) {
                         TestableExecutionHook hook = command.getBuilder().executionHook;
-                        assertTrue(hook.commandEmissionsMatch(1, 0, 1));
-                        assertTrue(hook.executionEventsMatch(0, 0, 0));
-                        assertTrue(hook.fallbackEventsMatch(1, 0, 1));
+                        //assertTrue(hook.commandEmissionsMatch(1, 0, 1));
+                        //assertTrue(hook.executionEventsMatch(0, 0, 0));
+                        //assertTrue(hook.fallbackEventsMatch(1, 0, 1));
                         assertEquals("onStart - onFallbackStart - onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - onFallbackSuccess - onSuccess - ", hook.executionSequence.toString());
                     }
                 });
@@ -1488,7 +1488,6 @@ public abstract class CommonHystrixCommandTests<C extends AbstractTestHystrixCom
     /**
      ********************* END SEMAPHORE-ISOLATED Execution Hook Tests ***********************************
      */
-
 
     /**
      * Abstract methods defining a way to instantiate each of the described commands.

--- a/hystrix-core/src/test/java/com/netflix/hystrix/CommonHystrixCommandTests.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/CommonHystrixCommandTests.java
@@ -807,9 +807,9 @@ public abstract class CommonHystrixCommandTests<C extends AbstractTestHystrixCom
                     @Override
                     public void call(C command) {
                         TestableExecutionHook hook = command.getBuilder().executionHook;
-                        //assertTrue(hook.commandEmissionsMatch(1, 0, 1));
-                        //assertTrue(hook.executionEventsMatch(0, 0, 0));
-                        //assertTrue(hook.fallbackEventsMatch(1, 0, 1));
+                        assertTrue(hook.commandEmissionsMatch(1, 0, 1));
+                        assertTrue(hook.executionEventsMatch(0, 0, 0));
+                        assertTrue(hook.fallbackEventsMatch(1, 0, 1));
                         assertEquals("onStart - onFallbackStart - onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - onFallbackSuccess - onSuccess - ", hook.executionSequence.toString());
                     }
                 });


### PR DESCRIPTION
3 fixes in this PR:
* execution semaphore was not being released
* fallback semaphore was not being released
* isExecutionComplete was not set to true