### PR TITLE
Add option to raise HystrixRuntimeException

### DIFF
--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/annotation/DefaultProperties.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/annotation/DefaultProperties.java
@@ -67,11 +67,17 @@ public @interface DefaultProperties {
     HystrixProperty[] threadPoolProperties() default {};
 
     /**
-     * Defines exceptions which should be ignored and wrapped to throw in HystrixBadRequestException.
-     * All methods annotated with @HystrixCommand will automatically inherit this property.
-     *
+     * Defines exceptions which should be ignored.
+     * Optionally these can be wrapped in HystrixRuntimeException if raiseHystrixExceptions contains RUNTIME_EXCEPTION.
      *
      * @return exceptions to ignore
      */
     Class<? extends Throwable>[] ignoreExceptions() default {};
+
+    /**
+     * When includes RUNTIME_EXCEPTION, any exceptions that are not ignored are wrapped in HystrixRuntimeException.
+     *
+     * @return exceptions to wrap
+     */
+    HystrixException[] raiseHystrixExceptions() default {};
 }

--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/annotation/HystrixCommand.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/annotation/HystrixCommand.java
@@ -101,7 +101,7 @@ public @interface HystrixCommand {
 
     /**
      * Defines exceptions which should be ignored.
-     * Optionally these can be wrapped in a HystrixRuntimeException if raiseHystrixExceptions is set to true.
+     * Optionally these can be wrapped in HystrixRuntimeException if raiseHystrixExceptions contains RUNTIME_EXCEPTION.
      *
      * @return exceptions to ignore
      */
@@ -116,9 +116,10 @@ public @interface HystrixCommand {
     ObservableExecutionMode observableExecutionMode() default ObservableExecutionMode.EAGER;
 
     /**
-     * When set to true, any exceptions that are not ignored are wrapped in HystrixRuntimeException.
-     * @return true to raise HystrixRuntimeException instead of their cause.
+     * When includes RUNTIME_EXCEPTION, any exceptions that are not ignored are wrapped in HystrixRuntimeException.
+     *
+     * @return exceptions to wrap
      */
-    boolean raiseHystrixRuntimeExceptions() default false;
+    HystrixException[] raiseHystrixExceptions() default {};
 }
 

--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/annotation/HystrixCommand.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/annotation/HystrixCommand.java
@@ -100,7 +100,8 @@ public @interface HystrixCommand {
     HystrixProperty[] threadPoolProperties() default {};
 
     /**
-     * Defines exceptions which should be ignored and wrapped to throw in HystrixBadRequestException.
+     * Defines exceptions which should be ignored.
+     * Optionally these can be wrapped in a HystrixRuntimeException if raiseHystrixExceptions is set to true.
      *
      * @return exceptions to ignore
      */
@@ -113,5 +114,11 @@ public @interface HystrixCommand {
      * @return observable execution mode
      */
     ObservableExecutionMode observableExecutionMode() default ObservableExecutionMode.EAGER;
+
+    /**
+     * When set to true, any exceptions that are not ignored are wrapped in HystrixRuntimeException.
+     * @return true to raise HystrixRuntimeException instead of their cause.
+     */
+    boolean raiseHystrixRuntimeExceptions() default false;
 }
 

--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/annotation/HystrixException.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/annotation/HystrixException.java
@@ -1,0 +1,8 @@
+package com.netflix.hystrix.contrib.javanica.annotation;
+
+/**
+ * Created by Mike Cowan
+ */
+public enum HystrixException {
+    RUNTIME_EXCEPTION,
+}

--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/aop/aspectj/HystrixCommandAspect.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/aop/aspectj/HystrixCommandAspect.java
@@ -103,6 +103,9 @@ public class HystrixCommandAspect {
         } catch (HystrixBadRequestException e) {
             throw e.getCause();
         } catch (HystrixRuntimeException e) {
+            if (metaHolder.getRaiseHystrixRuntimeExceptions()) {
+                throw e;
+            }
             throw getCause(e);
         }
         return result;
@@ -253,6 +256,7 @@ public class HystrixCommandAspect {
             return builder.defaultCommandKey(method.getName())
                             .hystrixCommand(hystrixCommand)
                             .observableExecutionMode(hystrixCommand.observableExecutionMode())
+                            .raiseHystrixRuntimeExceptions(hystrixCommand.raiseHystrixRuntimeExceptions())
                             .executionType(executionType)
                             .observable(ExecutionType.OBSERVABLE == executionType)
                             .build();

--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/aop/aspectj/HystrixCommandAspect.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/aop/aspectj/HystrixCommandAspect.java
@@ -21,6 +21,7 @@ import com.netflix.hystrix.HystrixInvokable;
 import com.netflix.hystrix.contrib.javanica.annotation.DefaultProperties;
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCollapser;
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixException;
 import com.netflix.hystrix.contrib.javanica.command.CommandExecutor;
 import com.netflix.hystrix.contrib.javanica.command.ExecutionType;
 import com.netflix.hystrix.contrib.javanica.command.HystrixCommandFactory;
@@ -103,7 +104,7 @@ public class HystrixCommandAspect {
         } catch (HystrixBadRequestException e) {
             throw e.getCause();
         } catch (HystrixRuntimeException e) {
-            if (metaHolder.getRaiseHystrixRuntimeExceptions()) {
+            if (metaHolder.raiseHystrixExceptionsContains(HystrixException.RUNTIME_EXCEPTION)) {
                 throw e;
             }
             throw getCause(e);
@@ -256,7 +257,6 @@ public class HystrixCommandAspect {
             return builder.defaultCommandKey(method.getName())
                             .hystrixCommand(hystrixCommand)
                             .observableExecutionMode(hystrixCommand.observableExecutionMode())
-                            .raiseHystrixRuntimeExceptions(hystrixCommand.raiseHystrixRuntimeExceptions())
                             .executionType(executionType)
                             .observable(ExecutionType.OBSERVABLE == executionType)
                             .build();

--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/command/MetaHolder.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/command/MetaHolder.java
@@ -67,6 +67,7 @@ public final class MetaHolder {
     private final JoinPoint joinPoint;
     private final boolean observable;
     private final ObservableExecutionMode observableExecutionMode;
+    private final boolean raiseHystrixRuntimeExceptions;
 
     private static final Function identityFun = new Function<Object, Object>() {
         @Nullable
@@ -101,6 +102,7 @@ public final class MetaHolder {
         this.extendedParentFallback = builder.extendedParentFallback;
         this.observable = builder.observable;
         this.observableExecutionMode = builder.observableExecutionMode;
+        this.raiseHystrixRuntimeExceptions = builder.raiseHystrixRuntimeExceptions;
     }
 
     public static Builder builder() {
@@ -299,6 +301,10 @@ public final class MetaHolder {
         return observableExecutionMode;
     }
 
+    public boolean getRaiseHystrixRuntimeExceptions() {
+        return raiseHystrixRuntimeExceptions;
+    }
+
     private String get(String key, String defaultKey) {
         return StringUtils.isNotBlank(key) ? key : defaultKey;
     }
@@ -353,6 +359,7 @@ public final class MetaHolder {
         private boolean observable;
         private JoinPoint joinPoint;
         private ObservableExecutionMode observableExecutionMode;
+        private boolean raiseHystrixRuntimeExceptions;
 
         public Builder hystrixCollapser(HystrixCollapser hystrixCollapser) {
             this.hystrixCollapser = hystrixCollapser;
@@ -471,6 +478,11 @@ public final class MetaHolder {
 
         public Builder observableExecutionMode(ObservableExecutionMode observableExecutionMode) {
             this.observableExecutionMode = observableExecutionMode;
+            return this;
+        }
+
+        public Builder raiseHystrixRuntimeExceptions(boolean raiseHystrixRuntimeExceptions) {
+            this.raiseHystrixRuntimeExceptions = raiseHystrixRuntimeExceptions;
             return this;
         }
 

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/common/error/BasicDefaultIgnoreExceptionsTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/common/error/BasicDefaultIgnoreExceptionsTest.java
@@ -33,7 +33,7 @@ public abstract class BasicDefaultIgnoreExceptionsTest {
         service.commandOverridesDefaultIgnoreExceptions(SpecificException.class);
     }
 
-    @Test(expected = HystrixRuntimeException.class)
+    @Test(expected = BadRequestException.class)
     public void testCommandOverridesDefaultIgnoreExceptions_nonIgnoreExceptionShouldBePropagated() {
         // method throws BadRequestException that isn't ignored
         service.commandOverridesDefaultIgnoreExceptions(BadRequestException.class);

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/common/error/BasicDefaultIgnoreExceptionsTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/common/error/BasicDefaultIgnoreExceptionsTest.java
@@ -33,7 +33,7 @@ public abstract class BasicDefaultIgnoreExceptionsTest {
         service.commandOverridesDefaultIgnoreExceptions(SpecificException.class);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = HystrixRuntimeException.class)
     public void testCommandOverridesDefaultIgnoreExceptions_nonIgnoreExceptionShouldBePropagated() {
         // method throws BadRequestException that isn't ignored
         service.commandOverridesDefaultIgnoreExceptions(BadRequestException.class);
@@ -64,7 +64,7 @@ public abstract class BasicDefaultIgnoreExceptionsTest {
             throw new BadRequestException("from 'commandInheritsIgnoreExceptionsFromDefault'");
         }
 
-        @HystrixCommand(ignoreExceptions = SpecificException.class)
+        @HystrixCommand(ignoreExceptions = SpecificException.class, raiseHystrixRuntimeExceptions = true)
         public Object commandOverridesDefaultIgnoreExceptions(Class<? extends Throwable> errorType) throws BadRequestException, SpecificException  {
             if(errorType.equals(BadRequestException.class)){
                 // isn't ignored because command doesn't specify this exception type in 'ignoreExceptions'

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/common/error/BasicDefaultRaiseHystrixExceptionsTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/common/error/BasicDefaultRaiseHystrixExceptionsTest.java
@@ -1,19 +1,19 @@
 package com.netflix.hystrix.contrib.javanica.test.common.error;
 
-import com.netflix.hystrix.contrib.javanica.annotation.DefaultProperties;
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-import com.netflix.hystrix.exception.HystrixRuntimeException;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.netflix.hystrix.contrib.javanica.annotation.DefaultProperties;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixException;
+import com.netflix.hystrix.exception.HystrixRuntimeException;
+
 /**
- * Test for {@link DefaultProperties#ignoreExceptions()} feature.
- *
- * <p>
- * Created by dmgcodevil.
+ * Created by Mike Cowan
  */
-public abstract class BasicDefaultIgnoreExceptionsTest {
+public abstract class BasicDefaultRaiseHystrixExceptionsTest {
+
     private Service service;
 
     @Before
@@ -51,12 +51,12 @@ public abstract class BasicDefaultIgnoreExceptionsTest {
         service.commandWithFallbackOverridesDefaultIgnoreExceptions(SpecificException.class);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = HystrixRuntimeException.class)
     public void testFallbackCommandOverridesDefaultIgnoreExceptions_nonIgnoreExceptionShouldBePropagated() {
         service.commandWithFallbackOverridesDefaultIgnoreExceptions(BadRequestException.class);
     }
 
-    @DefaultProperties(ignoreExceptions = BadRequestException.class)
+    @DefaultProperties(ignoreExceptions = BadRequestException.class, raiseHystrixExceptions = {HystrixException.RUNTIME_EXCEPTION})
     public static class Service {
         @HystrixCommand
         public Object commandInheritsDefaultIgnoreExceptions() throws BadRequestException {

--- a/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/error/DefaultRaiseHystrixExceptionsTest.java
+++ b/hystrix-contrib/hystrix-javanica/src/test/java/com/netflix/hystrix/contrib/javanica/test/spring/error/DefaultRaiseHystrixExceptionsTest.java
@@ -1,0 +1,36 @@
+package com.netflix.hystrix.contrib.javanica.test.spring.error;
+
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.netflix.hystrix.contrib.javanica.test.common.error.BasicDefaultRaiseHystrixExceptionsTest;
+import com.netflix.hystrix.contrib.javanica.test.spring.conf.AopCglibConfig;
+
+/**
+ * Created by Mike Cowan
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {AopCglibConfig.class, DefaultRaiseHystrixExceptionsTest.DefaultRaiseHystrixExceptionsTestConfig.class})
+public class DefaultRaiseHystrixExceptionsTest extends BasicDefaultRaiseHystrixExceptionsTest {
+
+    @Autowired
+    private BasicDefaultRaiseHystrixExceptionsTest.Service service;
+
+    @Override
+    protected BasicDefaultRaiseHystrixExceptionsTest.Service createService() {
+        return service;
+    }
+
+    @Configurable
+    public static class DefaultRaiseHystrixExceptionsTestConfig {
+
+        @Bean
+        public BasicDefaultRaiseHystrixExceptionsTest.Service userService() {
+            return new BasicDefaultRaiseHystrixExceptionsTest.Service();
+        }
+    }
+}


### PR DESCRIPTION
Adds the option to allow _HystrixRuntimeException_ to be thrown by `HystrixCommandAspect`.

The new property _raiseHystrixExceptions_ is supported by both `DefaultProperties` and `HystrixCommand`.

e.g.
```java
@DefaultProperties(
    ignoreExceptions = BadRequestException.class,
    raiseHystrixExceptions = {HystrixException.RUNTIME_EXCEPTION})
```

This pattern is extensible should people wish to add support for other Hystrix exceptions.

PR [requested](https://github.com/Netflix/Hystrix/issues/1344#issuecomment-254999908) by @dmgcodevil 