### PR TITLE
jmh test is more accurate when measuring the first command construction

### DIFF
--- a/hystrix-core/src/jmh/java/com/netflix/hystrix/perf/CommandConstructionPerfTest.java
+++ b/hystrix-core/src/jmh/java/com/netflix/hystrix/perf/CommandConstructionPerfTest.java
@@ -29,7 +29,7 @@ public class CommandConstructionPerfTest {
     static HystrixCommandGroupKey groupKey = HystrixCommandGroupKey.Factory.asKey("Group");
 
     @Benchmark
-    @BenchmarkMode({Mode.SampleTime})
+    @BenchmarkMode({Mode.SingleShotTime})
     @OutputTimeUnit(TimeUnit.MICROSECONDS)
     public HystrixCommand constructHystrixCommandByGroupKeyOnly() {
         return new HystrixCommand<Integer>(groupKey) {


### PR DESCRIPTION
Otherwise, data structures are cached and constructions does less work