### PR TITLE
Fix typo in collapser options keyword name (from shared-fn to shard-fn)

### DIFF
--- a/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
+++ b/hystrix-contrib/hystrix-clj/src/main/clojure/com/netflix/hystrix/core.clj
@@ -430,7 +430,7 @@
 (defn- extract-hystrix-collapser-options
   [meta-map]
   (let [key-map {:hystrix/collapser-key :collapser-key
-                 :hystrix/shared-fn     :shard-fn
+                 :hystrix/shard-fn      :shard-fn
                  :hystrix/scope         :scope
                  :hystrix/cache-key-fn  :cache-key-fn
                  :hystrix/init-fn       :init-fn }]


### PR DESCRIPTION
Fixes a typo in the `:hystrix/shard-fn` keyword option to the collapser creation macro.
