### PR TITLE
Hystrix code corrections

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCachedObservable.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCachedObservable.java
@@ -6,7 +6,7 @@ import rx.functions.Action0;
 import rx.subjects.ReplaySubject;
 
 public class HystrixCachedObservable<R> {
-    protected final Subscription originalSubscription;
+    private final Subscription originalSubscription;
     protected final Observable<R> cachedObservable;
     private volatile int outstandingSubscriptions = 0;
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/metric/HystrixCommandCompletion.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/metric/HystrixCommandCompletion.java
@@ -91,7 +91,7 @@ public class HystrixCommandCompletion extends HystrixCommandEvent {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         List<HystrixEventType> foundEventTypes = new ArrayList<HystrixEventType>();
 
         sb.append(getCommandKey().name()).append("[");

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/Exceptions.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/Exceptions.java
@@ -14,6 +14,7 @@ public class Exceptions {
         return Exceptions.<RuntimeException>doThrow(t);
     }
 
+    @SuppressWarnings("unchecked")
     private static <T extends Throwable> T doThrow(Throwable ex) throws T {
         throw (T) ex;
     }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
@@ -152,7 +152,7 @@ public class HystrixTimer {
             HystrixPropertiesStrategy propertiesStrategy = HystrixPlugins.getInstance().getPropertiesStrategy();
             int coreSize = propertiesStrategy.getTimerThreadPoolProperties().getCorePoolSize().get();
 
-            ThreadFactory threadFactory = null;
+            ThreadFactory threadFactory;
             if (!PlatformSpecific.isAppEngineStandardEnvironment()) {
                 threadFactory = new ThreadFactory() {
                     final AtomicInteger counter = new AtomicInteger();

--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/Striped64.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/Striped64.java
@@ -260,8 +260,7 @@ abstract class Striped64 extends Number {
                     try {
                         if (cells == as) {      // Expand table unless stale
                             Cell[] rs = new Cell[n << 1];
-                            for (int i = 0; i < n; ++i)
-                                rs[i] = as[i];
+                            System.arraycopy(as, 0, rs, 0, n);
                             cells = rs;
                         }
                     } finally {

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCircuitBreakerTest.java
@@ -638,15 +638,15 @@ public class HystrixCircuitBreakerTest {
         return new HystrixCircuitBreakerImpl(key, commandGroup, HystrixCommandPropertiesTest.asMock(properties), metrics);
     }
 
-    private static enum CommandOwnerForUnitTest implements HystrixCommandGroupKey {
+    private enum CommandOwnerForUnitTest implements HystrixCommandGroupKey {
         OWNER_ONE, OWNER_TWO
     }
 
-    private static enum ThreadPoolKeyForUnitTest implements HystrixThreadPoolKey {
+    private enum ThreadPoolKeyForUnitTest implements HystrixThreadPoolKey {
         THREAD_POOL_ONE, THREAD_POOL_TWO
     }
 
-    private static enum CommandKeyForUnitTest implements HystrixCommandKey {
+    private enum CommandKeyForUnitTest implements HystrixCommandKey {
         KEY_ONE, KEY_TWO
     }
 
@@ -665,7 +665,7 @@ public class HystrixCircuitBreakerTest {
 
     }
 
-    void performLoad(int totalNumCalls, int errPerc, int waitMillis) {
+    private void performLoad(int totalNumCalls, int errPerc, int waitMillis) {
 
         Random rnd = new Random();
 
@@ -691,7 +691,7 @@ public class HystrixCircuitBreakerTest {
 
     public class TestCommand extends HystrixCommand<String> {
 
-        boolean error;
+        final boolean error;
 
         public TestCommand(final boolean error) {
             super(HystrixCommandGroupKey.Factory.asKey("group"));
@@ -809,18 +809,17 @@ public class HystrixCircuitBreakerTest {
     public class MyHystrixCommandExecutionHook extends HystrixCommandExecutionHook {
 
         @Override
-        public <T> T onComplete(final HystrixInvokable<T> command, final T response) {
+        public <T> T onEmit(final HystrixInvokable<T> command, final T response) {
 
             logHC(command, response);
 
-            return super.onComplete(command, response);
+            return super.onEmit(command, response);
         }
-
-        private int counter = 0;
 
         private <T> void logHC(HystrixInvokable<T> command, T response) {
 
             if(command instanceof HystrixInvokableInfo) {
+                @SuppressWarnings("unchecked")
                 HystrixInvokableInfo<T> commandInfo = (HystrixInvokableInfo<T>)command;
             HystrixCommandMetrics metrics = commandInfo.getMetrics();
             System.out.println("cb/error-count/%/total: "

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixCommandTest.java
@@ -1002,12 +1002,15 @@ public class HystrixCommandTest extends CommonHystrixCommandTests<TestHystrixCom
             fail("we shouldn't get here");
         } catch (Exception e) {
             e.printStackTrace();
-            System.out.println("command.getExecutionTimeInMilliseconds(): " + command2.getExecutionTimeInMilliseconds());
-            // will be -1 because it never attempted execution
-            assertTrue(command2.isResponseRejected());
-            assertFalse(command2.isResponseShortCircuited());
-            assertFalse(command2.isResponseTimedOut());
-            assertNotNull(command2.getExecutionException());
+            if (command2 != null) {
+                System.out.println(
+                        "command.getExecutionTimeInMilliseconds(): " + command2.getExecutionTimeInMilliseconds());
+                // will be -1 because it never attempted execution
+                assertTrue(command2.isResponseRejected());
+                assertFalse(command2.isResponseShortCircuited());
+                assertFalse(command2.isResponseTimedOut());
+                assertNotNull(command2.getExecutionException());
+            }
 
             if (e instanceof HystrixRuntimeException && e.getCause() instanceof RejectedExecutionException) {
                 HystrixRuntimeException de = (HystrixRuntimeException) e;

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -4355,7 +4355,6 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         try {
             Thread.sleep(100);
         } catch (InterruptedException ex) {
-
         }
         //HystrixCircuitBreaker.Factory.reset();
     }


### PR DESCRIPTION
Hystrix code corrections [ Used Hystrix today 👍  , looked a bit into hystrix code ]
- Corrected for NullPointerException case on null command2
- Used current onEmit instead of deprecated onComplete
- Used System.arrayCopy() java method directly
- Used StringBuilder
- inner enum is static by default
- narrowed scope to needed
