### PR TITLE
Escape user entered input to avoid HTML injection. This fixes #1456

### DIFF
--- a/hystrix-dashboard/src/main/webapp/index.html
+++ b/hystrix-dashboard/src/main/webapp/index.html
@@ -24,7 +24,7 @@
 
 				streams.push(s);
 				$('#streams').html('<table>' + _.reduce(streams, function(html, s) {
-                            return html + '<tr><td>' + s.name + '</td><td>' + s.stream + '</td> <td><a href="#" onclick="removeStream(this);">Remove</a></td> </tr>';
+                            return html + '<tr><td>' + _.escape(s.name) + '</td><td>' + _.escape(s.stream) + '</td> <td><a href="#" onclick="removeStream(this);">Remove</a></td> </tr>';
 				}, '') + '</table>');
 
 				$('#message').html("");


### PR DESCRIPTION
Using [underscore escape](http://underscorejs.org/#escape) function, the user entered input is escaped.

