### PR TITLE
https://github.com/Netflix/Hystrix/issues/1697

### DIFF
--- a/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/hystrixThreadPool.js
+++ b/hystrix-dashboard/src/main/webapp/components/hystrixThreadPool/hystrixThreadPool.js
@@ -93,9 +93,6 @@
 		
 		function converAllAvg(data) {
 			convertAvg(data, "propertyValue_queueSizeRejectionThreshold", false);
-			
-			// the following will break when it becomes a compound string if the property is dynamically changed
-			convertAvg(data, "propertyValue_metricsRollingStatisticalWindowInMilliseconds", false);
 		}
 		
 		function convertAvg(data, key, decimal) {


### PR DESCRIPTION
Code changes to fix TPS calculation issue with hystrix thread pool in dashboard.

In previous changes Netflix hystrix issue-1251, we have updated TPS calculation for hystrixCommand in dashboard but this is not in sync with hystrixThreadpool so making this change to keep both in sync as currently we are getting different TPS value for hystrixCommand and hystrixThreadpool on dashboard.