### PR TITLE
Fix race condition in HystrixThreadPoolKey.asKey method

### DIFF
--- a/hystrix-core/build.gradle
+++ b/hystrix-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile 'com.netflix.archaius:archaius-core:0.4.1'
     compile 'io.reactivex:rxjava:1.1.5'
     compile 'org.slf4j:slf4j-api:1.7.0'
-	compile 'org.hdrhistogram:HdrHistogram:2.1.7'
+    compile 'org.hdrhistogram:HdrHistogram:2.1.7'
     testCompile 'junit:junit-dep:4.10'
     testCompile project(':hystrix-junit')
 }
@@ -16,8 +16,8 @@ javadoc {
     // we do not want the com.netflix.hystrix.util package include
     exclude '**/util/**'
 
-        options {
-	doclet = "org.benjchristensen.doclet.DocletExclude"
+    options {
+        doclet = "org.benjchristensen.doclet.DocletExclude"
         docletpath = [rootProject.file('./gradle/doclet-exclude.jar')]
         stylesheetFile = rootProject.file('./gradle/javadocStyleSheet.css')
         windowTitle = "Hystrix Javadoc ${project.version}"
@@ -37,12 +37,12 @@ jar {
 }
 
 jmh {
-	fork = 10
-	iterations = 3
-	jmhVersion = '1.11.2'
-	profilers = ['gc']
-	threads = 8
-	warmup = '1s'
-	warmupBatchSize = 1
-	warmupIterations = 5
+    fork = 10
+    iterations = 3
+    jmhVersion = '1.11.2'
+    profilers = ['gc']
+    threads = 8
+    warmup = '1s'
+    warmupBatchSize = 1
+    warmupIterations = 5
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixKey.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixKey.java
@@ -1,0 +1,34 @@
+package com.netflix.hystrix;
+
+/**
+ * Basic class for hystrix keys
+ */
+public interface HystrixKey {
+    /**
+     * The word 'name' is used instead of 'key' so that Enums can implement this interface and it work natively.
+     *
+     * @return String
+     */
+    String name();
+
+    /**
+     * Default implementation of the interface
+     */
+    abstract class HystrixKeyDefault implements HystrixKey {
+        private final String name;
+
+        public HystrixKeyDefault(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolKey.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolKey.java
@@ -15,31 +15,27 @@
  */
 package com.netflix.hystrix;
 
-import java.util.concurrent.ConcurrentHashMap;
+import com.netflix.hystrix.util.InternMap;
 
 /**
  * A key to represent a {@link HystrixThreadPool} for monitoring, metrics publishing, caching and other such uses.
  * <p>
  * This interface is intended to work natively with Enums so that implementing code can be an enum that implements this interface.
  */
-public interface HystrixThreadPoolKey {
-
-    /**
-     * The 'key' used as the name for a thread-pool.
-     * <p>
-     * The word 'name' is used instead of 'key' so that Enums can implement this interface and it work natively.
-     * 
-     * @return String
-     */
-    public String name();
-
-    public static class Factory {
-
+public interface HystrixThreadPoolKey extends HystrixKey {
+    class Factory {
         private Factory() {
         }
 
         // used to intern instances so we don't keep re-creating them millions of times for the same key
-        private static final ConcurrentHashMap<String, HystrixThreadPoolKey> intern = new ConcurrentHashMap<String, HystrixThreadPoolKey>();
+        private static final InternMap<String, HystrixThreadPoolKey> intern
+                = new InternMap<String, HystrixThreadPoolKey>(
+                new InternMap.ValueConstructor<String, HystrixThreadPoolKey>() {
+                    @Override
+                    public HystrixThreadPoolKey create(String key) {
+                        return new HystrixThreadPoolKeyDefault(key);
+                    }
+                });
 
         /**
          * Retrieve (or create) an interned HystrixThreadPoolKey instance for a given name.
@@ -48,32 +44,12 @@ public interface HystrixThreadPoolKey {
          * @return HystrixThreadPoolKey instance that is interned (cached) so a given name will always retrieve the same instance.
          */
         public static HystrixThreadPoolKey asKey(String name) {
-            HystrixThreadPoolKey existingKey = intern.get(name);
-            HystrixThreadPoolKey newKey = null;
-            if (existingKey == null) {
-                newKey = new HystrixThreadPoolKeyDefault(name);
-                existingKey = intern.putIfAbsent(name, newKey);
-            }
-            return existingKey != null ? existingKey : newKey;
-
+           return intern.interned(name);
         }
 
-        private static class HystrixThreadPoolKeyDefault implements HystrixThreadPoolKey {
-
-            private final String name;
-
-            private HystrixThreadPoolKeyDefault(String name) {
-                this.name = name;
-            }
-
-            @Override
-            public String name() {
-                return name;
-            }
-            
-            @Override
-            public String toString() {
-            	return name;
+        private static class HystrixThreadPoolKeyDefault extends HystrixKeyDefault implements HystrixThreadPoolKey {
+            public HystrixThreadPoolKeyDefault(String name) {
+                super(name);
             }
         }
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolKey.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolKey.java
@@ -39,7 +39,7 @@ public interface HystrixThreadPoolKey {
         }
 
         // used to intern instances so we don't keep re-creating them millions of times for the same key
-        private static ConcurrentHashMap<String, HystrixThreadPoolKey> intern = new ConcurrentHashMap<String, HystrixThreadPoolKey>();
+        private static final ConcurrentHashMap<String, HystrixThreadPoolKey> intern = new ConcurrentHashMap<String, HystrixThreadPoolKey>();
 
         /**
          * Retrieve (or create) an interned HystrixThreadPoolKey instance for a given name.
@@ -48,17 +48,19 @@ public interface HystrixThreadPoolKey {
          * @return HystrixThreadPoolKey instance that is interned (cached) so a given name will always retrieve the same instance.
          */
         public static HystrixThreadPoolKey asKey(String name) {
-            HystrixThreadPoolKey k = intern.get(name);
-            if (k == null) {
-                k = new HystrixThreadPoolKeyDefault(name);
-                intern.putIfAbsent(name, k);
+            HystrixThreadPoolKey existingKey = intern.get(name);
+            HystrixThreadPoolKey newKey = null;
+            if (existingKey == null) {
+                newKey = new HystrixThreadPoolKeyDefault(name);
+                existingKey = intern.putIfAbsent(name, newKey);
             }
-            return k;
+            return existingKey != null ? existingKey : newKey;
+
         }
 
         private static class HystrixThreadPoolKeyDefault implements HystrixThreadPoolKey {
 
-            private String name;
+            private final String name;
 
             private HystrixThreadPoolKeyDefault(String name) {
                 this.name = name;

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/InternMap.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/InternMap.java
@@ -1,0 +1,34 @@
+package com.netflix.hystrix.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Utility to have 'intern' - like functionality, which holds single instance of wrapper for a given key
+ */
+public class InternMap<K, V> {
+    private final ConcurrentMap<K, V> storage = new ConcurrentHashMap<K, V>();
+    private final ValueConstructor<K, V> valueConstructor;
+
+    public interface ValueConstructor<K, V> {
+        V create(K key);
+    }
+
+    public InternMap(ValueConstructor<K, V> valueConstructor) {
+        this.valueConstructor = valueConstructor;
+    }
+
+    public V interned(K key) {
+        V existingKey = storage.get(key);
+        V newKey = null;
+        if (existingKey == null) {
+            newKey = valueConstructor.create(key);
+            existingKey = storage.putIfAbsent(key, newKey);
+        }
+        return existingKey != null ? existingKey : newKey;
+    }
+
+    public int size() {
+        return storage.size();
+    }
+}


### PR DESCRIPTION
Fix rare case when this method would return different values for the same key

The problem would happen when:

1. Thread1: No such key when intern.get(name), so k was null
2. Thread1: We would enter if-statement
3. Thread2: Other thread would add key to intern map
4. Thread1: We will not put new key to intern map, but we will return newly created value instead of one stored in map