### PR TITLE
Fix circuitBreaker may stay closed forever

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/Hystrix.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/Hystrix.java
@@ -66,16 +66,20 @@ public class Hystrix {
      * Reset logic that doesn't have time/TimeUnit arguments.
      */
     private static void _reset() {
+        // basic component should be reset first.
+        HystrixPlugins.reset();
+        HystrixPropertiesFactory.reset();
+
+        // clear circuit breakers
+        HystrixCircuitBreaker.Factory.reset();
+
         // clear metrics
         HystrixCommandMetrics.reset();
         HystrixThreadPoolMetrics.reset();
         HystrixCollapserMetrics.reset();
         // clear collapsers
         HystrixCollapser.reset();
-        // clear circuit breakers
-        HystrixCircuitBreaker.Factory.reset();
-        HystrixPlugins.reset();
-        HystrixPropertiesFactory.reset();
+
         currentCommand.set(new ConcurrentStack<HystrixCommandKey>());
     }
 

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
@@ -200,6 +200,8 @@ public interface HystrixCircuitBreaker {
                     });
         }
 
+
+
         @Override
         public void markSuccess() {
             if (status.compareAndSet(Status.HALF_OPEN, Status.CLOSED)) {
@@ -242,7 +244,7 @@ public interface HystrixCircuitBreaker {
             if (properties.circuitBreakerForceClosed().get()) {
                 return true;
             }
-            if (circuitOpened.get() == -1) {
+            if (status.get() == Status.CLOSED) {
                 return true;
             } else {
                 if (status.get().equals(Status.HALF_OPEN)) {
@@ -268,7 +270,7 @@ public interface HystrixCircuitBreaker {
             if (properties.circuitBreakerForceClosed().get()) {
                 return true;
             }
-            if (circuitOpened.get() == -1) {
+            if (status.get() == Status.CLOSED) {
                 return true;
             } else {
                 if (isAfterSleepWindow()) {


### PR DESCRIPTION
HystrixCircuitBreakerImpl use circuitOpen and status to present circuit status.
It is possible 
that circuitOpen == -1L and status == OPEN at the same time which would make attemptExecution return true fore ever.
![hystrixcircuitbreakerimpl](https://user-images.githubusercontent.com/1519187/28510215-955342f2-7079-11e7-8f2e-e9033b8e44fa.png)
In my case, seting sleepWindowInMilliseconds to 999 ms and using a 60% rate fail command is easy to reproduce this issue.


And.
reset should work from inner to outer. 
e.g. a new HystrixCircuitBreakerImpl after HystrixCircuitBreaker.Factory.reset() may still get the old HystrixCommandProperties before HystrixPropertiesFactory.reset().