### PR TITLE
Fixed a potential bug in metrics-event-stream-jaxrs

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/AbstractHystrixStreamController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/AbstractHystrixStreamController.java
@@ -44,8 +44,6 @@ public abstract class AbstractHystrixStreamController {
 
 	private final int pausePollerThreadDelayInMs;
 
-	private static final AtomicInteger concurrentConnections = new AtomicInteger(0);
-
 	protected AbstractHystrixStreamController(Observable<String> sampleStream) {
 		this(sampleStream, DEFAULT_PAUSE_POLLER_THREAD_DELAY_IN_MS);
 	}
@@ -57,9 +55,7 @@ public abstract class AbstractHystrixStreamController {
 
 	protected abstract int getMaxNumberConcurrentConnectionsAllowed();
 
-	protected final AtomicInteger getCurrentConnections() {
-		return concurrentConnections;
-	}
+	protected abstract AtomicInteger getCurrentConnections();
 
 	/**
 	 * Maintain an open connection with the client. On initial connection send latest data of each requested event type and subsequently send all changes for each requested event type.

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixConfigSseController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixConfigSseController.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.hystrix.contrib.metrics.controller;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
@@ -47,6 +49,7 @@ import com.netflix.hystrix.serial.SerialHystrixConfiguration;
 @Path("/hystrix/config.stream")
 public class HystrixConfigSseController extends AbstractHystrixStreamController {
 
+	private static final AtomicInteger concurrentConnections = new AtomicInteger(0);
 	private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.config.stream.maxConcurrentConnections", 5);
 
 	public HystrixConfigSseController() {
@@ -67,5 +70,11 @@ public class HystrixConfigSseController extends AbstractHystrixStreamController 
 	protected int getMaxNumberConcurrentConnectionsAllowed() {
 		return maxConcurrentConnections.get();
 	}
+
+	@Override
+	protected AtomicInteger getCurrentConnections()  {
+		return concurrentConnections;
+	}
+	
 
 }

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixMetricsStreamController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixMetricsStreamController.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.hystrix.contrib.metrics.controller;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
@@ -47,6 +49,7 @@ import com.netflix.hystrix.serial.SerialHystrixDashboardData;
 @Path("/hystrix.stream")
 public class HystrixMetricsStreamController extends AbstractHystrixStreamController {
 
+	private static final AtomicInteger concurrentConnections = new AtomicInteger(0);
 	private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.config.stream.maxConcurrentConnections", 5);
 
 	public HystrixMetricsStreamController() {
@@ -66,6 +69,10 @@ public class HystrixMetricsStreamController extends AbstractHystrixStreamControl
 	@Override
 	protected int getMaxNumberConcurrentConnectionsAllowed() {
 		return maxConcurrentConnections.get();
+	}
+	@Override
+	protected AtomicInteger getCurrentConnections()  {
+		return concurrentConnections;
 	}
 
 }

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixRequestEventsSseController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixRequestEventsSseController.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.hystrix.contrib.metrics.controller;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
@@ -48,6 +50,7 @@ import com.netflix.hystrix.serial.SerialHystrixRequestEvents;
 @Path("/hystrix/request.stream")
 public class HystrixRequestEventsSseController extends AbstractHystrixStreamController {
 
+	private static final AtomicInteger concurrentConnections = new AtomicInteger(0);
 	private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.config.stream.maxConcurrentConnections", 5);
 
 	public HystrixRequestEventsSseController() {
@@ -69,4 +72,8 @@ public class HystrixRequestEventsSseController extends AbstractHystrixStreamCont
 		return maxConcurrentConnections.get();
 	}
 
+	@Override
+	protected AtomicInteger getCurrentConnections()  {
+		return concurrentConnections;
+	}
 }

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixUtilizationSseController.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/main/java/com/netflix/hystrix/contrib/metrics/controller/HystrixUtilizationSseController.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.hystrix.contrib.metrics.controller;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
@@ -47,6 +49,7 @@ import com.netflix.hystrix.serial.SerialHystrixUtilization;
 @Path("/hystrix/utilization.stream")
 public class HystrixUtilizationSseController extends AbstractHystrixStreamController {
 
+	private static final AtomicInteger concurrentConnections = new AtomicInteger(0);
 	private static DynamicIntProperty maxConcurrentConnections = DynamicPropertyFactory.getInstance().getIntProperty("hystrix.config.stream.maxConcurrentConnections", 5);
 
 	public HystrixUtilizationSseController() {
@@ -66,6 +69,11 @@ public class HystrixUtilizationSseController extends AbstractHystrixStreamContro
 	@Override
 	protected int getMaxNumberConcurrentConnectionsAllowed() {
 		return maxConcurrentConnections.get();
+	}
+	
+	@Override
+	protected AtomicInteger getCurrentConnections()  {
+		return concurrentConnections;
 	}
 
 }

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/StreamingOutputProviderTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/StreamingOutputProviderTest.java
@@ -80,10 +80,14 @@ public class StreamingOutputProviderTest {
 	}).subscribeOn(Schedulers.computation());
 
 	private AbstractHystrixStreamController sse = new AbstractHystrixStreamController(streamOfOnNexts) {
-
+		private  final AtomicInteger concurrentConnections = new AtomicInteger(0);
 		@Override
 		protected int getMaxNumberConcurrentConnectionsAllowed() {
 			return 2;
+		}
+		@Override
+		protected AtomicInteger getCurrentConnections() {
+			return concurrentConnections;
 		}
 
 	};


### PR DESCRIPTION
I had defined `currentConcurrentConnections` as a static variable in abstract class by mistake which caused it to be shared between implementations which was wrong. Now, I have moved it to the implementation class. This was the reason tests where failing sometimes.