### PR TITLE
Update build.gradle

### DIFF
--- a/hystrix-contrib/hystrix-javanica/build.gradle
+++ b/hystrix-contrib/hystrix-javanica/build.gradle
@@ -100,7 +100,6 @@ dependencies {
     compile "org.aspectj:aspectjrt:$aspectjVersion"
 
     compile 'com.google.guava:guava:15.0'
-    compile 'commons-collections:commons-collections:3.2.2'
     compile 'org.apache.commons:commons-lang3:3.1'
     compile 'com.google.code.findbugs:jsr305:2.0.0'
     compile 'org.ow2.asm:asm:5.0.4'


### PR DESCRIPTION
commons-collections is no longer used in this project, previously it was only used for a null check in FallbackMethod.java