### PR TITLE
Add threadPool maximumSize configuration

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/sample/stream/HystrixConfigurationJsonStream.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/sample/stream/HystrixConfigurationJsonStream.java
@@ -116,6 +116,7 @@ public class HystrixConfigurationJsonStream {
     private static void writeThreadPoolConfigJson(JsonGenerator json, HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolConfiguration threadPoolConfig) throws IOException {
         json.writeObjectFieldStart(threadPoolKey.name());
         json.writeNumberField("coreSize", threadPoolConfig.getCoreSize());
+        json.writeNumberField("maximumSize", threadPoolConfig.getMaximumSize());
         json.writeNumberField("maxQueueSize", threadPoolConfig.getMaxQueueSize());
         json.writeNumberField("queueRejectionThreshold", threadPoolConfig.getQueueRejectionThreshold());
         json.writeNumberField("keepAliveTimeInMinutes", threadPoolConfig.getKeepAliveTimeInMinutes());

--- a/hystrix-core/src/main/java/com/netflix/hystrix/config/HystrixThreadPoolConfiguration.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/config/HystrixThreadPoolConfiguration.java
@@ -23,17 +23,19 @@ public class HystrixThreadPoolConfiguration {
     private static final String VERSION = "1";
     private final HystrixThreadPoolKey threadPoolKey;
     private final int coreSize;
+    private final int maximumSize;
     private final int maxQueueSize;
     private final int queueRejectionThreshold;
     private final int keepAliveTimeInMinutes;
     private final int rollingCounterNumberOfBuckets;
     private final int rollingCounterBucketSizeInMilliseconds;
 
-    public HystrixThreadPoolConfiguration(HystrixThreadPoolKey threadPoolKey, int coreSize, int maxQueueSize, int queueRejectionThreshold,
+    public HystrixThreadPoolConfiguration(HystrixThreadPoolKey threadPoolKey, int coreSize, int maximumSize, int maxQueueSize, int queueRejectionThreshold,
                                            int keepAliveTimeInMinutes, int rollingCounterNumberOfBuckets,
                                            int rollingCounterBucketSizeInMilliseconds) {
         this.threadPoolKey = threadPoolKey;
         this.coreSize = coreSize;
+        this.maximumSize = maximumSize;
         this.maxQueueSize = maxQueueSize;
         this.queueRejectionThreshold = queueRejectionThreshold;
         this.keepAliveTimeInMinutes = keepAliveTimeInMinutes;
@@ -45,6 +47,7 @@ public class HystrixThreadPoolConfiguration {
         return new HystrixThreadPoolConfiguration(
                 threadPoolKey,
                 threadPoolProperties.coreSize().get(),
+                threadPoolProperties.maximumSize().get(),
                 threadPoolProperties.maxQueueSize().get(),
                 threadPoolProperties.queueSizeRejectionThreshold().get(),
                 threadPoolProperties.keepAliveTimeMinutes().get(),
@@ -58,6 +61,10 @@ public class HystrixThreadPoolConfiguration {
 
     public int getCoreSize() {
         return coreSize;
+    }
+
+    public int getMaximumSize() {
+        return maximumSize;
     }
 
     public int getMaxQueueSize() {

--- a/hystrix-core/src/test/java/com/netflix/hystrix/AbstractTestHystrixCommand.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/AbstractTestHystrixCommand.java
@@ -46,9 +46,9 @@ public interface AbstractTestHystrixCommand<R> extends HystrixObservable<R>, Ins
         @Override
         public HystrixThreadPoolProperties getThreadPoolProperties(HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolProperties.Setter builder) {
             if (builder == null) {
-                builder = HystrixThreadPoolProperties.Setter.getUnitTestPropertiesBuilder();
+                builder = HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder();
             }
-            return HystrixThreadPoolProperties.Setter.asMock(builder);
+            return HystrixThreadPoolPropertiesTest.asMock(builder);
         }
 
         @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -5336,7 +5336,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
                     .setThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(TestThreadIsolationWithSemaphoreSetSmallCommand.class.getSimpleName()))
                     .setThreadPoolPropertiesDefaults(HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder()
-                            .withCoreSize(poolSize).withMaxQueueSize(0))
+                            .withCoreSize(poolSize).withMaximumSize(poolSize).withMaxQueueSize(0))
                     .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
                             .withExecutionIsolationStrategy(ExecutionIsolationStrategy.THREAD)
                             .withExecutionIsolationSemaphoreMaxConcurrentRequests(1)));

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -5335,7 +5335,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         private TestThreadIsolationWithSemaphoreSetSmallCommand(TestCircuitBreaker circuitBreaker, int poolSize, Action0 action) {
             super(testPropsBuilder().setCircuitBreaker(circuitBreaker).setMetrics(circuitBreaker.metrics)
                     .setThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(TestThreadIsolationWithSemaphoreSetSmallCommand.class.getSimpleName()))
-                    .setThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter.getUnitTestPropertiesBuilder()
+                    .setThreadPoolPropertiesDefaults(HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder()
                             .withCoreSize(poolSize).withMaxQueueSize(0))
                     .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
                             .withExecutionIsolationStrategy(ExecutionIsolationStrategy.THREAD)

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolPropertiesTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolPropertiesTest.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.netflix.config.ConfigurationManager;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
+
+public class HystrixThreadPoolPropertiesTest {
+
+    /**
+     * Base properties for unit testing.
+     */
+        /* package */static HystrixThreadPoolProperties.Setter getUnitTestPropertiesBuilder() {
+        return HystrixThreadPoolProperties.Setter()
+                .withCoreSize(10)// core size of thread pool
+                .withMaximumSize(15) //maximum size of thread pool
+                .withKeepAliveTimeMinutes(1)// minutes to keep a thread alive (though in practice this doesn't get used as by default we set a fixed size)
+                .withMaxQueueSize(100)// size of queue (but we never allow it to grow this big ... this can't be dynamically changed so we use 'queueSizeRejectionThreshold' to artificially limit and reject)
+                .withQueueSizeRejectionThreshold(10)// number of items in queue at which point we reject (this can be dyamically changed)
+                .withMetricsRollingStatisticalWindowInMilliseconds(10000)// milliseconds for rolling number
+                .withMetricsRollingStatisticalWindowBuckets(10);// number of buckets in rolling number (10 1-second buckets)
+    }
+
+    /**
+     * Return a static representation of the properties with values from the Builder so that UnitTests can create properties that are not affected by the actual implementations which pick up their
+     * values dynamically.
+     *
+     * @param builder builder for a {@link HystrixThreadPoolProperties}
+     * @return HystrixThreadPoolProperties
+     */
+        /* package */static HystrixThreadPoolProperties asMock(final HystrixThreadPoolProperties.Setter builder) {
+        return new HystrixThreadPoolProperties(TestThreadPoolKey.TEST) {
+
+            @Override
+            public HystrixProperty<Integer> coreSize() {
+                return HystrixProperty.Factory.asProperty(builder.getCoreSize());
+            }
+
+            @Override
+            public HystrixProperty<Integer> maximumSize() {
+                return HystrixProperty.Factory.asProperty(builder.getMaximumSize());
+            }
+
+            @Override
+            public HystrixProperty<Integer> keepAliveTimeMinutes() {
+                return HystrixProperty.Factory.asProperty(builder.getKeepAliveTimeMinutes());
+            }
+
+            @Override
+            public HystrixProperty<Integer> maxQueueSize() {
+                return HystrixProperty.Factory.asProperty(builder.getMaxQueueSize());
+            }
+
+            @Override
+            public HystrixProperty<Integer> queueSizeRejectionThreshold() {
+                return HystrixProperty.Factory.asProperty(builder.getQueueSizeRejectionThreshold());
+            }
+
+            @Override
+            public HystrixProperty<Integer> metricsRollingStatisticalWindowInMilliseconds() {
+                return HystrixProperty.Factory.asProperty(builder.getMetricsRollingStatisticalWindowInMilliseconds());
+            }
+
+            @Override
+            public HystrixProperty<Integer> metricsRollingStatisticalWindowBuckets() {
+                return HystrixProperty.Factory.asProperty(builder.getMetricsRollingStatisticalWindowBuckets());
+            }
+
+        };
+
+    }
+
+    private static enum TestThreadPoolKey implements HystrixThreadPoolKey {
+        TEST
+    }
+
+    @After
+    public void cleanup() {
+        ConfigurationManager.getConfigInstance().clear();
+    }
+
+    @Test
+    public void testSetNeitherCoreNorMaximumSize() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST, HystrixThreadPoolProperties.Setter()) {
+
+        };
+
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.maximumSize().get().intValue());
+    }
+
+    @Test
+    public void testSetCoreSizeOnly() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter().withCoreSize(14)) {
+
+        };
+
+        assertEquals(14, properties.coreSize().get().intValue());
+        assertEquals(14, properties.maximumSize().get().intValue());
+    }
+
+    @Test
+    public void testSetMaximumSizeOnlyLowerThanDefaultCoreSize() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter().withMaximumSize(3)) {
+
+        };
+
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
+        assertEquals(3, properties.maximumSize().get().intValue());
+    }
+
+    @Test
+    public void testSetMaximumSizeOnlyEqualToDefaultCoreSize() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter().withMaximumSize(HystrixThreadPoolProperties.default_coreSize)) {
+
+        };
+
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.maximumSize().get().intValue());
+    }
+
+    @Test
+    public void testSetMaximumSizeOnlyGreaterThanDefaultCoreSize() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter().withMaximumSize(21)) {
+
+        };
+
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
+        assertEquals(21, properties.maximumSize().get().intValue());
+    }
+
+    @Test
+    public void testSetCoreSizeLessThanMaximumSize() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(2)
+                        .withMaximumSize(8)) {
+
+        };
+
+        assertEquals(2, properties.coreSize().get().intValue());
+        assertEquals(8, properties.maximumSize().get().intValue());
+    }
+
+    @Test
+    public void testSetCoreSizeEqualToMaximumSize() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(7)
+                        .withMaximumSize(7)) {
+
+        };
+
+        assertEquals(7, properties.coreSize().get().intValue());
+        assertEquals(7, properties.maximumSize().get().intValue());
+    }
+
+    @Test
+    public void testSetCoreSizeGreaterThanMaximumSize() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(12)
+                        .withMaximumSize(8)) {
+
+        };
+
+        assertEquals(12, properties.coreSize().get().intValue());
+        assertEquals(8, properties.maximumSize().get().intValue());
+    }
+}

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolTest.java
@@ -49,7 +49,7 @@ public class HystrixThreadPoolTest {
         int count = Factory.threadPools.size();
 
         HystrixThreadPool pool = Factory.getInstance(HystrixThreadPoolKey.Factory.asKey("threadPoolFactoryTest"),
-                HystrixThreadPoolProperties.Setter.getUnitTestPropertiesBuilder());
+                HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder());
 
         assertEquals(count + 1, Factory.threadPools.size());
         assertFalse(pool.getExecutor().isShutdown());
@@ -67,7 +67,7 @@ public class HystrixThreadPoolTest {
         int count = Factory.threadPools.size();
 
         HystrixThreadPool pool = Factory.getInstance(HystrixThreadPoolKey.Factory.asKey("threadPoolFactoryTest"),
-                HystrixThreadPoolProperties.Setter.getUnitTestPropertiesBuilder());
+                HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder());
 
         assertEquals(count + 1, Factory.threadPools.size());
         assertFalse(pool.getExecutor().isShutdown());
@@ -105,9 +105,9 @@ public class HystrixThreadPoolTest {
         });
         HystrixThreadPoolKey threadPoolKey = HystrixThreadPoolKey.Factory.asKey("threadPoolFactoryConcurrencyTest");
         HystrixThreadPool poolOne = new HystrixThreadPool.HystrixThreadPoolDefault(
-                threadPoolKey, HystrixThreadPoolProperties.Setter.getUnitTestPropertiesBuilder());
+                threadPoolKey, HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder());
         HystrixThreadPool poolTwo = new HystrixThreadPool.HystrixThreadPoolDefault(
-                threadPoolKey, HystrixThreadPoolProperties.Setter.getUnitTestPropertiesBuilder());
+                threadPoolKey, HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder());
 
         assertThat(poolOne.getExecutor(), is(poolTwo.getExecutor())); //Now that we get the threadPool from the metrics object, this will always be equal
         HystrixMetricsPublisherThreadPoolContainer hystrixMetricsPublisherThreadPool =
@@ -126,7 +126,7 @@ public class HystrixThreadPoolTest {
     public void testUnsubscribeHystrixThreadPool() throws InterruptedException {
         // methods are package-private so can't test it somewhere else
         HystrixThreadPool pool = Factory.getInstance(HystrixThreadPoolKey.Factory.asKey("threadPoolFactoryTest"),
-                HystrixThreadPoolProperties.Setter.getUnitTestPropertiesBuilder());
+                HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder());
         
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch start = new CountDownLatch(1);

--- a/hystrix-core/src/test/java/com/netflix/hystrix/InspectableBuilder.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/InspectableBuilder.java
@@ -37,7 +37,7 @@ public interface InspectableBuilder {
         HystrixCircuitBreaker circuitBreaker;
         HystrixThreadPool threadPool = null;
         HystrixCommandProperties.Setter commandPropertiesDefaults = HystrixCommandPropertiesTest.getUnitTestPropertiesSetter();
-        HystrixThreadPoolProperties.Setter threadPoolPropertiesDefaults = HystrixThreadPoolProperties.Setter.getUnitTestPropertiesBuilder();
+        HystrixThreadPoolProperties.Setter threadPoolPropertiesDefaults = HystrixThreadPoolPropertiesTest.getUnitTestPropertiesBuilder();
         HystrixCommandMetrics metrics;
         AbstractCommand.TryableSemaphore fallbackSemaphore = null;
         AbstractCommand.TryableSemaphore executionSemaphore = null;

--- a/hystrix-serialization/src/main/java/com/netflix/hystrix/serial/SerialHystrixConfiguration.java
+++ b/hystrix-serialization/src/main/java/com/netflix/hystrix/serial/SerialHystrixConfiguration.java
@@ -252,6 +252,7 @@ public class SerialHystrixConfiguration extends SerialHystrixMetric {
     private static void writeThreadPoolConfigJson(JsonGenerator json, HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolConfiguration threadPoolConfig) throws IOException {
         json.writeObjectFieldStart(threadPoolKey.name());
         json.writeNumberField("coreSize", threadPoolConfig.getCoreSize());
+        json.writeNumberField("maximumSize", threadPoolConfig.getMaximumSize());
         json.writeNumberField("maxQueueSize", threadPoolConfig.getMaxQueueSize());
         json.writeNumberField("queueRejectionThreshold", threadPoolConfig.getQueueRejectionThreshold());
         json.writeNumberField("keepAliveTimeInMinutes", threadPoolConfig.getKeepAliveTimeInMinutes());

--- a/hystrix-serialization/src/main/java/com/netflix/hystrix/serial/SerialHystrixConfiguration.java
+++ b/hystrix-serialization/src/main/java/com/netflix/hystrix/serial/SerialHystrixConfiguration.java
@@ -177,6 +177,7 @@ public class SerialHystrixConfiguration extends SerialHystrixMetric {
                 HystrixThreadPoolConfiguration threadPoolConfig = new HystrixThreadPoolConfiguration(
                        threadPoolKey,
                         threadPool.getValue().path("coreSize").asInt(),
+                        threadPool.getValue().path("maximumSize").asInt(),
                         threadPool.getValue().path("maxQueueSize").asInt(),
                         threadPool.getValue().path("queueRejectionThreshold").asInt(),
                         threadPool.getValue().path("keepAliveTimeInMinutes").asInt(),


### PR DESCRIPTION
With this change, it is possible to set `coreSize < maximumSize` and have a thread pool which can give up threads if they become inactive (subject to the keep-alive time).

Design considerations:
* An `IllegalArgumentException` is thrown if a `ThreadPoolExecutor` is configured with `coreSize > maximumSize`.  When that condition occurs when the constructor is invoked, this PR chooses to use `coreSize` for `maximumSize` to avoid the error and logs something to the user.
* This PR uses the discovered `coreSize` as the default value for `maximumSize`.  This should allow a clean migration, as no one currently has `maximumValue` configured.  So without that config, Hystrix should configure itself as before - a fixed size threadpool of size `coreSize`.  Further configuration can then set these independently.

This addresses #1242 