### PR TITLE
Added exporting of rollingMaxConcurrentExecutionCount value.

### DIFF
--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
@@ -272,6 +272,13 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
                 return HystrixRollingNumberEvent.TIMEOUT;
             }
         });
+        // the rolling number of MaxConcurrentExecutionCount. Can be used to determine saturation
+        safelyCreateRollingCountForEvent("rollingMaxConcurentExecutionCount", new Func0<HystrixRollingNumberEvent>() {
+            @Override
+            public HystrixRollingNumberEvent call() {
+                return HystrixRollingNumberEvent.COMMAND_MAX_ACTIVE;
+            }
+        });
 
         // the number of executionSemaphorePermits in use right now
         metricRegistry.register(createMetricName("executionSemaphorePermitsInUse"), new Gauge<Integer>() {


### PR DESCRIPTION
Make exporting of newly added property to dropwizard. Original issue is https://github.com/Netflix/Hystrix/issues/54 and pull request adding given metrics is mentioned here https://github.com/Netflix/Hystrix/pull/667 .