### PR TITLE
[HYSTRIX-1721] - Fixes normal-case unsubscribes

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/ExecutionResult.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/ExecutionResult.java
@@ -138,6 +138,8 @@ public class ExecutionResult {
             return events.get(eventType.ordinal());
         }
 
+        public boolean noEvents() { return numCollapsed == 0 && numFallbackEmissions == 0 && numEmissions == 0; }
+
         public boolean containsAnyOf(BitSet other) {
             return events.intersects(other);
         }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2012 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,14 +35,14 @@ public interface HystrixCircuitBreaker {
      * Every {@link HystrixCommand} requests asks this if it is allowed to proceed or not.  It is idempotent and does
      * not modify any internal state, and takes into account the half-open logic which allows some requests through
      * after the circuit has been opened
-     * 
+     *
      * @return boolean whether a request should be permitted
      */
     boolean allowRequest();
 
     /**
      * Whether the circuit is currently open (tripped).
-     * 
+     *
      * @return boolean state of circuit breaker
      */
     boolean isOpen();
@@ -75,7 +75,7 @@ public interface HystrixCircuitBreaker {
          * Get the {@link HystrixCircuitBreaker} instance for a given {@link HystrixCommandKey}.
          * <p>
          * This is thread-safe and ensures only 1 {@link HystrixCircuitBreaker} per {@link HystrixCommandKey}.
-         * 
+         *
          * @param key
          *            {@link HystrixCommandKey} of {@link HystrixCommand} instance requesting the {@link HystrixCircuitBreaker}
          * @param group
@@ -111,7 +111,7 @@ public interface HystrixCircuitBreaker {
 
         /**
          * Get the {@link HystrixCircuitBreaker} instance for a given {@link HystrixCommandKey} or null if none exists.
-         * 
+         *
          * @param key
          *            {@link HystrixCommandKey} of {@link HystrixCommand} instance requesting the {@link HystrixCircuitBreaker}
          * @return {@link HystrixCircuitBreaker} for {@link HystrixCommandKey}
@@ -131,7 +131,7 @@ public interface HystrixCircuitBreaker {
 
     /**
      * The default production implementation of {@link HystrixCircuitBreaker}.
-     * 
+     *
      * @ExcludeFromJavadoc
      * @ThreadSafe
      */
@@ -211,7 +211,9 @@ public interface HystrixCircuitBreaker {
                 }
                 Subscription newSubscription = subscribeToStream();
                 activeSubscription.set(newSubscription);
-                circuitOpened.set(-1L);
+                if (status.get().equals(Status.CLOSED)) {
+                    circuitOpened.set(-1L);
+                }
             }
         }
 
@@ -290,7 +292,7 @@ public interface HystrixCircuitBreaker {
 
     /**
      * An implementation of the circuit breaker that does nothing.
-     * 
+     *
      * @ExcludeFromJavadoc
      */
     /* package */static class NoOpCircuitBreaker implements HystrixCircuitBreaker {


### PR DESCRIPTION
Operations on HysterixObservableCommand treat all unsubscriptions as unsuccessful. This should not be the case when an unsubscription is due to normal circumstances, e.g. zipping an observable that emits more items than the other one (see added test case in HysterixCircuitBreakerTest.

This patch marks a HysterixObservableCommand as completed if:
 - it hasn't timed out
 - it has a nonzero event count
 - it didn't fail to execute

There is also an added check at the end of markSuccess to fix the inconsistency of Status.CLOSED and circuitOpened. As described in https://github.com/Netflix/Hystrix/pull/1640, it is possible that: "After thread A change status from HALF_OPEN to CLOSED in markSuccess, thread B changed status from CLOSED to OPEN before thread A had a chance to reset the HealthCountsStream"