### PR TITLE
throw IllegalStateException if request cache is not available when clearing

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixRequestCache.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixRequestCache.java
@@ -129,7 +129,7 @@ public class HystrixRequestCache {
             /* look for the stored value */
             ConcurrentHashMap<ValueCacheKey, HystrixCachedObservable<?>> cacheInstance = requestVariableForCache.get(concurrencyStrategy);
             if (cacheInstance == null) {
-                throw new IllegalStateException("Request caching is not available.  Maybe you need to initialize the HystrixRequestContext?");
+                throw new IllegalStateException("Request caching is not available. Maybe you need to initialize the HystrixRequestContext?");
             }
             HystrixCachedObservable<T> alreadySet = (HystrixCachedObservable<T>) cacheInstance.putIfAbsent(key, f);
             if (alreadySet != null) {
@@ -150,8 +150,13 @@ public class HystrixRequestCache {
     public void clear(String cacheKey) {
         ValueCacheKey key = getRequestCacheKey(cacheKey);
         if (key != null) {
+            ConcurrentHashMap<ValueCacheKey, HystrixCachedObservable<?>> cacheInstance = requestVariableForCache.get(concurrencyStrategy);
+            if (cacheInstance == null) {
+                throw new IllegalStateException("Request caching is not available. Maybe you need to initialize the HystrixRequestContext?");
+            }
+
             /* remove this cache key */
-            requestVariableForCache.get(concurrencyStrategy).remove(key);
+            cacheInstance.remove(key);
         }
     }
 


### PR DESCRIPTION
While an `IllegalStateException` is already thrown when the `ConcurrentHashMap` cannot be retrieved for getting or putting to it, this will also throw an exception when it is not available when clearing.