### PR TITLE
Fix backwards incompatibility for appengine

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolMetrics.java
@@ -25,8 +25,10 @@ import org.slf4j.LoggerFactory;
 import rx.functions.Func0;
 import rx.functions.Func2;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -93,7 +95,18 @@ public class HystrixThreadPoolMetrics extends HystrixMetrics {
      * @return {@code Collection<HystrixThreadPoolMetrics>}
      */
     public static Collection<HystrixThreadPoolMetrics> getInstances() {
-        return Collections.unmodifiableCollection(metrics.values());
+        List<HystrixThreadPoolMetrics> threadPoolMetrics = new ArrayList<HystrixThreadPoolMetrics>();
+        for (HystrixThreadPoolMetrics tpm: metrics.values()) {
+            if (hasExecutedCommandsOnThread(tpm)) {
+                threadPoolMetrics.add(tpm);
+            }
+        }
+
+        return Collections.unmodifiableCollection(threadPoolMetrics);
+    }
+
+    private static boolean hasExecutedCommandsOnThread(HystrixThreadPoolMetrics threadPoolMetrics) {
+        return threadPoolMetrics.getCurrentCompletedTaskCount().intValue() > 0;
     }
 
     public static final Func2<long[], HystrixCommandCompletion, long[]> appendEventToBucket

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolMetricsTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolMetricsTest.java
@@ -25,51 +25,50 @@ import static org.junit.Assert.assertEquals;
 
 public class HystrixThreadPoolMetricsTest {
 
-	private static final HystrixCommandGroupKey groupKey = HystrixCommandGroupKey.Factory.asKey("HystrixThreadPoolMetrics-UnitTest");
-	private static final HystrixThreadPoolKey tpKey = HystrixThreadPoolKey.Factory.asKey("HystrixThreadPoolMetrics-ThreadPool");
+    private static final HystrixCommandGroupKey groupKey = HystrixCommandGroupKey.Factory.asKey("HystrixThreadPoolMetrics-UnitTest");
+    private static final HystrixThreadPoolKey tpKey = HystrixThreadPoolKey.Factory.asKey("HystrixThreadPoolMetrics-ThreadPool");
 
     @Before
     public void resetAll() {
-		HystrixThreadPoolMetrics.reset();
-	}
+        HystrixThreadPoolMetrics.reset();
+    }
 
-	@Test
-	public void shouldYieldNoExecutedTasksOnStartup() throws Exception {
-		//given
-		final Collection<HystrixThreadPoolMetrics> instances = HystrixThreadPoolMetrics.getInstances();
+    @Test
+    public void shouldYieldNoExecutedTasksOnStartup() throws Exception {
+        //given
+        final Collection<HystrixThreadPoolMetrics> instances = HystrixThreadPoolMetrics.getInstances();
 
-		//then
-		assertEquals(0, instances.size());
+        //then
+        assertEquals(0, instances.size());
 
-	}
-	@Test
-	public void shouldReturnOneExecutedTask() throws Exception {
-		//given
-		final Collection<HystrixThreadPoolMetrics> instances = HystrixThreadPoolMetrics.getInstances();
-		RollingThreadPoolEventCounterStream.getInstance(tpKey, 10, 100).startCachingStreamValuesIfUnstarted();
+    }
+    @Test
+    public void shouldReturnOneExecutedTask() throws Exception {
+        //given
+        RollingThreadPoolEventCounterStream.getInstance(tpKey, 10, 100).startCachingStreamValuesIfUnstarted();
 
-		//when
-		new NoOpHystrixCommand().execute();
+        new NoOpHystrixCommand().execute();
+        Thread.sleep(100);
 
-		//then
-		Thread.sleep(100);
-		assertEquals(1, instances.size());
-		assertEquals(1, instances.iterator().next().getRollingCountThreadsExecuted());
-	}
+        final Collection<HystrixThreadPoolMetrics> instances = HystrixThreadPoolMetrics.getInstances();
 
-	private static class NoOpHystrixCommand extends HystrixCommand<Void> {
-		public NoOpHystrixCommand() {
-			super(Setter.withGroupKey(groupKey)
+        //then
+        assertEquals(1, instances.size());
+        HystrixThreadPoolMetrics metrics = instances.iterator().next();
+        assertEquals(1, instances.iterator().next().getRollingCountThreadsExecuted());
+    }
+
+    private static class NoOpHystrixCommand extends HystrixCommand<Void> {
+        public NoOpHystrixCommand() {
+            super(Setter.withGroupKey(groupKey)
                     .andThreadPoolKey(tpKey)
                     .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter().withMetricsRollingStatisticalWindowInMilliseconds(100)));
-		}
+        }
 
-		@Override
-		protected Void run() throws Exception {
-			System.out.println("Run in thread : " + Thread.currentThread().getName());
+        @Override
+        protected Void run() throws Exception {
+            System.out.println("Run in thread : " + Thread.currentThread().getName());
             return null;
-		}
-	}
-
-
+        }
+    }
 }


### PR DESCRIPTION
Accidentally introduced incompatibility in #1356 .

This PR restores `PlatformSpecific.isAppEngine()` and changes the boolean tracking which platform is found (GAE-Standard / anything else) to a 3-valued enum (STANDARD / APPENGINE_STANDARD / APPENGINE_FLEXIBLE)