### PR TITLE
Made circuit-opening happen in background

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -520,7 +520,7 @@ import java.util.concurrent.atomic.AtomicReference;
         executionHook.onStart(_cmd);
 
         /* determine if we're allowed to execute */
-        if (circuitBreaker.allowRequest()) {
+        if (circuitBreaker.attemptExecution()) {
             final TryableSemaphore executionSemaphore = getExecutionSemaphore();
             final AtomicBoolean semaphoreHasBeenReleased = new AtomicBoolean(false);
             final Action0 singleSemaphoreRelease = new Action0() {
@@ -601,6 +601,7 @@ import java.util.concurrent.atomic.AtomicReference;
         final Func1<Throwable, Observable<R>> handleFallback = new Func1<Throwable, Observable<R>>() {
             @Override
             public Observable<R> call(Throwable t) {
+                circuitBreaker.markNonSuccess();
                 Exception e = getExceptionFromThrowable(t);
                 executionResult = executionResult.setExecutionException(e);
                 if (e instanceof RejectedExecutionException) {

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCommandMetrics.java
@@ -343,6 +343,10 @@ public class HystrixCommandMetrics extends HystrixMetrics {
         }
     }
 
+    /* package-private */ HealthCountsStream getHealthCountsStream() {
+        return healthCountsStream;
+    }
+
     /**
      * Retrieve a snapshot of total requests, error count and error percentage.
      *


### PR DESCRIPTION
as health counts stream produces new values

* This allows for methods which imply reading the circuit-breaker status (isOpen/allowRequest) to be idempotent
* Added new method (attemptExecution), which command internally uses to actually manipulate status

Addresses #1541 