### PR TITLE
Handle not wrapped exceptions same way as all other

### DIFF
--- a/hystrix-core/src/test/java/com/netflix/hystrix/NotWrappedByHystrixTestRuntimeException.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/NotWrappedByHystrixTestRuntimeException.java
@@ -5,4 +5,7 @@ import com.netflix.hystrix.exception.ExceptionNotWrappedByHystrix;
 public class NotWrappedByHystrixTestRuntimeException extends RuntimeException implements ExceptionNotWrappedByHystrix {
     private static final long serialVersionUID = 1L;
 
+    public NotWrappedByHystrixTestRuntimeException() {
+        super("Raw exception for TestHystrixCommand");
+    }
 }


### PR DESCRIPTION
Closes #1536

First of all I want to note that this change is **breaking** one as far as I can see.

While most of my motivation is in #1536 and I will put an overview and some extra thoughts here:

`Hystrix` had that nice idea that `BadRequestException` was designed to bypass fallbacks. It was a really nice feature that allowed users of `Hystrix` to make a difference between execution errors and some conditional (so called "expected") errors e.g. validation.

#1414 #1503 introduced that nice concept of exception unwrapping which is really cool and I'm grateful to authors to have this feature. It has only one flaw - it has broken an idea of `BadRequestException`. Now any exception that implements `ExceptionNotWrappedByHystrix` leaves no choice to user if he wants to have fallbacks available - not to use it.

This PR solves this issue.
I hope I haven't broken a lot.

So the consequences of this PR:

* users need to review their logic as all fallbacks will start to work in case of exceptions marked by `ExceptionNotWrappedByHystrix`