### PR TITLE
Add hystrix-junit5 module

### DIFF
--- a/hystrix-contrib/hystrix-junit5/build.gradle
+++ b/hystrix-contrib/hystrix-junit5/build.gradle
@@ -1,0 +1,7 @@
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+dependencies {
+    implementation project(':hystrix-core')
+    implementation "org.junit.jupiter:junit-jupiter-engine:5.0.1"
+}

--- a/hystrix-contrib/hystrix-junit5/src/main/java/com/hystrix/junit5/HystrixRequestContextExtension.java
+++ b/hystrix-contrib/hystrix-junit5/src/main/java/com/hystrix/junit5/HystrixRequestContextExtension.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hystrix.junit5;
+
+import com.netflix.hystrix.Hystrix;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
+import org.junit.jupiter.api.extension.*;
+
+/**
+ * JUnit 5 extension to be used to simplify tests that require a HystrixRequestContext.
+ * <p>
+ * Example of usage:
+ * <p>
+ * <blockquote>
+ * <pre>
+ *     @ExtendWith(HystrixRequestContextExtension.class)
+ *     public class HystrixTest {
+ *         private HystrixRequestContextExtension request;
+ *
+ *         public HystrixRequestContextExtensionTest(HystrixRequestContextExtension request) {
+ *             this.request = request;
+ *         }
+ *     }
+ * </pre>
+ * </blockquote>
+ */
+public class HystrixRequestContextExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private HystrixRequestContext context;
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext,
+                                     ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter()
+                .getType()
+                .equals(HystrixRequestContextExtension.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext,
+                                   ExtensionContext extensionContext) throws ParameterResolutionException {
+        return this;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        setup();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        shutdown();
+    }
+
+    public HystrixRequestContext context() {
+        return this.context;
+    }
+
+    public void reset() {
+        shutdown();
+        setup();
+    }
+
+    public final void setup() {
+        this.context = HystrixRequestContext.initializeContext();
+        Hystrix.reset();
+    }
+
+    public final void shutdown() {
+        if (this.context != null) {
+            this.context.shutdown();
+            this.context = null;
+        }
+    }
+}

--- a/hystrix-contrib/hystrix-junit5/src/test/java/com/hystrix/junit5/HystrixRequestContextExtensionTest.java
+++ b/hystrix-contrib/hystrix-junit5/src/test/java/com/hystrix/junit5/HystrixRequestContextExtensionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hystrix.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(HystrixRequestContextExtension.class)
+public class HystrixRequestContextExtensionTest {
+
+    // like JUnit 4 @Rule
+    private HystrixRequestContextExtension request;
+
+    public HystrixRequestContextExtensionTest(HystrixRequestContextExtension request) {
+        this.request = request;
+    }
+
+    @Test
+    public void initContext() {
+        assertNotNull(request.context());
+    }
+
+    @Test
+    public void manuallyShutdownContextDontBreak() {
+        this.request.shutdown();
+        this.request.shutdown();
+        assertNull(request.context());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ include 'hystrix-core', \
 'hystrix-contrib/hystrix-network-auditor-agent', \
 'hystrix-contrib/hystrix-javanica', \
 'hystrix-contrib/hystrix-junit', \
+'hystrix-contrib/hystrix-junit5', \
 'hystrix-dashboard', \
 'hystrix-serialization' 
 
@@ -27,3 +28,6 @@ project(':hystrix-contrib/hystrix-yammer-metrics-publisher').name = 'hystrix-yam
 project(':hystrix-contrib/hystrix-network-auditor-agent').name = 'hystrix-network-auditor-agent'
 project(':hystrix-contrib/hystrix-javanica').name = 'hystrix-javanica'
 project(':hystrix-contrib/hystrix-junit').name = 'hystrix-junit'
+project(':hystrix-contrib/hystrix-junit5').name = 'hystrix-junit5'
+
+


### PR DESCRIPTION
hystrix-junit5 contains `HystrixRequestContextExtension` to support JUnit 5 jupiter engine.
`HystrixRequestContextExtension` is same feature with hystrix-junit `HystrixRequestContextRule`.

NOTE: 