### PR TITLE
bugfix/Fixing typo in fallback error message

### DIFF
--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/command/AbstractHystrixCommand.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/command/AbstractHystrixCommand.java
@@ -202,7 +202,7 @@ public abstract class AbstractHystrixCommand<T> extends com.netflix.hystrix.Hyst
      * Builder to create error message for failed fallback operation.
      */
     static class FallbackErrorMessageBuilder {
-        private StringBuilder builder = new StringBuilder("failed to processed fallback");
+        private StringBuilder builder = new StringBuilder("failed to process fallback");
 
         static FallbackErrorMessageBuilder create() {
             return new FallbackErrorMessageBuilder();


### PR DESCRIPTION
Error message "failed to processed fallback" should be "failed to process fallback".