### PR TITLE
Fix metrics ignore CommandGroup when calculating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Hystrix Releases #
 
+### Version 1.5.12 ([Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.hystrix%22%20AND%20v%3A%221.5.12%22), [Bintray](https://bintray.com/netflixoss/maven/Hystrix/1.5.12/)) ###
+
+- [Pull 1586](https://github.com/Netflix/Hystrix/pull/1586) Start streams for CodaHale metric consumer, ot get it actually working
+- [Pull 1584](https://github.com/Netflix/Hystrix/pull/1584) Javanica: Wire up allowMaximumSizeToDivergeFromCoreSize thread-pool property
+- [Pull 1585](https://github.com/Netflix/Hystrix/pull/1585) Fix actualMaximumSize Codahale threadpool metric calculation
+- [Pull 1567](https://github.com/Netflix/Hystrix/pull/1567) Fix interaction between ExceptionNotWrappedInHystrix and HystrixBadRequestException.  Thanks @gagoman !
+- [Pull 1576](https://github.com/Netflix/Hystrix/pull/1576) Fix permyriad calculation for 99.9p latency
+- [Pull 1524](https://github.com/Netflix/Hystrix/pull/1524) Javanica: Support rx.Single or rx.Completable types.  Thanks @dmgcodevil !
+- [Pull 1574](https://github.com/Netflix/Hystrix/pull/1574) Add unit-test for using a Completable in a HystrixObservableCommand
+- [Pull 1572](https://github.com/Netflix/Hystrix/pull/1572) Javanica: Wire up maximumSize thread-pool property.  Thanks @dmgcodevil !
+- [Pull 1573](https://github.com/Netflix/Hystrix/pull/1573) Javanica: Don't get cause from HystrixBadRequestException if null.  Thanks @dmgcodevil !
+- [Pull 1570](https://github.com/Netflix/Hystrix/pull/1570) Only create HystrixContextRunnable in timeout case lazily, when timeout is fired
+- [Pull 1568](https://github.com/Netflix/Hystrix/pull/1568) Made circuit-opening happen in background thread, powered by metric streams
+- [Pull 1561](https://github.com/Netflix/Hystrix/pull/1561) Add error-handling for unexpected errors to servlet writes in metric sample servlet
+- [Pull 1556](https://github.com/Netflix/Hystrix/pull/1556) Typo fix in Javanica fallback log. Thanks @Thunderforge !
+- [Pull 1551](https://github.com/Netflix/Hystrix/pull/1551) Match colors in multiple circuit-breaker status case.  Thanks @eunmin !
+- [Pull 1547](https://github.com/Netflix/Hystrix/pull/1547) Support multiple circuit-breaker statuses in dashboard against aggregated data.  Thanks @eunmin !
+- [Pull 1539](https://github.com/Netflix/Hystrix/pull/1539) Fix unintentionally shared variable in hystrix-metrics-event-stream-jaxrs.  Thanks @justinjose28 !
+- [Pull 1535](https://github.com/Netflix/Hystrix/pull/1535) Move markCommandExecution after markEvent SUCCESS to allow eventNotifier to have full context of execution.  Thanks @bltb!
+
 ### Version 1.5.11 ([Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.hystrix%22%20AND%20v%3A%221.5.11%22), [Bintray](https://bintray.com/netflixoss/maven/Hystrix/1.5.11/)) ###
 
 - [Pull 1531](https://github.com/Netflix/Hystrix/pull/1531) Add assertion to dashboard receiving metrics data.  Thanks @lholmquist !

--- a/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/AbstractCommand.java
@@ -303,7 +303,7 @@ import java.util.concurrent.atomic.AtomicReference;
      * @param sizeOfBatch number of commands in request batch
      */
     /* package */void markAsCollapsedCommand(HystrixCollapserKey collapserKey, int sizeOfBatch) {
-        eventNotifier.markEvent(HystrixEventType.COLLAPSED, this.metricsCommandKey);
+        eventNotifier.markEvent(HystrixEventType.COLLAPSED, this.commandKey);
         executionResult = executionResult.markCollapsed(collapserKey, sizeOfBatch);
     }
 
@@ -392,7 +392,7 @@ import java.util.concurrent.atomic.AtomicReference;
             public void call() {
                 if (_cmd.commandState.compareAndSet(CommandState.OBSERVABLE_CHAIN_CREATED, CommandState.UNSUBSCRIBED)) {
                     if (!_cmd.executionResult.containsTerminalEvent()) {
-                        _cmd.eventNotifier.markEvent(HystrixEventType.CANCELLED, _cmd.metricsCommandKey);
+                        _cmd.eventNotifier.markEvent(HystrixEventType.CANCELLED, _cmd.commandKey);
                         try {
                             executionHook.onUnsubscribe(_cmd);
                         } catch (Throwable hookEx) {
@@ -404,7 +404,7 @@ import java.util.concurrent.atomic.AtomicReference;
                     handleCommandEnd(false); //user code never ran
                 } else if (_cmd.commandState.compareAndSet(CommandState.USER_CODE_EXECUTED, CommandState.UNSUBSCRIBED)) {
                     if (!_cmd.executionResult.containsTerminalEvent()) {
-                        _cmd.eventNotifier.markEvent(HystrixEventType.CANCELLED, _cmd.metricsCommandKey);
+                        _cmd.eventNotifier.markEvent(HystrixEventType.CANCELLED, _cmd.commandKey);
                         try {
                             executionHook.onUnsubscribe(_cmd);
                         } catch (Throwable hookEx) {
@@ -1150,7 +1150,7 @@ import java.util.concurrent.atomic.AtomicReference;
                     // otherwise it means we lost a race and the run() execution completed or did not start
                     if (originalCommand.isCommandTimedOut.compareAndSet(TimedOutStatus.NOT_EXECUTED, TimedOutStatus.TIMED_OUT)) {
                         // report timeout failure
-                        originalCommand.eventNotifier.markEvent(HystrixEventType.TIMEOUT, originalCommand.metricsCommandKey);
+                        originalCommand.eventNotifier.markEvent(HystrixEventType.TIMEOUT, originalCommand.commandKey);
 
                         // shut down the original request
                         s.unsubscribe();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsPublisherFactory.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/metrics/HystrixMetricsPublisherFactory.java
@@ -102,17 +102,18 @@ public class HystrixMetricsPublisherFactory {
 
     /* package */ HystrixMetricsPublisherCommand getPublisherForCommand(HystrixCommandKey commandKey, HystrixCommandGroupKey commandOwner, HystrixCommandMetrics metrics, HystrixCircuitBreaker circuitBreaker, HystrixCommandProperties properties) {
         // attempt to retrieve from cache first
-        HystrixMetricsPublisherCommand publisher = commandPublishers.get(commandKey.name());
+        final String cacheKey = commandOwner == null ? commandKey.name() : commandOwner.name() + "." + commandKey.name();
+        HystrixMetricsPublisherCommand publisher = commandPublishers.get(cacheKey);
         if (publisher != null) {
             return publisher;
         } else {
             synchronized (this) {
-                HystrixMetricsPublisherCommand existingPublisher = commandPublishers.get(commandKey.name());
+                HystrixMetricsPublisherCommand existingPublisher = commandPublishers.get(cacheKey);
                 if (existingPublisher != null) {
                     return existingPublisher;
                 } else {
                     HystrixMetricsPublisherCommand newPublisher = HystrixPlugins.getInstance().getMetricsPublisher().getMetricsPublisherForCommand(commandKey, commandOwner, metrics, circuitBreaker, properties);
-                    commandPublishers.putIfAbsent(commandKey.name(), newPublisher);
+                    commandPublishers.putIfAbsent(cacheKey, newPublisher);
                     newPublisher.initialize();
                     return newPublisher;
                 }


### PR DESCRIPTION
## Issue :

Metrics in HystrixMetricsPublisherFactory are cached by CommandKey, while the full metric name is generated with CommandGroup being part of the path. 

For example, 
 ```
groupA.commandA
 groupB.commandA
 groupC.commandA
```

Would generate one single metric `groupX.commandA`, where _X_ is the CommandGroup which happened to be executed first. 

Same by-command-key caching is in **HystrixCommandMetrics**. 

Other caching instances are the streams : _RollingCommandEventCounterStream, CumulativeCommandEventCounterStream, CumulativeCommandEventCounterStream,_ etc.. 

## This pull request

The challenging part is with stream registries:  their public API to get instances don't take CommandGroup parameter, making impossible to generate a proper cache key without breaking backward compatibility.  

In order to bypass this limitation, a fake `metricsCommandKey` was introduced, which has name formed using both commandGroup and commandKey.
It is used when instantiating HystrixCommandMetrics instance, as well as in all calls on it.

The HystrixMetricsPublisherFactory takes original commandKey and makes cache key on its own, since later on group+key is used to generate full metric name.


This is a hack, most probably the right solution would be to change the API to take CommandGroup everywhere. 



