### PR TITLE
Prevent duplicate arguments from getting into a single collapser RequestBatch

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapser.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCollapser.java
@@ -379,7 +379,6 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
      *         {@link #mapResponseToRequests} to transform the {@code <BatchReturnType>} into {@code <ResponseType>}
      */
     public Observable<ResponseType> toObservable(Scheduler observeOn) {
-
         return Observable.defer(new Func0<Observable<ResponseType>>() {
             @Override
             public Observable<ResponseType> call() {
@@ -399,20 +398,12 @@ public abstract class HystrixCollapser<BatchReturnType, ResponseType, RequestArg
                 Observable<ResponseType> response = requestCollapser.submitRequest(getRequestArgument());
 
                 if (isRequestCacheEnabled && cacheKey != null) {
-                    /*
-                     * A race can occur here with multiple threads queuing but only one will be cached.
-                     * This means we can have some duplication of requests in a thread-race but we're okay
-                     * with having some inefficiency in duplicate requests in the same batch
-                     * and then subsequent requests will retrieve a previously cached Observable.
-                     *
-                     * If this is an issue we can make a lazy-future that gets set in the cache
-                     * then only the winning 'put' will be invoked to actually call 'submitRequest'
-                     */
                     HystrixCachedObservable<ResponseType> toCache = HystrixCachedObservable.from(response);
                     HystrixCachedObservable<ResponseType> fromCache = requestCache.putIfAbsent(cacheKey, toCache);
                     if (fromCache == null) {
                         return toCache.toObservable();
                     } else {
+                        toCache.unsubscribe();
                         return fromCache.toObservable();
                     }
                 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestSubject.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/collapser/CollapsedRequestSubject.java
@@ -49,19 +49,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
     private final ReplaySubject<T> subject = ReplaySubject.create();
     private final Observable<T> subjectWithAccounting;
 
-    private volatile boolean subscribedTo = false;
     private volatile int outstandingSubscriptions = 0;
 
     public CollapsedRequestSubject(final R arg, final RequestBatch<?, T, R> containingBatch) {
+        if (arg == RequestCollapser.NULL_SENTINEL) {
+            this.argument = null;
+        } else {
+            this.argument = arg;
+        }
         this.subjectWithAccounting = subject
                 .doOnSubscribe(new Action0() {
                     @Override
                     public void call() {
                         outstandingSubscriptions++;
-                        if (!subscribedTo) {
-                            subscribedTo = true;
-                            //containingBatch.add(arg, this);
-                        }
                     }
                 })
                 .doOnUnsubscribe(new Action0() {
@@ -73,7 +73,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
                         }
                     }
                 });
-        this.argument = arg;
     }
 
     public CollapsedRequestSubject(final R arg) {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/properties/HystrixPropertiesFactory.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/properties/HystrixPropertiesFactory.java
@@ -43,6 +43,7 @@ public class HystrixPropertiesFactory {
     public static void reset() {
         commandProperties.clear();
         threadPoolProperties.clear();
+        collapserProperties.clear();
     }
 
     // String is CommandKey.name() (we can't use CommandKey directly as we can't guarantee it implements hashcode/equals correctly)


### PR DESCRIPTION
If this is attempted, then 1 of 2 things can occur:
If request-caching is on: the response for the 2nd-nth instance of the argument is the same as the first
If off: the response for the 2nd-nth instance of the argument is an error

This fixes the failing unit test supplied in #1176 