### PR TITLE
Single method which ensures core less than equal to maximum

### DIFF
--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherThreadPool.java
@@ -153,6 +153,13 @@ public class HystrixCodaHaleMetricsPublisherThreadPool implements HystrixMetrics
             }
         });
 
+        metricRegistry.register(createMetricName("propertyValue_actualMaximumSize"), new Gauge<Number>() {
+            @Override
+            public Number getValue() {
+                return properties.maximumSize().get();
+            }
+        });
+
         metricRegistry.register(createMetricName("propertyValue_keepAliveTimeInMinutes"), new Gauge<Number>() {
             @Override
             public Number getValue() {

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherThreadPool.java
@@ -146,6 +146,13 @@ public class HystrixCodaHaleMetricsPublisherThreadPool implements HystrixMetrics
             }
         });
 
+        metricRegistry.register(createMetricName("propertyValue_maximumSize"), new Gauge<Number>() {
+            @Override
+            public Number getValue() {
+                return properties.maximumSize().get();
+            }
+        });
+
         metricRegistry.register(createMetricName("propertyValue_keepAliveTimeInMinutes"), new Gauge<Number>() {
             @Override
             public Number getValue() {

--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/sample/stream/HystrixConfigurationJsonStream.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/sample/stream/HystrixConfigurationJsonStream.java
@@ -117,6 +117,7 @@ public class HystrixConfigurationJsonStream {
         json.writeObjectFieldStart(threadPoolKey.name());
         json.writeNumberField("coreSize", threadPoolConfig.getCoreSize());
         json.writeNumberField("maximumSize", threadPoolConfig.getMaximumSize());
+        json.writeNumberField("actualMaximumSize", threadPoolConfig.getActualMaximumSize());
         json.writeNumberField("maxQueueSize", threadPoolConfig.getMaxQueueSize());
         json.writeNumberField("queueRejectionThreshold", threadPoolConfig.getQueueRejectionThreshold());
         json.writeNumberField("keepAliveTimeInMinutes", threadPoolConfig.getKeepAliveTimeInMinutes());

--- a/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherThreadPool.java
@@ -256,6 +256,13 @@ public class HystrixServoMetricsPublisherThreadPool extends HystrixServoMetricsP
             }
         });
 
+        monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_actualMaximumSize").build()) {
+            @Override
+            public Number getValue() {
+                return properties.actualMaximumSize();
+            }
+        });
+
         monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_keepAliveTimeInMinutes").build()) {
             @Override
             public Number getValue() {

--- a/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherThreadPool.java
@@ -249,6 +249,13 @@ public class HystrixServoMetricsPublisherThreadPool extends HystrixServoMetricsP
             }
         });
 
+        monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_maximumSize").build()) {
+            @Override
+            public Number getValue() {
+                return properties.maximumSize().get();
+            }
+        });
+
         monitors.add(new InformationalMetric<Number>(MonitorConfig.builder("propertyValue_keepAliveTimeInMinutes").build()) {
             @Override
             public Number getValue() {

--- a/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherThreadPool.java
@@ -149,6 +149,13 @@ public class HystrixYammerMetricsPublisherThreadPool implements HystrixMetricsPu
             }
         });
 
+        metricsRegistry.newGauge(createMetricName("propertyValue_actualMaximumSize"), new Gauge<Number>() {
+            @Override
+            public Number value() {
+                return properties.actualMaximumSize();
+            }
+        });
+
         metricsRegistry.newGauge(createMetricName("propertyValue_keepAliveTimeInMinutes"), new Gauge<Number>() {
             @Override
             public Number value() {

--- a/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-yammer-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/yammermetricspublisher/HystrixYammerMetricsPublisherThreadPool.java
@@ -142,6 +142,13 @@ public class HystrixYammerMetricsPublisherThreadPool implements HystrixMetricsPu
             }
         });
 
+        metricsRegistry.newGauge(createMetricName("propertyValue_maximumSize"), new Gauge<Number>() {
+            @Override
+            public Number value() {
+                return properties.maximumSize().get();
+            }
+        });
+
         metricsRegistry.newGauge(createMetricName("propertyValue_keepAliveTimeInMinutes"), new Gauge<Number>() {
             @Override
             public Number value() {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolProperties.java
@@ -138,7 +138,7 @@ public abstract class HystrixThreadPoolProperties {
     public Integer actualMaximumSize() {
         final int coreSize = coreSize().get();
         final int maximumSize = maximumSize().get();
-        if (allowMaximumSizeToDivergeFromCoreSize.get()) {
+        if (getAllowMaximumSizeToDivergeFromCoreSize().get()) {
             if (coreSize > maximumSize) {
                 return coreSize;
             } else {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolProperties.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPoolProperties.java
@@ -116,12 +116,37 @@ public abstract class HystrixThreadPoolProperties {
     }
 
     /**
-     * Maximum thread-pool size that gets passed to {@link ThreadPoolExecutor#setMaximumPoolSize(int)}
+     * Maximum thread-pool size configured for threadpool.  May conflict with other config, so if you need the
+     * actual value that gets passed to {@link ThreadPoolExecutor#setMaximumPoolSize(int)}, use {@link #actualMaximumSize()}
      *
      * @return {@code HystrixProperty<Integer>}
      */
     public HystrixProperty<Integer> maximumSize() {
         return maximumPoolSize;
+    }
+
+    /**
+     * Given all of the thread pool configuration, what is the actual maximumSize applied to the thread pool
+     * via {@link ThreadPoolExecutor#setMaximumPoolSize(int)}
+     *
+     * Cases:
+     * 1) allowMaximumSizeToDivergeFromCoreSize == false: maximumSize is set to coreSize
+     * 2) allowMaximumSizeToDivergeFromCoreSize == true, maximumSize >= coreSize: thread pool has different core/max sizes, so return the configured max
+     * 3) allowMaximumSizeToDivergeFromCoreSize == true, maximumSize < coreSize: threadpool incorrectly configured, use coreSize for max size
+     * @return actually configured maximum size of threadpool
+     */
+    public Integer actualMaximumSize() {
+        final int coreSize = coreSize().get();
+        final int maximumSize = maximumSize().get();
+        if (allowMaximumSizeToDivergeFromCoreSize.get()) {
+            if (coreSize > maximumSize) {
+                return coreSize;
+            } else {
+                return maximumSize;
+            }
+        } else {
+            return coreSize;
+        }
     }
 
     /**

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolPropertiesTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixThreadPoolPropertiesTest.java
@@ -98,84 +98,190 @@ public class HystrixThreadPoolPropertiesTest {
     }
 
     @Test
-    public void testSetNeitherCoreNorMaximumSize() {
-        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST, HystrixThreadPoolProperties.Setter()) {
-
+    public void testSetNeitherCoreNorMaximumSizeWithDivergenceDisallowed() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withAllowMaximumSizeToDivergeFromCoreSize(false)) {
         };
 
         assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
         assertEquals(HystrixThreadPoolProperties.default_maximumSize, properties.maximumSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, (int) properties.actualMaximumSize());
     }
 
     @Test
-    public void testSetCoreSizeOnly() {
+    public void testSetNeitherCoreNorMaximumSizeWithDivergenceAllowed() {
         HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
-                HystrixThreadPoolProperties.Setter().withCoreSize(14)) {
+                HystrixThreadPoolProperties.Setter()
+                        .withAllowMaximumSizeToDivergeFromCoreSize(true)) {
+        };
 
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_maximumSize, properties.maximumSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_maximumSize, (int) properties.actualMaximumSize());
+    }
+
+    @Test
+    public void testSetCoreSizeOnlyWithDivergenceDisallowed() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(14)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(false)) {
         };
 
         assertEquals(14, properties.coreSize().get().intValue());
         assertEquals(HystrixThreadPoolProperties.default_maximumSize, properties.maximumSize().get().intValue());
+        assertEquals(14, (int) properties.actualMaximumSize());
     }
 
     @Test
-    public void testSetMaximumSizeOnlyLowerThanDefaultCoreSize() {
+    public void testSetCoreSizeOnlyWithDivergenceAllowed() {
         HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
-                HystrixThreadPoolProperties.Setter().withMaximumSize(3)) {
+                HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(14)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(true)) {
+        };
 
+        assertEquals(14, properties.coreSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_maximumSize, properties.maximumSize().get().intValue());
+        assertEquals(14, (int) properties.actualMaximumSize());
+    }
+
+    @Test
+    public void testSetMaximumSizeOnlyLowerThanDefaultCoreSizeWithDivergenceDisallowed() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withMaximumSize(3)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(false)) {
         };
 
         assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
         assertEquals(3, properties.maximumSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, (int) properties.actualMaximumSize());
     }
 
     @Test
-    public void testSetMaximumSizeOnlyGreaterThanDefaultCoreSize() {
+    public void testSetMaximumSizeOnlyLowerThanDefaultCoreSizeWithDivergenceAllowed() {
         HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
-                HystrixThreadPoolProperties.Setter().withMaximumSize(21)) {
+                HystrixThreadPoolProperties.Setter()
+                        .withMaximumSize(3)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(true)) {
+        };
 
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
+        assertEquals(3, properties.maximumSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, (int) properties.actualMaximumSize());
+    }
+
+    @Test
+    public void testSetMaximumSizeOnlyGreaterThanDefaultCoreSizeWithDivergenceDisallowed() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withMaximumSize(21)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(false)) {
         };
 
         assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
         assertEquals(21, properties.maximumSize().get().intValue());
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, (int) properties.actualMaximumSize());
     }
 
     @Test
-    public void testSetCoreSizeLessThanMaximumSize() {
+    public void testSetMaximumSizeOnlyGreaterThanDefaultCoreSizeWithDivergenceAllowed() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withMaximumSize(21)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(true)) {
+        };
+
+        assertEquals(HystrixThreadPoolProperties.default_coreSize, properties.coreSize().get().intValue());
+        assertEquals(21, properties.maximumSize().get().intValue());
+        assertEquals(21, (int) properties.actualMaximumSize());
+    }
+
+    @Test
+    public void testSetCoreSizeLessThanMaximumSizeWithDivergenceDisallowed() {
         HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
                 HystrixThreadPoolProperties.Setter()
                         .withCoreSize(2)
-                        .withMaximumSize(8)) {
-
+                        .withMaximumSize(8)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(false)) {
         };
 
         assertEquals(2, properties.coreSize().get().intValue());
         assertEquals(8, properties.maximumSize().get().intValue());
+        assertEquals(2, (int) properties.actualMaximumSize());
     }
 
     @Test
-    public void testSetCoreSizeEqualToMaximumSize() {
+    public void testSetCoreSizeLessThanMaximumSizeWithDivergenceAllowed() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(2)
+                        .withMaximumSize(8)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(true)) {
+        };
+
+        assertEquals(2, properties.coreSize().get().intValue());
+        assertEquals(8, properties.maximumSize().get().intValue());
+        assertEquals(8, (int) properties.actualMaximumSize());
+    }
+
+    @Test
+    public void testSetCoreSizeEqualToMaximumSizeDivergenceDisallowed() {
         HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
                 HystrixThreadPoolProperties.Setter()
                         .withCoreSize(7)
-                        .withMaximumSize(7)) {
-
+                        .withMaximumSize(7)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(false)) {
         };
 
         assertEquals(7, properties.coreSize().get().intValue());
         assertEquals(7, properties.maximumSize().get().intValue());
+        assertEquals(7, (int) properties.actualMaximumSize());
     }
 
     @Test
-    public void testSetCoreSizeGreaterThanMaximumSize() {
+    public void testSetCoreSizeEqualToMaximumSizeDivergenceAllowed() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(7)
+                        .withMaximumSize(7)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(true)) {
+        };
+
+        assertEquals(7, properties.coreSize().get().intValue());
+        assertEquals(7, properties.maximumSize().get().intValue());
+        assertEquals(7, (int) properties.actualMaximumSize());
+    }
+
+    @Test
+    public void testSetCoreSizeGreaterThanMaximumSizeWithDivergenceDisallowed() {
         HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
                 HystrixThreadPoolProperties.Setter()
                         .withCoreSize(12)
-                        .withMaximumSize(8)) {
-
+                        .withMaximumSize(8)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(false)) {
         };
 
         assertEquals(12, properties.coreSize().get().intValue());
         assertEquals(8, properties.maximumSize().get().intValue());
+        assertEquals(12, (int) properties.actualMaximumSize());
+    }
+
+    @Test
+    public void testSetCoreSizeGreaterThanMaximumSizeWithDivergenceAllowed() {
+        HystrixThreadPoolProperties properties = new HystrixThreadPoolProperties(TestThreadPoolKey.TEST,
+                HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(12)
+                        .withMaximumSize(8)
+                        .withAllowMaximumSizeToDivergeFromCoreSize(true)) {
+        };
+
+        assertEquals(12, properties.coreSize().get().intValue());
+        assertEquals(8, properties.maximumSize().get().intValue());
+        assertEquals(12, (int) properties.actualMaximumSize());
     }
 }
+
+

--- a/hystrix-serialization/src/main/java/com/netflix/hystrix/serial/SerialHystrixConfiguration.java
+++ b/hystrix-serialization/src/main/java/com/netflix/hystrix/serial/SerialHystrixConfiguration.java
@@ -137,6 +137,7 @@ public class SerialHystrixConfiguration extends SerialHystrixMetric {
         json.writeObjectFieldStart(threadPoolKey.name());
         json.writeNumberField("coreSize", threadPoolConfig.getCoreSize());
         json.writeNumberField("maximumSize", threadPoolConfig.getMaximumSize());
+        json.writeNumberField("actualMaximumSize", threadPoolConfig.getActualMaximumSize());
         json.writeNumberField("maxQueueSize", threadPoolConfig.getMaxQueueSize());
         json.writeNumberField("queueRejectionThreshold", threadPoolConfig.getQueueRejectionThreshold());
         json.writeNumberField("keepAliveTimeInMinutes", threadPoolConfig.getKeepAliveTimeInMinutes());


### PR DESCRIPTION
Builds on #1439 to distinguish the value configured as the maximum for the threadpool, and the value actually applied.  In cases where the maximum was being pushed out, now both are.