### PR TITLE
bug fix for issue https://github.com/Netflix/Hystrix/issues/1631

### DIFF
--- a/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/utils/AopUtils.java
+++ b/hystrix-contrib/hystrix-javanica/src/main/java/com/netflix/hystrix/contrib/javanica/utils/AopUtils.java
@@ -47,7 +47,7 @@ public final class AopUtils {
         Method method = null;
         if (joinPoint.getSignature() instanceof MethodSignature) {
             MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-            method = getDeclaredMethod(joinPoint.getTarget().getClass(), signature.getName(),
+            method = getDeclaredMethod(signature.getDeclaringType().getClass(), signature.getName(),
                     getParameterTypes(joinPoint));
         }
         return method;


### PR DESCRIPTION
Pull request for https://github.com/Netflix/Hystrix/issues/1631

NPE is thrown when com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand annotation is used applied on static method.

