### PR TITLE
Allow scalar commands (HystrixCommand) to set completion state on an onNext

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -363,6 +363,19 @@ import java.util.concurrent.atomic.AtomicReference;
     public Observable<R> toObservable() {
         final AbstractCommand<R> _cmd = this;
 
+        final Action1<R> scalarEmitCleanup = new Action1<R>() {
+            @Override
+            public void call(R r) {
+                if (commandIsScalar()) {
+                    if (_cmd.commandState.compareAndSet(CommandState.OBSERVABLE_CHAIN_CREATED, CommandState.TERMINAL)) {
+                        handleCommandEnd(false); //user code never ran
+                    } else if (_cmd.commandState.compareAndSet(CommandState.USER_CODE_EXECUTED, CommandState.TERMINAL)) {
+                        handleCommandEnd(true); //user code did run
+                    }
+                }
+            }
+        };
+
         //doOnCompleted handler already did all of the SUCCESS work
         //doOnError handler already did all of the FAILURE/TIMEOUT/REJECTION/BAD_REQUEST work
         final Action0 terminateCommandCleanup = new Action0() {
@@ -370,9 +383,9 @@ import java.util.concurrent.atomic.AtomicReference;
             @Override
             public void call() {
                 if (_cmd.commandState.compareAndSet(CommandState.OBSERVABLE_CHAIN_CREATED, CommandState.TERMINAL)) {
-                    handleCommandEnd(_cmd, false); //user code never ran
+                    handleCommandEnd(false); //user code never ran
                 } else if (_cmd.commandState.compareAndSet(CommandState.USER_CODE_EXECUTED, CommandState.TERMINAL)) {
-                    handleCommandEnd(_cmd, true); //user code did run
+                    handleCommandEnd(true); //user code did run
                 }
             }
         };
@@ -385,12 +398,12 @@ import java.util.concurrent.atomic.AtomicReference;
                     _cmd.eventNotifier.markEvent(HystrixEventType.CANCELLED, _cmd.commandKey);
                     _cmd.executionResultAtTimeOfCancellation = _cmd.executionResult
                             .addEvent((int) (System.currentTimeMillis() - _cmd.commandStartTimestamp), HystrixEventType.CANCELLED);
-                    handleCommandEnd(_cmd, false); //user code never ran
+                    handleCommandEnd(false); //user code never ran
                 } else if (_cmd.commandState.compareAndSet(CommandState.USER_CODE_EXECUTED, CommandState.UNSUBSCRIBED)) {
                     _cmd.eventNotifier.markEvent(HystrixEventType.CANCELLED, _cmd.commandKey);
                     _cmd.executionResultAtTimeOfCancellation = _cmd.executionResult
                             .addEvent((int) (System.currentTimeMillis() - _cmd.commandStartTimestamp), HystrixEventType.CANCELLED);
-                    handleCommandEnd(_cmd, true); //user code did run
+                    handleCommandEnd(true); //user code did run
                 }
             }
         };
@@ -468,7 +481,6 @@ import java.util.concurrent.atomic.AtomicReference;
                         Observable.defer(applyHystrixSemantics)
                                 .map(wrapWithAllOnNextHooks);
 
-
                 Observable<R> afterCache;
 
                 // put in cache
@@ -490,6 +502,7 @@ import java.util.concurrent.atomic.AtomicReference;
                 }
 
                 return afterCache
+                        .doOnNext(scalarEmitCleanup)
                         .doOnTerminate(terminateCommandCleanup)     // perform cleanup once (either on normal terminal state (this line), or unsubscribe (next line))
                         .doOnUnsubscribe(unsubscribeCommandCleanup) // perform cleanup once
                         .doOnCompleted(fireOnCompletedHook);
@@ -541,6 +554,8 @@ import java.util.concurrent.atomic.AtomicReference;
         }
     }
 
+    abstract protected boolean commandIsScalar();
+
     /**
      * This decorates "Hystrix" functionality around the run() Observable.
      *
@@ -556,17 +571,26 @@ import java.util.concurrent.atomic.AtomicReference;
                     executionResult = executionResult.addEvent(HystrixEventType.EMIT);
                     eventNotifier.markEvent(HystrixEventType.EMIT, commandKey);
                 }
+                if (commandIsScalar()) {
+                    long latency = System.currentTimeMillis() - executionResult.getStartTimestamp();
+                    eventNotifier.markCommandExecution(getCommandKey(), properties.executionIsolationStrategy().get(), (int) latency, executionResult.getOrderedList());
+                    eventNotifier.markEvent(HystrixEventType.SUCCESS, commandKey);
+                    executionResult = executionResult.addEvent((int) latency, HystrixEventType.SUCCESS);
+                    circuitBreaker.markSuccess();
+                }
             }
         };
 
-        final Action0 markCompleted = new Action0() {
+        final Action0 markOnCompleted = new Action0() {
             @Override
             public void call() {
-                long latency = System.currentTimeMillis() - executionResult.getStartTimestamp();
-                eventNotifier.markEvent(HystrixEventType.SUCCESS, commandKey);
-                executionResult = executionResult.addEvent((int) latency, HystrixEventType.SUCCESS);
-                circuitBreaker.markSuccess();
-                eventNotifier.markCommandExecution(getCommandKey(), properties.executionIsolationStrategy().get(), (int) latency, executionResult.getOrderedList());
+                if (!commandIsScalar()) {
+                    long latency = System.currentTimeMillis() - executionResult.getStartTimestamp();
+                    eventNotifier.markCommandExecution(getCommandKey(), properties.executionIsolationStrategy().get(), (int) latency, executionResult.getOrderedList());
+                    eventNotifier.markEvent(HystrixEventType.SUCCESS, commandKey);
+                    executionResult = executionResult.addEvent((int) latency, HystrixEventType.SUCCESS);
+                    circuitBreaker.markSuccess();
+                }
             }
         };
 
@@ -611,7 +635,7 @@ import java.util.concurrent.atomic.AtomicReference;
         }
 
         return execution.doOnNext(markEmits)
-                .doOnCompleted(markCompleted)
+                .doOnCompleted(markOnCompleted)
                 .onErrorResumeNext(handleFallback)
                 .doOnEach(setRequestContext);
     }
@@ -877,9 +901,9 @@ import java.util.concurrent.atomic.AtomicReference;
                     @Override
                     public void call() {
                         if (commandState.compareAndSet(CommandState.OBSERVABLE_CHAIN_CREATED, CommandState.TERMINAL)) {
-                            cleanUpAfterResponseFromCache(_cmd, false); //user code never ran
+                            cleanUpAfterResponseFromCache(false); //user code never ran
                         } else if (commandState.compareAndSet(CommandState.USER_CODE_EXECUTED, CommandState.TERMINAL)) {
-                            cleanUpAfterResponseFromCache(_cmd, true); //user code did run
+                            cleanUpAfterResponseFromCache(true); //user code did run
                         }
                     }
                 })
@@ -887,15 +911,15 @@ import java.util.concurrent.atomic.AtomicReference;
                     @Override
                     public void call() {
                         if (commandState.compareAndSet(CommandState.OBSERVABLE_CHAIN_CREATED, CommandState.UNSUBSCRIBED)) {
-                            cleanUpAfterResponseFromCache(_cmd, false); //user code never ran
+                            cleanUpAfterResponseFromCache(false); //user code never ran
                         } else if (commandState.compareAndSet(CommandState.USER_CODE_EXECUTED, CommandState.UNSUBSCRIBED)) {
-                            cleanUpAfterResponseFromCache(_cmd, true); //user code did run
+                            cleanUpAfterResponseFromCache(true); //user code did run
                         }
                     }
                 });
     }
 
-    private void cleanUpAfterResponseFromCache(final AbstractCommand<R> _cmd, boolean commandExecutionStarted) {
+    private void cleanUpAfterResponseFromCache(boolean commandExecutionStarted) {
         Reference<TimerListener> tl = timeoutTimer.get();
         if (tl != null) {
             tl.clear();
@@ -912,7 +936,7 @@ import java.util.concurrent.atomic.AtomicReference;
         eventNotifier.markEvent(HystrixEventType.RESPONSE_FROM_CACHE, commandKey);
     }
 
-    private void handleCommandEnd(final AbstractCommand _cmd, boolean commandExecutionStarted) {
+    private void handleCommandEnd(boolean commandExecutionStarted) {
         Reference<TimerListener> tl = timeoutTimer.get();
         if (tl != null) {
             tl.clear();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommand.java
@@ -404,4 +404,8 @@ public abstract class HystrixCommand<R> extends AbstractCommand<R> implements Hy
         return "getFallback";
     }
 
+    @Override
+    protected boolean commandIsScalar() {
+        return true;
+    }
 }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandResponseFromCache.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandResponseFromCache.java
@@ -21,27 +21,24 @@ public class HystrixCommandResponseFromCache<R> extends HystrixCachedObservable<
                 .doOnError(new Action1<Throwable>() {
                     @Override
                     public void call(Throwable throwable) {
-                        if (!completionLogicRun.get()) {
+                        if (completionLogicRun.compareAndSet(false, true)) {
                             commandCompleted(commandToCopyStateInto);
-                            completionLogicRun.set(true);
                         }
                     }
                 })
                 .doOnCompleted(new Action0() {
                     @Override
                     public void call() {
-                        if (!completionLogicRun.get()) {
+                        if (completionLogicRun.compareAndSet(false, true)) {
                             commandCompleted(commandToCopyStateInto);
-                            completionLogicRun.set(true);
                         }
                     }
                 })
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {
-                        if (!completionLogicRun.get()) {
+                        if (completionLogicRun.compareAndSet(false, true)) {
                             commandUnsubscribed(commandToCopyStateInto);
-                            completionLogicRun.set(true);
                         }
                     }
                 });

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixObservableCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixObservableCommand.java
@@ -67,6 +67,11 @@ public abstract class HystrixObservableCommand<R> extends AbstractCommand<R> imp
         return "resumeWithFallback";
     }
 
+    @Override
+    protected boolean commandIsScalar() {
+        return false;
+    }
+
     /**
      * Construct a {@link HystrixObservableCommand} with defined {@link Setter} that allows injecting property and strategy overrides and other optional arguments.
      * <p>

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
@@ -358,7 +358,7 @@ public class HystrixCircuitBreakerTest {
     public void testCircuitClosedAfterSuccess() {
         String key = "cmd-G";
         try {
-            int sleepWindow = 20;
+            int sleepWindow = 100;
             HystrixCommand<Boolean> cmd1 = new FailureCommand(key, 1, sleepWindow);
             HystrixCircuitBreaker cb = cmd1.circuitBreaker;
 
@@ -397,6 +397,8 @@ public class HystrixCircuitBreakerTest {
             asyncResult.toBlocking().single();
 
             // all requests should be open again
+
+            Thread.sleep(100);
             System.out.println("CircuitBreaker state 2 : " + cmd1.getMetrics().getHealthCounts());
             assertTrue(cb.allowRequest());
             assertTrue(cb.allowRequest());


### PR DESCRIPTION
* This allows unsubscribes that happen between onNext/onCompleted to not affect the internal Hystrix command state

* That situation arises naturally fairly frequently - examples include a downstream take(1) or Observable.zip()