### PR TITLE
Publish the value of the currentPoolSize property

### DIFF
--- a/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherThreadPool.java
+++ b/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherThreadPool.java
@@ -180,6 +180,13 @@ public class HystrixServoMetricsPublisherThreadPool extends HystrixServoMetricsP
             }
         });
 
+        monitors.add(new GaugeMetric(MonitorConfig.builder("currentPoolSize").build()) {
+            @Override
+            public Number getValue() {
+                return metrics.getCurrentPoolSize();
+            }
+        });
+
         monitors.add(new GaugeMetric(MonitorConfig.builder("completedTaskCount").build()) {
             @Override
             public Number getValue() {


### PR DESCRIPTION
Expose the currentPoolSize so it can be collected via servo / JMX and collected by application performance monitoring tools.