### PR TITLE
Fixing unsubscription races by modeling explicit FSMs for command and thread execution state

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCounters.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCounters.java
@@ -24,12 +24,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class HystrixCounters {
     private static final AtomicInteger concurrentThreadsExecuting = new AtomicInteger(0);
 
-    /* package-private */ static void incrementGlobalConcurrentThreads() {
-        concurrentThreadsExecuting.incrementAndGet();
+    /* package-private */ static int incrementGlobalConcurrentThreads() {
+        return concurrentThreadsExecuting.incrementAndGet();
     }
 
-    /* package-private */ static void decrementGlobalConcurrentThreads() {
-        concurrentThreadsExecuting.decrementAndGet();
+    /* package-private */ static int decrementGlobalConcurrentThreads() {
+        return concurrentThreadsExecuting.decrementAndGet();
     }
 
     /**

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -3763,7 +3763,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
                         assertTrue(hook.fallbackEventsMatch(0, 0, 0));
                         assertEquals(HystrixBadRequestException.class, hook.getCommandException().getClass());
                         assertEquals(HystrixBadRequestException.class, hook.getExecutionException().getClass());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onError - onThreadComplete - ", hook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onError - ", hook.executionSequence.toString());
                     }
                 });
     }
@@ -3798,7 +3798,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
                         assertEquals(RuntimeException.class, hook.getCommandException().getClass());
                         assertEquals(RuntimeException.class, hook.getExecutionException().getClass());
                         assertNull(hook.getFallbackException());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onError - onThreadComplete - ", hook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onError - ", hook.executionSequence.toString());
                     }
                 });
     }
@@ -3829,7 +3829,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
                         assertTrue(hook.executionEventsMatch(0, 1, 0));
                         assertTrue(hook.fallbackEventsMatch(1, 0, 1));
                         assertEquals(RuntimeException.class, hook.getExecutionException().getClass());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onFallbackStart - onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - onFallbackSuccess - onThreadComplete - onSuccess - ", hook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onFallbackStart - onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - onFallbackSuccess - onSuccess - ", hook.executionSequence.toString());
                     }
                 });
     }
@@ -3862,7 +3862,7 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
                         assertEquals(RuntimeException.class, hook.getCommandException().getClass());
                         assertEquals(RuntimeException.class, hook.getExecutionException().getClass());
                         assertEquals(RuntimeException.class, hook.getFallbackException().getClass());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", hook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onFallbackStart - onFallbackError - onError - ", hook.executionSequence.toString());
                     }
                 });
     }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -2108,12 +2108,12 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                                 "onExecutionEmit - !onRunSuccess - !onComplete - onEmit - " +
                                 "onExecutionEmit - !onRunSuccess - !onComplete - onEmit - " +
                                 "onExecutionEmit - !onRunSuccess - !onComplete - onEmit - " +
-                                "onExecutionError - !onRunError - onFallbackStart - " +
+                                "onExecutionError - !onRunError - onThreadComplete - onFallbackStart - " +
                                 "onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - " +
                                 "onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - " +
                                 "onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - " +
                                 "onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - " +
-                                "onFallbackSuccess - onThreadComplete - onSuccess - ", command.getBuilder().executionHook.executionSequence.toString());
+                                "onFallbackSuccess - onSuccess - ", command.getBuilder().executionHook.executionSequence.toString());
                     }
                 });
     }
@@ -2144,7 +2144,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                         assertTrue(hook.fallbackEventsMatch(0, 0, 0));
                         assertEquals(HystrixBadRequestException.class, hook.getCommandException().getClass());
                         assertEquals(HystrixBadRequestException.class, hook.getExecutionException().getClass());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onError - onThreadComplete - ", command.getBuilder().executionHook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onError - ", command.getBuilder().executionHook.executionSequence.toString());
                     }
                 });
     }
@@ -2177,7 +2177,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                         assertEquals(RuntimeException.class, hook.getCommandException().getClass());
                         assertEquals(RuntimeException.class, hook.getExecutionException().getClass());
                         assertNull(hook.getFallbackException());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onError - onThreadComplete - ", command.getBuilder().executionHook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onError - ", command.getBuilder().executionHook.executionSequence.toString());
                     }
                 });
     }
@@ -2208,7 +2208,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                         assertTrue(hook.executionEventsMatch(0, 1, 0));
                         assertTrue(hook.fallbackEventsMatch(1, 0, 1));
                         assertEquals(RuntimeException.class, hook.getExecutionException().getClass());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onFallbackStart - onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - onFallbackSuccess - onThreadComplete - onSuccess - ", command.getBuilder().executionHook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onFallbackStart - onFallbackEmit - !onFallbackSuccess - !onComplete - onEmit - onFallbackSuccess - onSuccess - ", command.getBuilder().executionHook.executionSequence.toString());
                     }
                 });
     }
@@ -2241,7 +2241,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                         assertEquals(RuntimeException.class, hook.getCommandException().getClass());
                         assertEquals(RuntimeException.class, hook.getExecutionException().getClass());
                         assertEquals(RuntimeException.class, hook.getFallbackException().getClass());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.getBuilder().executionHook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onFallbackStart - onFallbackError - onError - ", command.getBuilder().executionHook.executionSequence.toString());
                     }
                 });
     }
@@ -2274,7 +2274,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                         assertEquals(RuntimeException.class, hook.getCommandException().getClass());
                         assertEquals(RuntimeException.class, hook.getExecutionException().getClass());
                         assertEquals(RuntimeException.class, hook.getFallbackException().getClass());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.getBuilder().executionHook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onFallbackStart - onFallbackError - onError - ", command.getBuilder().executionHook.executionSequence.toString());
                     }
                 });
     }
@@ -2307,7 +2307,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                         assertEquals(RuntimeException.class, hook.getCommandException().getClass());
                         assertEquals(RuntimeException.class, hook.getExecutionException().getClass());
                         assertEquals(RuntimeException.class, hook.getFallbackException().getClass());
-                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onFallbackStart - onFallbackError - onError - onThreadComplete - ", command.getBuilder().executionHook.executionSequence.toString());
+                        assertEquals("onStart - onThreadStart - !onRunStart - onExecutionStart - onExecutionError - !onRunError - onThreadComplete - onFallbackStart - onFallbackError - onError - ", command.getBuilder().executionHook.executionSequence.toString());
                     }
                 });
     }


### PR DESCRIPTION
 * Also made onThreadComplete hook fire as soon as user-provided execution emits terminal or is unsubscribed