### PR TITLE
Update PlatformSpecific to only detect App Engine Standard Environment

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/metrics/eventstream/HystrixMetricsPoller.java
@@ -80,7 +80,7 @@ public class HystrixMetricsPoller {
         this.listener = listener;
 
         ThreadFactory threadFactory = null;
-        if (!PlatformSpecific.isAppEngine()) {
+        if (!PlatformSpecific.isAppEngineStandardEnvironment()) {
             threadFactory = new MetricsPollerThreadFactory();
         } else {
             threadFactory = PlatformSpecific.getAppEngineThreadFactory();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixConcurrencyStrategy.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixConcurrencyStrategy.java
@@ -72,7 +72,7 @@ public abstract class HystrixConcurrencyStrategy {
      */
     public ThreadPoolExecutor getThreadPool(final HystrixThreadPoolKey threadPoolKey, HystrixProperty<Integer> corePoolSize, HystrixProperty<Integer> maximumPoolSize, HystrixProperty<Integer> keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue) {
         ThreadFactory threadFactory = null;
-        if (!PlatformSpecific.isAppEngine()) {
+        if (!PlatformSpecific.isAppEngineStandardEnvironment()) {
             threadFactory = new ThreadFactory() {
                 protected final AtomicInteger threadNumber = new AtomicInteger(0);
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
@@ -153,7 +153,7 @@ public class HystrixTimer {
             int coreSize = propertiesStrategy.getTimerThreadPoolProperties().getCorePoolSize().get();
 
             ThreadFactory threadFactory = null;
-            if (!PlatformSpecific.isAppEngine()) {
+            if (!PlatformSpecific.isAppEngineStandardEnvironment()) {
                 threadFactory = new ThreadFactory() {
                     final AtomicInteger counter = new AtomicInteger();
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/PlatformSpecific.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/PlatformSpecific.java
@@ -19,24 +19,29 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.ThreadFactory;
 
 public class PlatformSpecific {
-    private final boolean isAppEngine;
+    private final boolean isAppEngineStandardEnvironment;
 
     private static PlatformSpecific INSTANCE = new PlatformSpecific();
 
     private PlatformSpecific() {
-        isAppEngine = determineAppEngineReflectively();
+        isAppEngineStandardEnvironment = determineAppEngineReflectively();
     }
 
-    public static boolean isAppEngine() {
-        return INSTANCE.isAppEngine;
+    public static boolean isAppEngineStandardEnvironment() {
+        return INSTANCE.isAppEngineStandardEnvironment;
     }
 
     /*
      * This detection mechanism is from Guava - specifically
      * http://docs.guava-libraries.googlecode.com/git/javadoc/src-html/com/google/common/util/concurrent/MoreExecutors.html#line.766
+     * Added GAE_LONG_APP_ID check to detect only AppEngine Standard Environment
      */
     private static boolean determineAppEngineReflectively() {
         if (System.getProperty("com.google.appengine.runtime.environment") == null) {
+            return false;
+        }
+        // GAE_LONG_APP_ID is only set in the GAE Flexible Environment, where we want standard threading
+        if (System.getenv("GAE_LONG_APP_ID") != null) {
             return false;
         }
         try {


### PR DESCRIPTION
Fixes #1352.

App Engine now has two environments, Standard and Flexible. The Flexible environment is just a Docker container, and as such can use standard Java threading. This change detects the Flexible environment via an environment variable that does not exist in the Standard environment, but exists for Flexible (both in local development and in production).