### PR TITLE
Interrupt execution thread on HystrixCommand#queue()#cancel(true)

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandProperties.java
@@ -50,6 +50,7 @@ public abstract class HystrixCommandProperties {
     private static final Boolean default_executionTimeoutEnabled = true;
     private static final ExecutionIsolationStrategy default_executionIsolationStrategy = ExecutionIsolationStrategy.THREAD;
     private static final Boolean default_executionIsolationThreadInterruptOnTimeout = true;
+    private static final Boolean default_executionIsolationThreadInterruptOnFutureCancel = false;
     private static final Boolean default_metricsRollingPercentileEnabled = true;
     private static final Boolean default_requestCacheEnabled = true;
     private static final Integer default_fallbackIsolationSemaphoreMaxConcurrentRequests = 10;
@@ -77,6 +78,7 @@ public abstract class HystrixCommandProperties {
     private final HystrixProperty<Integer> fallbackIsolationSemaphoreMaxConcurrentRequests; // Number of permits for fallback semaphore
     private final HystrixProperty<Boolean> fallbackEnabled; // Whether fallback should be attempted.
     private final HystrixProperty<Boolean> executionIsolationThreadInterruptOnTimeout; // Whether an underlying Future/Thread (when runInSeparateThread == true) should be interrupted after a timeout
+    private final HystrixProperty<Boolean> executionIsolationThreadInterruptOnFutureCancel; // Whether canceling an underlying Future/Thread (when runInSeparateThread == true) should interrupt the execution thread
     private final HystrixProperty<Integer> metricsRollingStatisticalWindowInMilliseconds; // milliseconds back that will be tracked
     private final HystrixProperty<Integer> metricsRollingStatisticalWindowBuckets; // number of buckets in the statisticalWindow
     private final HystrixProperty<Boolean> metricsRollingPercentileEnabled; // Whether monitoring should be enabled (SLA and Tracers).
@@ -121,6 +123,7 @@ public abstract class HystrixCommandProperties {
         this.executionTimeoutInMilliseconds = getProperty(propertyPrefix, key, "execution.isolation.thread.timeoutInMilliseconds", builder.getExecutionIsolationThreadTimeoutInMilliseconds(), default_executionTimeoutInMilliseconds);
         this.executionTimeoutEnabled = getProperty(propertyPrefix, key, "execution.timeout.enabled", builder.getExecutionTimeoutEnabled(), default_executionTimeoutEnabled);
         this.executionIsolationThreadInterruptOnTimeout = getProperty(propertyPrefix, key, "execution.isolation.thread.interruptOnTimeout", builder.getExecutionIsolationThreadInterruptOnTimeout(), default_executionIsolationThreadInterruptOnTimeout);
+        this.executionIsolationThreadInterruptOnFutureCancel = getProperty(propertyPrefix, key, "execution.isolation.thread.interruptOnFutureCancel", builder.getExecutionIsolationThreadInterruptOnFutureCancel(), default_executionIsolationThreadInterruptOnFutureCancel);
         this.executionIsolationSemaphoreMaxConcurrentRequests = getProperty(propertyPrefix, key, "execution.isolation.semaphore.maxConcurrentRequests", builder.getExecutionIsolationSemaphoreMaxConcurrentRequests(), default_executionIsolationSemaphoreMaxConcurrentRequests);
         this.fallbackIsolationSemaphoreMaxConcurrentRequests = getProperty(propertyPrefix, key, "fallback.isolation.semaphore.maxConcurrentRequests", builder.getFallbackIsolationSemaphoreMaxConcurrentRequests(), default_fallbackIsolationSemaphoreMaxConcurrentRequests);
         this.fallbackEnabled = getProperty(propertyPrefix, key, "fallback.enabled", builder.getFallbackEnabled(), default_fallbackEnabled);
@@ -238,6 +241,17 @@ public abstract class HystrixCommandProperties {
      */
     public HystrixProperty<Boolean> executionIsolationThreadInterruptOnTimeout() {
         return executionIsolationThreadInterruptOnTimeout;
+    }
+
+    /**
+     * Whether the execution thread should be interrupted if the execution observable is unsubscribed or the future is cancelled via {@link Future#cancel(true)}).
+     * <p>
+     * Applicable only when {@link #executionIsolationStrategy()} == THREAD.
+     * 
+     * @return {@code HystrixProperty<Boolean>}
+     */
+    public HystrixProperty<Boolean> executionIsolationThreadInterruptOnFutureCancel() {
+        return executionIsolationThreadInterruptOnFutureCancel;
     }
 
     /**
@@ -531,6 +545,7 @@ public abstract class HystrixCommandProperties {
         private Integer executionIsolationSemaphoreMaxConcurrentRequests = null;
         private ExecutionIsolationStrategy executionIsolationStrategy = null;
         private Boolean executionIsolationThreadInterruptOnTimeout = null;
+        private Boolean executionIsolationThreadInterruptOnFutureCancel = null;
         private Integer executionTimeoutInMilliseconds = null;
         private Boolean executionTimeoutEnabled = null;
         private Integer fallbackIsolationSemaphoreMaxConcurrentRequests = null;
@@ -585,7 +600,11 @@ public abstract class HystrixCommandProperties {
             return executionIsolationThreadInterruptOnTimeout;
         }
 
-        /**
+        public Boolean getExecutionIsolationThreadInterruptOnFutureCancel() {
+			return executionIsolationThreadInterruptOnFutureCancel;
+		}
+
+		/**
          * @deprecated As of 1.4.0, use {@link #getExecutionTimeoutInMilliseconds()}
          */
         @Deprecated
@@ -687,6 +706,11 @@ public abstract class HystrixCommandProperties {
 
         public Setter withExecutionIsolationThreadInterruptOnTimeout(boolean value) {
             this.executionIsolationThreadInterruptOnTimeout = value;
+            return this;
+        }
+
+        public Setter withExecutionIsolationThreadInterruptOnFutureCancel(boolean value) {
+            this.executionIsolationThreadInterruptOnFutureCancel = value;
             return this;
         }
 

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandPropertiesTest.java
@@ -36,6 +36,7 @@ public class HystrixCommandPropertiesTest {
                 .withExecutionTimeoutEnabled(true)
                 .withExecutionIsolationStrategy(ExecutionIsolationStrategy.THREAD) // we want thread execution by default in tests
                 .withExecutionIsolationThreadInterruptOnTimeout(true)
+                .withExecutionIsolationThreadInterruptOnFutureCancel(true)
                 .withCircuitBreakerForceOpen(false) // we don't want short-circuiting by default
                 .withCircuitBreakerErrorThresholdPercentage(40) // % of 'marks' that must be failed to trip the circuit
                 .withMetricsRollingStatisticalWindowInMilliseconds(5000)// milliseconds back that will be tracked
@@ -109,6 +110,11 @@ public class HystrixCommandPropertiesTest {
             @Override
             public HystrixProperty<Boolean> executionIsolationThreadInterruptOnTimeout() {
                 return HystrixProperty.Factory.asProperty(builder.getExecutionIsolationThreadInterruptOnTimeout());
+            }
+
+            @Override
+            public HystrixProperty<Boolean> executionIsolationThreadInterruptOnFutureCancel() {
+                return HystrixProperty.Factory.asProperty(builder.getExecutionIsolationThreadInterruptOnFutureCancel());
             }
 
             @Override


### PR DESCRIPTION
The implementation of java.util.concurrent.Future returned by com.netflix.hystrix.HystrixCommand#queue()#cancel(boolean mayInterruptIfRunning) ignores the "mayInterruptIfRunning" flag and never calls Thread#interrupt() on Hystrix Execution Thread running the command's run() method. This complicates the handling of situations where commands have to be interrupted. I am not sure it would make sense to enable the interruption of the getFallback() method, as well-behaved fallbacks probably should not do stuff that may require interruption.

The interruption of the execution thread IMO makes sense only through the invocation of the Future#cancel(boolean) method. The command should not be interruptible if executed via com.netflix.hystrix.HystrixCommand#execute() (blocking invocation forfeits interruption) or com.netflix.hystrix.AbstractCommand#observe() (interruption does not seem to me to be a concept you'd want to mix in a pure reactive consumption of a command; for that, you could check for unsubscription). As the current behavior is never to interrupt the running thread, we should probably hide the new behavior behind a command property with default false to preserve the previous behavior.

[Please notice that the change linked in this pull request is alpha-quality at best and is meant to collect feedback on (1) if it makes sense at all to work on this and (2) if there are better places where the lifecycle can be extended to obtain the intended result:-) ]