### PR TITLE
Support multiple circuit status for Hystrix Dashboard

### DIFF
--- a/hystrix-dashboard/src/main/webapp/components/hystrixCommand/templates/hystrixCircuit.html
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixCommand/templates/hystrixCircuit.html
@@ -43,7 +43,11 @@
 			<% } else {
 				/* We have some circuits that are open */  
 			%>
-				Circuit <font color="orange"><%= isCircuitBreakerOpen.toString().replace("true", "Open").replace("false", "Closed") %></font>
+				<% if(typeof isCircuitBreakerOpen === 'object' ) { %>
+					Circuit <font color="orange">Open <%= isCircuitBreakerOpen.true %></font> <font color="green">Closed <%= isCircuitBreakerOpen.false %></font>
+				<% } else { %>
+					Circuit <font color="orange"><%= isCircuitBreakerOpen.toString().replace("true", "Open").replace("false", "Closed") %></font>
+				<% } %>
 			<% }  %>
 		<% } %>
 		</div>


### PR DESCRIPTION
Hystrix Dashboard displays `[object Object]` on circuit status when isCircuitBreakerOpen is aggregate using Turbine stream.

<img width="373" alt="2017-04-25 6 54 49" src="https://cloud.githubusercontent.com/assets/1837478/25381531/1dc67716-29ef-11e7-8c0d-93f16655469f.png">

I fixed it like this :

<img width="393" alt="2017-04-25 6 53 21" src="https://cloud.githubusercontent.com/assets/1837478/25381545/29a47222-29ef-11e7-9f70-363457eb4c7d.png">
