### PR TITLE
assert the circuitBreakerForceClosed property

### DIFF
--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/hystrixCommand.js
@@ -174,6 +174,7 @@
             assertNotNull(data,"propertyValue_circuitBreakerSleepWindowInMilliseconds");
             assertNotNull(data,"propertyValue_circuitBreakerErrorThresholdPercentage");
             assertNotNull(data,"propertyValue_circuitBreakerForceOpen");
+            assertNotNull(data,"propertyValue_circuitBreakerForceClosed");
             assertNotNull(data,"propertyValue_executionIsolationStrategy");
             assertNotNull(data,"propertyValue_executionIsolationThreadTimeoutInMilliseconds");
             assertNotNull(data,"propertyValue_executionIsolationThreadInterruptOnTimeout");


### PR DESCRIPTION
The motivation here is the "propertyValue_circuitBreakerForceOpen" is currently being checked to make sure there is a value.  

It would make sense that the "propertyValue_circuitBreakerForceClosed" value also be checked