### PR TITLE
Possibility to add custom root node for command and thread pool metrics

### DIFF
--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisher.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisher.java
@@ -55,7 +55,7 @@ public class HystrixCodaHaleMetricsPublisher extends HystrixMetricsPublisher {
 
     @Override
     public HystrixMetricsPublisherThreadPool getMetricsPublisherForThreadPool(HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolMetrics metrics, HystrixThreadPoolProperties properties) {
-        return new HystrixCodaHaleMetricsPublisherThreadPool(threadPoolKey, metrics, properties, metricRegistry);
+        return new HystrixCodaHaleMetricsPublisherThreadPool(metricsRootNode, threadPoolKey, metrics, properties, metricRegistry);
     }
 
     @Override

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisher.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisher.java
@@ -36,15 +36,21 @@ import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisherThreadPool;
  * Coda Hale Metrics (https://github.com/codahale/metrics) implementation of {@link HystrixMetricsPublisher}.
  */
 public class HystrixCodaHaleMetricsPublisher extends HystrixMetricsPublisher {
+    private final String metricsRootNode;
     private final MetricRegistry metricRegistry;
 
     public HystrixCodaHaleMetricsPublisher(MetricRegistry metricRegistry) {
+        this(null, metricRegistry);
+    }
+
+    public HystrixCodaHaleMetricsPublisher(String metricsRootNode, MetricRegistry metricRegistry) {
+        this.metricsRootNode = metricsRootNode;
         this.metricRegistry = metricRegistry;
     }
 
     @Override
     public HystrixMetricsPublisherCommand getMetricsPublisherForCommand(HystrixCommandKey commandKey, HystrixCommandGroupKey commandGroupKey, HystrixCommandMetrics metrics, HystrixCircuitBreaker circuitBreaker, HystrixCommandProperties properties) {
-        return new HystrixCodaHaleMetricsPublisherCommand(commandKey, commandGroupKey, metrics, circuitBreaker, properties, metricRegistry);
+        return new HystrixCodaHaleMetricsPublisherCommand(metricsRootNode, commandKey, commandGroupKey, metrics, circuitBreaker, properties, metricRegistry);
     }
 
     @Override

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
@@ -29,6 +29,7 @@ import rx.functions.Func0;
  * Implementation of {@link HystrixMetricsPublisherCommand} using Coda Hale Metrics (https://github.com/codahale/metrics)
  */
 public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPublisherCommand {
+    private final String metricsRootNode;
     private final HystrixCommandKey key;
     private final HystrixCommandGroupKey commandGroupKey;
     private final HystrixCommandMetrics metrics;
@@ -41,6 +42,11 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
     static final Logger logger = LoggerFactory.getLogger(HystrixCodaHaleMetricsPublisherCommand.class);
 
     public HystrixCodaHaleMetricsPublisherCommand(HystrixCommandKey commandKey, HystrixCommandGroupKey commandGroupKey, HystrixCommandMetrics metrics, HystrixCircuitBreaker circuitBreaker, HystrixCommandProperties properties, MetricRegistry metricRegistry) {
+        this(null, commandKey, commandGroupKey, metrics, circuitBreaker, properties, metricRegistry);
+    }
+
+    public HystrixCodaHaleMetricsPublisherCommand(String metricsRootNode, HystrixCommandKey commandKey, HystrixCommandGroupKey commandGroupKey, HystrixCommandMetrics metrics, HystrixCircuitBreaker circuitBreaker, HystrixCommandProperties properties, MetricRegistry metricRegistry) {
+        this.metricsRootNode = metricsRootNode;
         this.key = commandKey;
         this.commandGroupKey = commandGroupKey;
         this.metrics = metrics;
@@ -494,7 +500,7 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
     }
 
     protected String createMetricName(String name) {
-        return MetricRegistry.name(metricGroup, metricType, name);
+        return MetricRegistry.name(metricsRootNode, metricGroup, metricType, name);
     }
 
     protected void createCumulativeCountForEvent(final String name, final HystrixRollingNumberEvent event) {

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommand.java
@@ -41,10 +41,6 @@ public class HystrixCodaHaleMetricsPublisherCommand implements HystrixMetricsPub
 
     static final Logger logger = LoggerFactory.getLogger(HystrixCodaHaleMetricsPublisherCommand.class);
 
-    public HystrixCodaHaleMetricsPublisherCommand(HystrixCommandKey commandKey, HystrixCommandGroupKey commandGroupKey, HystrixCommandMetrics metrics, HystrixCircuitBreaker circuitBreaker, HystrixCommandProperties properties, MetricRegistry metricRegistry) {
-        this(null, commandKey, commandGroupKey, metrics, circuitBreaker, properties, metricRegistry);
-    }
-
     public HystrixCodaHaleMetricsPublisherCommand(String metricsRootNode, HystrixCommandKey commandKey, HystrixCommandGroupKey commandGroupKey, HystrixCommandMetrics metrics, HystrixCircuitBreaker circuitBreaker, HystrixCommandProperties properties, MetricRegistry metricRegistry) {
         this.metricsRootNode = metricsRootNode;
         this.key = commandKey;

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherThreadPool.java
@@ -39,11 +39,6 @@ public class HystrixCodaHaleMetricsPublisherThreadPool implements HystrixMetrics
 
     static final Logger logger = LoggerFactory.getLogger(HystrixCodaHaleMetricsPublisherThreadPool.class);
 
-    public HystrixCodaHaleMetricsPublisherThreadPool(HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolMetrics metrics, HystrixThreadPoolProperties properties, MetricRegistry metricRegistry) {
-        this(null, threadPoolKey, metrics,properties, metricRegistry);
-    }
-
-
     public HystrixCodaHaleMetricsPublisherThreadPool(String metricsRootNode, HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolMetrics metrics, HystrixThreadPoolProperties properties, MetricRegistry metricRegistry) {
         this.metricsRootNode = metricsRootNode;
         this.key = threadPoolKey;

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherThreadPool.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
  * Implementation of {@link HystrixMetricsPublisherThreadPool} using Coda Hale Metrics (https://github.com/codahale/metrics)
  */
 public class HystrixCodaHaleMetricsPublisherThreadPool implements HystrixMetricsPublisherThreadPool {
+    private final String metricsRootNode;
     private final HystrixThreadPoolKey key;
     private final HystrixThreadPoolMetrics metrics;
     private final HystrixThreadPoolProperties properties;
@@ -39,6 +40,12 @@ public class HystrixCodaHaleMetricsPublisherThreadPool implements HystrixMetrics
     static final Logger logger = LoggerFactory.getLogger(HystrixCodaHaleMetricsPublisherThreadPool.class);
 
     public HystrixCodaHaleMetricsPublisherThreadPool(HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolMetrics metrics, HystrixThreadPoolProperties properties, MetricRegistry metricRegistry) {
+        this(null, threadPoolKey, metrics,properties, metricRegistry);
+    }
+
+
+    public HystrixCodaHaleMetricsPublisherThreadPool(String metricsRootNode, HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolMetrics metrics, HystrixThreadPoolProperties properties, MetricRegistry metricRegistry) {
+        this.metricsRootNode = metricsRootNode;
         this.key = threadPoolKey;
         this.metrics = metrics;
         this.properties = properties;
@@ -183,6 +190,6 @@ public class HystrixCodaHaleMetricsPublisherThreadPool implements HystrixMetrics
     }
 
     protected String createMetricName(String name) {
-        return MetricRegistry.name(metricGroup, metricType, name);
+        return MetricRegistry.name(metricsRootNode, metricGroup, metricType, name);
     }
 }

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/test/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommandTest.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/test/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommandTest.java
@@ -1,16 +1,12 @@
 package com.netflix.hystrix.contrib.codahalemetricspublisher;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.strategy.HystrixPlugins;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -20,7 +16,7 @@ public class HystrixCodaHaleMetricsPublisherCommandTest {
 
     @Before
     public void setup() {
-        HystrixPlugins.getInstance().registerMetricsPublisher(new HystrixCodaHaleMetricsPublisher(metricRegistry));
+        HystrixPlugins.getInstance().registerMetricsPublisher(new HystrixCodaHaleMetricsPublisher("hystrix", metricRegistry));
     }
 
     @Test
@@ -30,13 +26,13 @@ public class HystrixCodaHaleMetricsPublisherCommandTest {
 
         Thread.sleep(1000);
 
-        assertThat((Long) metricRegistry.getGauges().get("test.test.countSuccess").getValue(), is(1L));
+        assertThat((Long) metricRegistry.getGauges().get("hystrix.testGroup.testCommand.countSuccess").getValue(), is(1L));
 
     }
 
     private static class Command extends HystrixCommand<Void> {
-        final static HystrixCommandKey hystrixCommandKey = HystrixCommandKey.Factory.asKey("test");
-        final static HystrixCommandGroupKey hystrixCommandGroupKey = HystrixCommandGroupKey.Factory.asKey("test");
+        final static HystrixCommandKey hystrixCommandKey = HystrixCommandKey.Factory.asKey("testCommand");
+        final static HystrixCommandGroupKey hystrixCommandGroupKey = HystrixCommandGroupKey.Factory.asKey("testGroup");
 
         Command() {
             super(Setter.withGroupKey(hystrixCommandGroupKey).andCommandKey(hystrixCommandKey));

--- a/hystrix-contrib/hystrix-codahale-metrics-publisher/src/test/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommandTest.java
+++ b/hystrix-contrib/hystrix-codahale-metrics-publisher/src/test/java/com/netflix/hystrix/contrib/codahalemetricspublisher/HystrixCodaHaleMetricsPublisherCommandTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixThreadPoolKey;
 import com.netflix.hystrix.strategy.HystrixPlugins;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,15 +28,17 @@ public class HystrixCodaHaleMetricsPublisherCommandTest {
         Thread.sleep(1000);
 
         assertThat((Long) metricRegistry.getGauges().get("hystrix.testGroup.testCommand.countSuccess").getValue(), is(1L));
+        assertThat((Long) metricRegistry.getGauges().get("hystrix.HystrixThreadPool.threadGroup.totalTaskCount").getValue(), is(1L));
 
     }
 
     private static class Command extends HystrixCommand<Void> {
         final static HystrixCommandKey hystrixCommandKey = HystrixCommandKey.Factory.asKey("testCommand");
         final static HystrixCommandGroupKey hystrixCommandGroupKey = HystrixCommandGroupKey.Factory.asKey("testGroup");
+        final static HystrixThreadPoolKey hystrixThreadPool = HystrixThreadPoolKey.Factory.asKey("threadGroup");
 
         Command() {
-            super(Setter.withGroupKey(hystrixCommandGroupKey).andCommandKey(hystrixCommandKey));
+            super(Setter.withGroupKey(hystrixCommandGroupKey).andCommandKey(hystrixCommandKey).andThreadPoolKey(hystrixThreadPool));
         }
 
         @Override


### PR DESCRIPTION
Currently, command and thread pool metrics are stored in the same root ( commandGroup.commandName... and HystrixThreadPool.commadGroup....).

This PR allows to store metrics in the provided root node i.e. hystrix.commandGroup.commandName... , so they are not stored in the same root as other metrics.