### PR TITLE
Update readme to address jdk7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ mvn -f download-hystrix-pom.xml dependency:copy-dependencies
 
 It will download hystrix-core-*.jar and its dependencies into ./target/dependency/.
 
-You need Java 6 or later.
+You need Java 7 or later.
 
 ## Build
 


### PR DESCRIPTION
Seems that hystrix is not supported on jdk6 anymore, so maybe this change will help new users...

Feel free to ignore if not :)