### PR TITLE
hystrix-metrics-event-stream implementation using JAX-RS

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/README.md
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/README.md
@@ -1,0 +1,62 @@
+# hystrix-metrics-event-stream-jaxrs
+
+This module is a JAX-RS implementation of [hystrix-metrics-event-stream](https://github.com/Netflix/Hystrix/tree/master/hystrix-contrib/hystrix-metrics-event-stream) module without any Servlet API dependency and exposes metrics in a [text/event-stream](https://developer.mozilla.org/en-US/docs/Server-sent_events/Using_server-sent_events) formatted stream that continues as long as a client holds the connection.
+
+
+# Binaries
+
+Binaries and dependency information for Maven, Ivy, Gradle and others can be found at [http://search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22hystrix-metrics-event-stream-jaxrs%22).
+
+Example for Maven ([lookup latest version](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22hystrix-metrics-event-stream-jaxrs%22)):
+
+```xml
+<dependency>
+    <groupId>com.netflix.hystrix</groupId>
+    <artifactId>hystrix-metrics-event-stream-jaxrs</artifactId>
+    <version>1.6.0</version>
+</dependency>
+```
+and for Ivy:
+
+```xml
+<dependency org="com.netflix.hystrix" name="hystrix-metrics-event-stream-jaxrs" rev="1.6.0" />
+```
+
+# Installation
+
+1) Include hystrix-metrics-event-stream-jaxrs*.jar in your classpath (such as /WEB-INF/lib). 
+2) Register `HystrixStreamFeature` in your `javax.ws.rs.core.Application` as shown below.
+
+```java
+
+public class HystrixStreamApplication extends Application{
+
+    @Override
+    public Set<Class<?>> getClasses() {
+			Set<Class<?>> clazzes = new HashSet<Class<?>>();
+			clazzes.add(HystrixStreamFeature.class);
+			return clazzes;
+   }
+}
+```
+
+3) Following end-points are available
+  * /hystrix.stream - Stream Hystrix Metrics
+  * /hystrix/utilization.stream - Stream Hystrix Utilization
+  * /hystrix/config.stream - Stream Hystrix configuration
+  * /hystrix/request.stream - Stream Hystrix SSE events
+  
+
+
+# Test
+
+To test your installation you can use curl like this:
+
+```
+$ curl http://hostname:port/appname/hystrix.stream
+
+data: {"rollingCountFailure":0,"propertyValue_executionIsolationThreadInterruptOnTimeout":true,"rollingCountTimeout":0,"rollingCountExceptionsThrown":0,"rollingCountFallbackSuccess":0,"errorCount":0,"type":"HystrixCommand","propertyValue_circuitBreakerEnabled":true,"reportingHosts":1,"latencyTotal":{"0":0,"95":0,"99.5":0,"90":0,"25":0,"99":0,"75":0,"100":0,"50":0},"currentConcurrentExecutionCount":0,"rollingCountSemaphoreRejected":0,"rollingCountFallbackRejection":0,"rollingCountShortCircuited":0,"rollingCountResponsesFromCache":0,"propertyValue_circuitBreakerForceClosed":false,"name":"IdentityCookieAuthSwitchProfile","propertyValue_executionIsolationThreadPoolKeyOverride":"null","rollingCountSuccess":0,"propertyValue_requestLogEnabled":true,"requestCount":0,"rollingCountCollapsedRequests":0,"errorPercentage":0,"propertyValue_circuitBreakerSleepWindowInMilliseconds":5000,"latencyTotal_mean":0,"propertyValue_circuitBreakerForceOpen":false,"propertyValue_circuitBreakerRequestVolumeThreshold":20,"propertyValue_circuitBreakerErrorThresholdPercentage":50,"propertyValue_executionIsolationStrategy":"THREAD","rollingCountFallbackFailure":0,"isCircuitBreakerOpen":false,"propertyValue_executionIsolationSemaphoreMaxConcurrentRequests":20,"propertyValue_executionIsolationThreadTimeoutInMilliseconds":1000,"propertyValue_metricsRollingStatisticalWindowInMilliseconds":10000,"propertyValue_fallbackIsolationSemaphoreMaxConcurrentRequests":10,"latencyExecute":{"0":0,"95":0,"99.5":0,"90":0,"25":0,"99":0,"75":0,"100":0,"50":0},"group":"IDENTITY","latencyExecute_mean":0,"propertyValue_requestCacheEnabled":true,"rollingCountThreadPoolRejected":0}
+
+data: {"rollingCountFailure":0,"propertyValue_executionIsolationThreadInterruptOnTimeout":true,"rollingCountTimeout":0,"rollingCountExceptionsThrown":0,"rollingCountFallbackSuccess":0,"errorCount":0,"type":"HystrixCommand","propertyValue_circuitBreakerEnabled":true,"reportingHosts":3,"latencyTotal":{"0":1,"95":1,"99.5":1,"90":1,"25":1,"99":1,"75":1,"100":1,"50":1},"currentConcurrentExecutionCount":0,"rollingCountSemaphoreRejected":0,"rollingCountFallbackRejection":0,"rollingCountShortCircuited":0,"rollingCountResponsesFromCache":0,"propertyValue_circuitBreakerForceClosed":false,"name":"CryptexDecrypt","propertyValue_executionIsolationThreadPoolKeyOverride":"null","rollingCountSuccess":1,"propertyValue_requestLogEnabled":true,"requestCount":1,"rollingCountCollapsedRequests":0,"errorPercentage":0,"propertyValue_circuitBreakerSleepWindowInMilliseconds":15000,"latencyTotal_mean":1,"propertyValue_circuitBreakerForceOpen":false,"propertyValue_circuitBreakerRequestVolumeThreshold":60,"propertyValue_circuitBreakerErrorThresholdPercentage":150,"propertyValue_executionIsolationStrategy":"THREAD","rollingCountFallbackFailure":0,"isCircuitBreakerOpen":false,"propertyValue_executionIsolationSemaphoreMaxConcurrentRequests":60,"propertyValue_executionIsolationThreadTimeoutInMilliseconds":3000,"propertyValue_metricsRollingStatisticalWindowInMilliseconds":30000,"propertyValue_fallbackIsolationSemaphoreMaxConcurrentRequests":30,"latencyExecute":{"0":0,"95":0,"99.5":0,"90":0,"25":0,"99":0,"75":0,"100":0,"50":0},"group":"CRYPTEX","latencyExecute_mean":0,"propertyValue_requestCacheEnabled":true,"rollingCountThreadPoolRejected":0}
+```
+

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/build.gradle
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    compileApi project(':hystrix-core')
+	compile project(':hystrix-serialization')
+    provided 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+    testCompile 'junit:junit-dep:4.10'
+    testCompile 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:2.25.1'
+	testCompile 'org.glassfish.jersey.media:jersey-media-sse:2.25.1'
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/HystrixStream.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/HystrixStream.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import rx.Observable;
+
+/**
+ * @author justinjose28
+ * 
+ */
+public final class HystrixStream {
+	private final Observable<String> sampleStream;
+	private final int pausePollerThreadDelayInMs;
+	private final AtomicInteger concurrentConnections;
+
+	public HystrixStream(Observable<String> sampleStream, int pausePollerThreadDelayInMs, AtomicInteger concurrentConnections) {
+		this.sampleStream = sampleStream;
+		this.pausePollerThreadDelayInMs = pausePollerThreadDelayInMs;
+		this.concurrentConnections = concurrentConnections;
+	}
+
+	public Observable<String> getSampleStream() {
+		return sampleStream;
+	}
+
+	public int getPausePollerThreadDelayInMs() {
+		return pausePollerThreadDelayInMs;
+	}
+
+	public AtomicInteger getConcurrentConnections() {
+		return concurrentConnections;
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/HystrixStreamFeature.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/HystrixStreamFeature.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+import com.netflix.hystrix.contrib.metrics.controller.HystrixConfigSseController;
+import com.netflix.hystrix.contrib.metrics.controller.HystrixMetricsStreamController;
+import com.netflix.hystrix.contrib.metrics.controller.HystrixRequestEventsSseController;
+import com.netflix.hystrix.contrib.metrics.controller.HystrixUtilizationSseController;
+
+/**
+ * @author justinjose28
+ * 
+ */
+public class HystrixStreamFeature implements Feature {
+
+	@Override
+	public boolean configure(FeatureContext context) {
+		context.register(new HystrixMetricsStreamController());
+		context.register(new HystrixUtilizationSseController());
+		context.register(new HystrixRequestEventsSseController());
+		context.register(new HystrixConfigSseController());
+		context.register(HystrixStreamingOutputProvider.class);
+		return true;
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/HystrixStreamingOutputProvider.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/HystrixStreamingOutputProvider.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import rx.Subscriber;
+import rx.Subscription;
+import rx.schedulers.Schedulers;
+
+/**
+ * {@link MessageBodyWriter} implementation which handles serialization of HystrixStream
+ * 
+ * 
+ * @author justinjose28
+ * 
+ */
+
+@Provider
+public class HystrixStreamingOutputProvider implements MessageBodyWriter<HystrixStream> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(HystrixStreamingOutputProvider.class);
+
+	@Override
+	public boolean isWriteable(Class<?> t, Type gt, Annotation[] as, MediaType mediaType) {
+		return HystrixStream.class.isAssignableFrom(t);
+	}
+
+	@Override
+	public long getSize(HystrixStream o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+		return -1;
+	}
+
+	@Override
+	public void writeTo(HystrixStream o, Class<?> t, Type gt, Annotation[] as, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, final OutputStream entity) throws IOException {
+		Subscription sampleSubscription = null;
+		final AtomicBoolean moreDataWillBeSent = new AtomicBoolean(true);
+		try {
+
+			sampleSubscription = o.getSampleStream().observeOn(Schedulers.io()).subscribe(new Subscriber<String>() {
+				@Override
+				public void onCompleted() {
+					LOGGER.error("HystrixSampleSseServlet: ({}) received unexpected OnCompleted from sample stream", getClass().getSimpleName());
+					moreDataWillBeSent.set(false);
+				}
+
+				@Override
+				public void onError(Throwable e) {
+					moreDataWillBeSent.set(false);
+				}
+
+				@Override
+				public void onNext(String sampleDataAsString) {
+					if (sampleDataAsString != null) {
+						try {
+							entity.write(("data: " + sampleDataAsString + "\n\n").getBytes());
+							entity.flush();
+						} catch (IOException ioe) {
+							moreDataWillBeSent.set(false);
+						}
+					}
+				}
+			});
+
+			while (moreDataWillBeSent.get()) {
+				try {
+					Thread.sleep(o.getPausePollerThreadDelayInMs());
+				} catch (InterruptedException e) {
+					moreDataWillBeSent.set(false);
+				}
+			}
+		} finally {
+			o.getConcurrentConnections().decrementAndGet();
+			if (sampleSubscription != null && !sampleSubscription.isUnsubscribed()) {
+				sampleSubscription.unsubscribe();
+			}
+		}
+	}
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/AbstractHystrixStreamController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/AbstractHystrixStreamController.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import rx.Observable;
+
+import com.netflix.hystrix.contrib.metrics.HystrixStream;
+import com.netflix.hystrix.contrib.metrics.HystrixStreamingOutputProvider;
+
+/**
+ * @author justinjose28
+ * 
+ */
+public abstract class AbstractHystrixStreamController {
+	protected final Observable<String> sampleStream;
+
+	static final Logger logger = LoggerFactory.getLogger(AbstractHystrixStreamController.class);
+
+	// wake up occasionally and check that poller is still alive. this value controls how often
+	protected static final int DEFAULT_PAUSE_POLLER_THREAD_DELAY_IN_MS = 500;
+
+	private final int pausePollerThreadDelayInMs;
+
+	private static final AtomicInteger concurrentConnections = new AtomicInteger(0);
+
+	protected AbstractHystrixStreamController(Observable<String> sampleStream) {
+		this(sampleStream, DEFAULT_PAUSE_POLLER_THREAD_DELAY_IN_MS);
+	}
+
+	protected AbstractHystrixStreamController(Observable<String> sampleStream, int pausePollerThreadDelayInMs) {
+		this.sampleStream = sampleStream;
+		this.pausePollerThreadDelayInMs = pausePollerThreadDelayInMs;
+	}
+
+	protected abstract int getMaxNumberConcurrentConnectionsAllowed();
+
+	protected final AtomicInteger getCurrentConnections() {
+		return concurrentConnections;
+	}
+
+	/**
+	 * Maintain an open connection with the client. On initial connection send latest data of each requested event type and subsequently send all changes for each requested event type.
+	 * 
+	 * @return JAX-RS Response - Serialization will be handled by {@link HystrixStreamingOutputProvider}
+	 */
+	protected Response handleRequest() {
+		ResponseBuilder builder = null;
+		/* ensure we aren't allowing more connections than we want */
+		int numberConnections = getCurrentConnections().get();
+		int maxNumberConnectionsAllowed = getMaxNumberConcurrentConnectionsAllowed(); // may change at runtime, so look this up for each request
+		if (numberConnections >= maxNumberConnectionsAllowed) {
+			builder = Response.status(Status.SERVICE_UNAVAILABLE).entity("MaxConcurrentConnections reached: " + maxNumberConnectionsAllowed);
+		} else {
+			/* initialize response */
+			builder = Response.status(Status.OK);
+			builder.header(HttpHeaders.CONTENT_TYPE, "text/event-stream;charset=UTF-8");
+			builder.header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, max-age=0, must-revalidate");
+			builder.header("Pragma", "no-cache");
+			getCurrentConnections().incrementAndGet();
+			builder.entity(new HystrixStream(sampleStream, pausePollerThreadDelayInMs, getCurrentConnections()));
+		}
+		return builder.build();
+
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixConfigSseController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixConfigSseController.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import rx.functions.Func1;
+
+import com.netflix.config.DynamicIntProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.hystrix.config.HystrixConfiguration;
+import com.netflix.hystrix.config.HystrixConfigurationStream;
+import com.netflix.hystrix.contrib.metrics.HystrixStreamFeature;
+import com.netflix.hystrix.serial.SerialHystrixConfiguration;
+
+/**
+ * Streams Hystrix config in text/event-stream format.
+ * <p>
+ * Install by:
+ * <p>
+ * 1) Including hystrix-metrics-event-stream-jaxrs-*.jar in your classpath.
+ * <p>
+ * 2) Register {@link HystrixStreamFeature} in your {@link Application}.
+ * <p>
+ * 3) Stream will be available at path /hystrix/config.stream
+ * <p>
+ *
+ * @author justinjose28
+ * 
+ */
+@Path("/hystrix/config.stream")
+public class HystrixConfigSseController extends AbstractHystrixStreamController {
+
+	private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.config.stream.maxConcurrentConnections", 5);
+
+	public HystrixConfigSseController() {
+		super(HystrixConfigurationStream.getInstance().observe().map(new Func1<HystrixConfiguration, String>() {
+			@Override
+			public String call(HystrixConfiguration hystrixConfiguration) {
+				return SerialHystrixConfiguration.toJsonString(hystrixConfiguration);
+			}
+		}));
+	}
+
+	@GET
+	public Response getStream() {
+		return handleRequest();
+	}
+
+	@Override
+	protected int getMaxNumberConcurrentConnectionsAllowed() {
+		return maxConcurrentConnections.get();
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixMetricsStreamController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixMetricsStreamController.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+import com.netflix.config.DynamicIntProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.hystrix.contrib.metrics.HystrixStreamFeature;
+import com.netflix.hystrix.metric.consumer.HystrixDashboardStream;
+import com.netflix.hystrix.serial.SerialHystrixDashboardData;
+
+/**
+ * Streams Hystrix metrics in text/event-stream format.
+ * <p>
+ * Install by:
+ * <p>
+ * 1) Including hystrix-metrics-event-stream-jaxrs-*.jar in your classpath.
+ * <p>
+ * 2) Register {@link HystrixStreamFeature} in your {@link Application}.
+ * <p>
+ * 3) Stream will be available at path /hystrix.stream
+ * <p>
+ * 
+ * @author justinjose28
+ * 
+ */
+@Path("/hystrix.stream")
+public class HystrixMetricsStreamController extends AbstractHystrixStreamController {
+
+	private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.config.stream.maxConcurrentConnections", 5);
+
+	public HystrixMetricsStreamController() {
+		super(HystrixDashboardStream.getInstance().observe().concatMap(new Func1<HystrixDashboardStream.DashboardData, Observable<String>>() {
+			@Override
+			public Observable<String> call(HystrixDashboardStream.DashboardData dashboardData) {
+				return Observable.from(SerialHystrixDashboardData.toMultipleJsonStrings(dashboardData));
+			}
+		}));
+	}
+
+	@GET
+	public Response getStream() {
+		return handleRequest();
+	}
+
+	@Override
+	protected int getMaxNumberConcurrentConnectionsAllowed() {
+		return maxConcurrentConnections.get();
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixRequestEventsSseController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixRequestEventsSseController.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import rx.functions.Func1;
+
+import com.netflix.config.DynamicIntProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.hystrix.contrib.metrics.HystrixStreamFeature;
+import com.netflix.hystrix.metric.HystrixRequestEvents;
+import com.netflix.hystrix.metric.HystrixRequestEventsStream;
+import com.netflix.hystrix.serial.SerialHystrixRequestEvents;
+
+/**
+ * Resource that writes SSE JSON every time a request is made
+ * 
+ * <p>
+ * Install by:
+ * <p>
+ * 1) Including hystrix-metrics-event-stream-jaxrs-*.jar in your classpath.
+ * <p>
+ * 2) Register {@link HystrixStreamFeature} in your {@link Application}.
+ * <p>
+ * 3) Stream will be available at path /hystrix/request.stream
+ * <p>
+ * 
+ * @author justinjose28
+ * 
+ */
+@Path("/hystrix/request.stream")
+public class HystrixRequestEventsSseController extends AbstractHystrixStreamController {
+
+	private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.config.stream.maxConcurrentConnections", 5);
+
+	public HystrixRequestEventsSseController() {
+		super(HystrixRequestEventsStream.getInstance().observe().map(new Func1<HystrixRequestEvents, String>() {
+			@Override
+			public String call(HystrixRequestEvents requestEvents) {
+				return SerialHystrixRequestEvents.toJsonString(requestEvents);
+			}
+		}));
+	}
+
+	@GET
+	public Response getStream() {
+		return handleRequest();
+	}
+
+	@Override
+	protected int getMaxNumberConcurrentConnectionsAllowed() {
+		return maxConcurrentConnections.get();
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixUtilizationSseController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixUtilizationSseController.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import rx.functions.Func1;
+
+import com.netflix.config.DynamicIntProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.hystrix.contrib.metrics.HystrixStreamFeature;
+import com.netflix.hystrix.metric.sample.HystrixUtilization;
+import com.netflix.hystrix.metric.sample.HystrixUtilizationStream;
+import com.netflix.hystrix.serial.SerialHystrixUtilization;
+
+/**
+ * Streams Hystrix config in text/event-stream format.
+ * <p>
+ * Install by:
+ * <p>
+ * 1) Including hystrix-metrics-event-stream-jaxrs-*.jar in your classpath.
+ * <p>
+ * 2) Register {@link HystrixStreamFeature} in your {@link Application}.
+ * <p>
+ * 3) Stream will be available at path /hystrix/utilization.stream
+ * <p>
+ * 
+ * @author justinjose28
+ * 
+ */
+@Path("/hystrix/utilization.stream")
+public class HystrixUtilizationSseController extends AbstractHystrixStreamController {
+
+	private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.config.stream.maxConcurrentConnections", 5);
+
+	public HystrixUtilizationSseController() {
+		super(HystrixUtilizationStream.getInstance().observe().map(new Func1<HystrixUtilization, String>() {
+			@Override
+			public String call(HystrixUtilization hystrixUtilization) {
+				return SerialHystrixUtilization.toJsonString(hystrixUtilization);
+			}
+		}));
+	}
+
+	@GET
+	public Response getStream() {
+		return handleRequest();
+	}
+
+	@Override
+	protected int getMaxNumberConcurrentConnectionsAllowed() {
+		return maxConcurrentConnections.get();
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystricsMetricsControllerTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystricsMetricsControllerTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.ServiceUnavailableException;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.configuration.SystemConfiguration;
+import org.glassfish.jersey.media.sse.EventInput;
+import org.glassfish.jersey.media.sse.InboundEvent;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.contrib.metrics.HystrixStreamFeature;
+
+/**
+ * @author justinjose28
+ * 
+ */
+@Path("/hystrix")
+public class HystricsMetricsControllerTest extends JerseyTest {
+	protected static final AtomicInteger requestCount = new AtomicInteger(0);
+
+	@POST
+	@Path("/command")
+	@Consumes(APPLICATION_JSON)
+	public void command() throws Exception {
+		TestHystrixCommand command = new TestHystrixCommand();
+		command.execute();
+	}
+
+	@Override
+	protected Application configure() {
+		int port = 0;
+		try {
+			final ServerSocket socket = new ServerSocket(0);
+			port = socket.getLocalPort();
+			socket.close();
+		} catch (IOException e1) {
+			throw new RuntimeException("Failed to find port to start test server");
+		}
+		set(TestProperties.CONTAINER_PORT, port);
+		try {
+			SystemConfiguration.setSystemProperties("test.properties");
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to load config file");
+		}
+		return new ResourceConfig(HystricsMetricsControllerTest.class, HystrixStreamFeature.class);
+	}
+
+	protected String getPath() {
+		return "hystrix.stream";
+	}
+
+	protected boolean isStreamValid(String data) {
+		return data.contains("\"type\":\"HystrixThreadPool\"") && data.contains("\"currentCompletedTaskCount\":" + requestCount.get());
+	}
+
+	@Test
+	public void testInfiniteStream() throws Exception {
+		executeHystrixCommand(); // Execute a Hystrix command so that metrics are initialized.
+		EventInput stream = getStream(); // Invoke Stream API which returns a steady stream output.
+		validateStream(stream, 1000); // Validate the stream.
+		System.out.println("Validated Stream Output 1");
+		executeHystrixCommand(); // Execute Hystrix Command again so that request count is updated.
+		validateStream(stream, 1000); // Stream should show updated request count
+		System.out.println("Validated Stream Output 2");
+		stream.close();
+	}
+
+	@Test
+	public void testConcurrency() throws Exception {
+		executeHystrixCommand(); // Execute a Hystrix command so that metrics are initialized.
+		List<EventInput> streamList = new ArrayList<EventInput>();
+		// Fire 5 requests, validate their responses and hold these connections.
+		for (int i = 0; i < 5; i++) {
+			EventInput stream = getStream();
+			System.out.println("Received Response for Request#" + (i + 1));
+			streamList.add(stream);
+			validateStream(stream, 1000);
+			System.out.println("Validated Response#" + (i + 1));
+		}
+
+		// Sixth request should fail since max configured connection is 5.
+		try {
+			streamList.add(getStreamFailFast());
+			Assert.fail("Expected 'ServiceUnavailableException' but, request went through.");
+		} catch (ServiceUnavailableException e) {
+			System.out.println("Got ServiceUnavailableException as expected.");
+		}
+
+		// Close one of the connections
+		streamList.get(0).close();
+
+		// Try again after closing one of the connections. This request should go through.
+		EventInput eventInput = getStream();
+		streamList.add(eventInput);
+		validateStream(eventInput, 1000);
+
+	}
+
+	private void executeHystrixCommand() throws Exception {
+		Response response = target("hystrix/command").request().post(null);
+		assertEquals(204, response.getStatus());
+		System.out.println("Hystrix Command ran successfully.");
+		requestCount.incrementAndGet();
+	}
+
+	private EventInput getStream() throws Exception {
+		long timeElapsed = System.currentTimeMillis();
+		while (System.currentTimeMillis() - timeElapsed < 3000) {
+			try {
+				return getStreamFailFast();
+			} catch (Exception e) {
+
+			}
+		}
+		fail("Not able to connect to Stream end point");
+		return null;
+	}
+
+	private EventInput getStreamFailFast() throws Exception {
+		return target(getPath()).request().get(EventInput.class);
+	}
+
+	private void validateStream(EventInput eventInput, long waitTime) {
+		long timeElapsed = System.currentTimeMillis();
+		while (!eventInput.isClosed() && System.currentTimeMillis() - timeElapsed < waitTime) {
+			final InboundEvent inboundEvent = eventInput.read();
+			if (inboundEvent == null) {
+				Assert.fail("Failed while verifying stream. Looks like connection has been closed.");
+				break;
+			}
+			String data = inboundEvent.readData(String.class);
+			System.out.println(data);
+			if (isStreamValid(data)) {
+				return;
+			}
+		}
+		Assert.fail("Failed while verifying stream");
+	}
+
+	public static class TestHystrixCommand extends HystrixCommand<Void> {
+
+		protected TestHystrixCommand() {
+			super(HystrixCommandGroupKey.Factory.asKey("test"));
+		}
+
+		@Override
+		protected Void run() throws Exception {
+			return null;
+		}
+
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystrixConfigControllerTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystrixConfigControllerTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+/**
+ * @author justinjose28
+ * 
+ */
+public class HystrixConfigControllerTest extends HystricsMetricsControllerTest {
+
+	@Override
+	protected String getPath() {
+		return "hystrix/config.stream";
+	}
+
+	@Override
+	protected boolean isStreamValid(String data) {
+		return data.contains("\"type\":\"HystrixConfig\"");
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystrixUtilizationControllerTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystrixUtilizationControllerTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+/**
+ * @author justinjose28
+ *
+ */
+public class HystrixUtilizationControllerTest extends HystricsMetricsControllerTest {
+
+	@Override
+	protected String getPath() {
+		return "hystrix/utilization.stream";
+	}
+
+	@Override
+	protected boolean isStreamValid(String data) {
+		return data.contains("\"type\":\"HystrixUtilization\"");
+	}
+
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/StreamingOutputProviderTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/StreamingOutputProviderTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.hystrix.contrib.metrics.controller;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Func1;
+import rx.schedulers.Schedulers;
+
+import com.netflix.hystrix.contrib.metrics.HystrixStream;
+import com.netflix.hystrix.contrib.metrics.HystrixStreamingOutputProvider;
+
+public class StreamingOutputProviderTest {
+
+	private final Observable<String> streamOfOnNexts = Observable.interval(100, TimeUnit.MILLISECONDS).map(new Func1<Long, String>() {
+		@Override
+		public String call(Long timestamp) {
+			return "test-stream";
+		}
+	});
+
+	private final Observable<String> streamOfOnNextThenOnError = Observable.create(new Observable.OnSubscribe<String>() {
+		@Override
+		public void call(Subscriber<? super String> subscriber) {
+			try {
+				Thread.sleep(100);
+				subscriber.onNext("test-stream");
+				Thread.sleep(100);
+				subscriber.onError(new RuntimeException("stream failure"));
+			} catch (InterruptedException ex) {
+				ex.printStackTrace();
+			}
+		}
+	}).subscribeOn(Schedulers.computation());
+
+	private final Observable<String> streamOfOnNextThenOnCompleted = Observable.create(new Observable.OnSubscribe<String>() {
+		@Override
+		public void call(Subscriber<? super String> subscriber) {
+			try {
+				Thread.sleep(100);
+				subscriber.onNext("test-stream");
+				Thread.sleep(100);
+				subscriber.onCompleted();
+			} catch (InterruptedException ex) {
+				ex.printStackTrace();
+			}
+		}
+	}).subscribeOn(Schedulers.computation());
+
+	private AbstractHystrixStreamController sse = new AbstractHystrixStreamController(streamOfOnNexts) {
+
+		@Override
+		protected int getMaxNumberConcurrentConnectionsAllowed() {
+			return 2;
+		}
+
+	};
+
+	@Test
+	public void concurrencyTest() throws Exception {
+
+		Response resp = sse.handleRequest();
+		assertEquals(200, resp.getStatus());
+		assertEquals("text/event-stream;charset=UTF-8", resp.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+		assertEquals("no-cache, no-store, max-age=0, must-revalidate", resp.getHeaders().getFirst(HttpHeaders.CACHE_CONTROL));
+		assertEquals("no-cache", resp.getHeaders().getFirst("Pragma"));
+
+		resp = sse.handleRequest();
+		assertEquals(200, resp.getStatus());
+
+		resp = sse.handleRequest();
+		assertEquals(503, resp.getStatus());
+		assertEquals("MaxConcurrentConnections reached: " + sse.getMaxNumberConcurrentConnectionsAllowed(), resp.getEntity());
+
+		sse.getCurrentConnections().decrementAndGet();
+
+		resp = sse.handleRequest();
+		assertEquals(200, resp.getStatus());
+	}
+
+	@Test
+	public void testInfiniteOnNextStream() throws Exception {
+		final PipedInputStream is = new PipedInputStream();
+		final PipedOutputStream os = new PipedOutputStream(is);
+		final AtomicInteger writes = new AtomicInteger(0);
+		final HystrixStream stream = new HystrixStream(streamOfOnNexts, 100, new AtomicInteger(1));
+		Thread streamingThread = startStreamingThread(stream, os);
+		verifyStream(is, writes);
+		Thread.sleep(1000); // Let the provider stream for some time.
+		streamingThread.interrupt(); // Stop streaming
+
+		os.close();
+		is.close();
+
+		System.out.println("Total lines:" + writes.get());
+		assertTrue(writes.get() >= 9); // Observable is configured to emit events in every 100 ms. So expect at least 9 in a second.
+		assertTrue(stream.getConcurrentConnections().get() == 0); // Provider is expected to decrement connection count when streaming process is terminated.
+	}
+
+	@Test
+	public void testOnError() throws Exception {
+		testStreamOnce(streamOfOnNextThenOnError);
+	}
+
+	@Test
+	public void testOnComplete() throws Exception {
+		testStreamOnce(streamOfOnNextThenOnCompleted);
+	}
+
+	private void testStreamOnce(Observable<String> observable) throws Exception {
+		final PipedInputStream is = new PipedInputStream();
+		final PipedOutputStream os = new PipedOutputStream(is);
+		final AtomicInteger writes = new AtomicInteger(0);
+		final HystrixStream stream = new HystrixStream(observable, 100, new AtomicInteger(1));
+		startStreamingThread(stream, os);
+		verifyStream(is, writes);
+		Thread.sleep(1000);
+
+		os.close();
+		is.close();
+
+		System.out.println("Total lines:" + writes.get());
+		assertTrue(writes.get() == 1);
+		assertTrue(stream.getConcurrentConnections().get() == 0);
+
+	}
+
+	private static Thread startStreamingThread(final HystrixStream stream, final OutputStream outputSteam) {
+		Thread th1 = new Thread(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					final HystrixStreamingOutputProvider provider = new HystrixStreamingOutputProvider();
+					provider.writeTo(stream, null, null, null, null, null, outputSteam);
+				} catch (IOException e) {
+					fail(e.getMessage());
+				}
+			}
+		});
+		th1.start();
+		return th1;
+	}
+
+	private static void verifyStream(final InputStream is, final AtomicInteger lineCount) {
+		Thread th2 = new Thread(new Runnable() {
+			public void run() {
+				BufferedReader br = null;
+				try {
+					br = new BufferedReader(new InputStreamReader(is));
+					String line;
+					while ((line = br.readLine()) != null) {
+						if (!"".equals(line)) {
+							System.out.println(line);
+							lineCount.incrementAndGet();
+						}
+					}
+				} catch (IOException e) {
+					fail("Failed while verifying streaming output.Stacktrace:" + e.getMessage());
+				} finally {
+					if (br != null) {
+						try {
+							br.close();
+						} catch (IOException e) {
+							fail("Failed while verifying streaming output.Stacktrace:" + e.getMessage());
+						}
+					}
+				}
+
+			}
+		});
+		th2.start();
+	}
+}

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/resources/test.properties
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+hystrix.stream.utilization.intervalInMilliseconds=10
+hystrix.stream.dashboard.intervalInMilliseconds=10
+hystrix.stream.config.intervalInMilliseconds=10

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ include 'hystrix-core', \
 'hystrix-contrib/hystrix-request-servlet', \
 'hystrix-contrib/hystrix-servo-metrics-publisher', \
 'hystrix-contrib/hystrix-metrics-event-stream', \
+'hystrix-contrib/hystrix-metrics-event-stream-jaxrs', \
 'hystrix-contrib/hystrix-rx-netty-metrics-stream', \
 'hystrix-contrib/hystrix-codahale-metrics-publisher', \
 'hystrix-contrib/hystrix-yammer-metrics-publisher', \
@@ -19,6 +20,7 @@ project(':hystrix-contrib/hystrix-clj').name = 'hystrix-clj'
 project(':hystrix-contrib/hystrix-request-servlet').name = 'hystrix-request-servlet'
 project(':hystrix-contrib/hystrix-servo-metrics-publisher').name = 'hystrix-servo-metrics-publisher'
 project(':hystrix-contrib/hystrix-metrics-event-stream').name = 'hystrix-metrics-event-stream'
+project(':hystrix-contrib/hystrix-metrics-event-stream-jaxrs').name = 'hystrix-metrics-event-stream-jaxrs'
 project(':hystrix-contrib/hystrix-rx-netty-metrics-stream').name = 'hystrix-rx-netty-metrics-stream'
 project(':hystrix-contrib/hystrix-codahale-metrics-publisher').name = 'hystrix-codahale-metrics-publisher'
 project(':hystrix-contrib/hystrix-yammer-metrics-publisher').name = 'hystrix-yammer-metrics-publisher'


### PR DESCRIPTION
This pull request adds a new module hystrix-metrics-event-stream-jaxrs which is based on JAX-RS rather than Servlet API. This module is helpful for applications which depend only on JAX-RS. See this [issue](https://github.com/Netflix/Hystrix/issues/1490)