### PR TITLE
Stabilize tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+addons:
+  apt:
+    packages:
+      - lynx
+
 language: java
 sudo: false
 
@@ -6,3 +11,6 @@ jdk:
 
 script:
   - ./gradlew --info check
+
+after_failure:
+  - if [ -f /home/travis/build/Netflix/Hystrix/hystrix-core/build/reports/tests/test/index.html ]; then lynx -dump /home/travis/build/Netflix/Hystrix/hystrix-core/build/reports/tests/test/index.html; fi

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystricsMetricsControllerTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystricsMetricsControllerTest.java
@@ -92,42 +92,56 @@ public class HystricsMetricsControllerTest extends JerseyTest {
 	public void testInfiniteStream() throws Exception {
 		executeHystrixCommand(); // Execute a Hystrix command so that metrics are initialized.
 		EventInput stream = getStream(); // Invoke Stream API which returns a steady stream output.
-		validateStream(stream, 1000); // Validate the stream.
-		System.out.println("Validated Stream Output 1");
-		executeHystrixCommand(); // Execute Hystrix Command again so that request count is updated.
-		validateStream(stream, 1000); // Stream should show updated request count
-		System.out.println("Validated Stream Output 2");
-		stream.close();
+		try {
+			validateStream(stream, 1000); // Validate the stream.
+			System.out.println("Validated Stream Output 1");
+			executeHystrixCommand(); // Execute Hystrix Command again so that request count is updated.
+			validateStream(stream, 1000); // Stream should show updated request count
+			System.out.println("Validated Stream Output 2");
+		} finally {
+			if (stream != null) {
+				stream.close();
+			}
+		}
 	}
 
 	@Test
 	public void testConcurrency() throws Exception {
 		executeHystrixCommand(); // Execute a Hystrix command so that metrics are initialized.
 		List<EventInput> streamList = new ArrayList<EventInput>();
-		// Fire 5 requests, validate their responses and hold these connections.
-		for (int i = 0; i < 5; i++) {
-			EventInput stream = getStream();
-			System.out.println("Received Response for Request#" + (i + 1));
-			streamList.add(stream);
-			validateStream(stream, 1000);
-			System.out.println("Validated Response#" + (i + 1));
-		}
-
-		// Sixth request should fail since max configured connection is 5.
 		try {
-			streamList.add(getStreamFailFast());
-			Assert.fail("Expected 'ServiceUnavailableException' but, request went through.");
-		} catch (ServiceUnavailableException e) {
-			System.out.println("Got ServiceUnavailableException as expected.");
+			// Fire 5 requests, validate their responses and hold these connections.
+			for (int i = 0; i < 5; i++) {
+				EventInput stream = getStream();
+				System.out.println("Received Response for Request#" + (i + 1));
+				streamList.add(stream);
+				validateStream(stream, 1000);
+				System.out.println("Validated Response#" + (i + 1));
+			}
+
+			// Sixth request should fail since max configured connection is 5.
+			try {
+				streamList.add(getStreamFailFast());
+				Assert.fail("Expected 'ServiceUnavailableException' but, request went through.");
+			} catch (ServiceUnavailableException e) {
+				System.out.println("Got ServiceUnavailableException as expected.");
+			}
+
+			// Close one of the connections
+			streamList.get(0).close();
+			streamList.remove(0);
+
+			// Try again after closing one of the connections. This request should go through.
+			EventInput eventInput = getStream();
+			streamList.add(eventInput);
+			validateStream(eventInput, 1000);
+		} finally {
+			for (EventInput stream : streamList) {
+				if (stream != null) {
+					stream.close();
+				}
+			}
 		}
-
-		// Close one of the connections
-		streamList.get(0).close();
-
-		// Try again after closing one of the connections. This request should go through.
-		EventInput eventInput = getStream();
-		streamList.add(eventInput);
-		validateStream(eventInput, 1000);
 
 	}
 

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystricsMetricsControllerTest.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/java/com/netflix/hystrix/contrib/metrics/controller/HystricsMetricsControllerTest.java
@@ -110,8 +110,8 @@ public class HystricsMetricsControllerTest extends JerseyTest {
 		executeHystrixCommand(); // Execute a Hystrix command so that metrics are initialized.
 		List<EventInput> streamList = new ArrayList<EventInput>();
 		try {
-			// Fire 5 requests, validate their responses and hold these connections.
-			for (int i = 0; i < 5; i++) {
+			// Fire 3 requests, validate their responses and hold these connections.
+			for (int i = 0; i < 3; i++) {
 				EventInput stream = getStream();
 				System.out.println("Received Response for Request#" + (i + 1));
 				streamList.add(stream);
@@ -119,7 +119,7 @@ public class HystricsMetricsControllerTest extends JerseyTest {
 				System.out.println("Validated Response#" + (i + 1));
 			}
 
-			// Sixth request should fail since max configured connection is 5.
+			// Fourth request should fail since max configured connection is 3.
 			try {
 				streamList.add(getStreamFailFast());
 				Assert.fail("Expected 'ServiceUnavailableException' but, request went through.");

--- a/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/resources/test.properties
+++ b/hystrix-contrib/hystrix-metrics-event-stream-jaxrs/src/test/resources/test.properties
@@ -1,3 +1,4 @@
 hystrix.stream.utilization.intervalInMilliseconds=10
 hystrix.stream.dashboard.intervalInMilliseconds=10
 hystrix.stream.config.intervalInMilliseconds=10
+hystrix.config.stream.maxConcurrentConnections=3

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -5434,7 +5434,6 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                     .setCircuitBreaker(circuitBreaker)
                     .setMetrics(circuitBreaker.metrics)
                     .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
-                            .withExecutionTimeoutEnabled(false)
                             .withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE)
                             .withCircuitBreakerEnabled(false))
                     .setExecutionSemaphore(semaphore));

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -1156,7 +1156,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         final CountDownLatch allTerminal = new CountDownLatch(1);
 
         Observable.merge(results)
-                .subscribeOn(Schedulers.computation())
+                .subscribeOn(Schedulers.newThread())
                 .subscribe(new Subscriber<Boolean>() {
                     @Override
                     public void onCompleted() {
@@ -2700,7 +2700,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         final LatchedSemaphoreCommand command2 = new LatchedSemaphoreCommand(circuitBreaker, semaphore, startLatch, sharedLatch);
 
         Observable<Boolean> merged = Observable.merge(command1.toObservable(), command2.toObservable())
-                .subscribeOn(Schedulers.computation());
+                .subscribeOn(Schedulers.newThread());
 
         final CountDownLatch terminal = new CountDownLatch(1);
 
@@ -5434,7 +5434,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                     .setCircuitBreaker(circuitBreaker)
                     .setMetrics(circuitBreaker.metrics)
                     .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
-                            .withExecutionTimeoutInMilliseconds(30000)
+                            .withExecutionTimeoutEnabled(false)
                             .withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE)
                             .withCircuitBreakerEnabled(false))
                     .setExecutionSemaphore(semaphore));
@@ -5461,7 +5461,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                         s.onCompleted();
                     }
                 }
-            }).subscribeOn(Schedulers.computation());
+            }).subscribeOn(Schedulers.newThread());
         }
 
         @Override

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -5434,6 +5434,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                     .setCircuitBreaker(circuitBreaker)
                     .setMetrics(circuitBreaker.metrics)
                     .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
+                            .withExecutionTimeoutInMilliseconds(30000)
                             .withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE)
                             .withCircuitBreakerEnabled(false))
                     .setExecutionSemaphore(semaphore));

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -5434,6 +5434,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                     .setCircuitBreaker(circuitBreaker)
                     .setMetrics(circuitBreaker.metrics)
                     .setCommandPropertiesDefaults(HystrixCommandPropertiesTest.getUnitTestPropertiesSetter()
+                            .withExecutionTimeoutEnabled(false)
                             .withExecutionIsolationStrategy(ExecutionIsolationStrategy.SEMAPHORE)
                             .withCircuitBreakerEnabled(false))
                     .setExecutionSemaphore(semaphore));

--- a/hystrix-core/src/test/java/com/netflix/hystrix/UnsubscribedTasksRequestCacheTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/UnsubscribedTasksRequestCacheTest.java
@@ -20,6 +20,8 @@ import com.netflix.hystrix.exception.HystrixRuntimeException;
 import com.netflix.hystrix.strategy.HystrixPlugins;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
 import com.netflix.hystrix.strategy.executionhook.HystrixCommandExecutionHook;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -72,6 +74,16 @@ public class UnsubscribedTasksRequestCacheTest {
         protected String getCacheKey() {
             return String.valueOf(value);
         }
+    }
+
+    @Before
+    public void init() {
+        HystrixPlugins.reset();
+    }
+
+    @After
+    public void reset() {
+        HystrixPlugins.reset();
     }
 
     @Test


### PR DESCRIPTION
Reset HystrixPlugins before and after test to avoid test failure when running after other tests

The test seems to run OK on its own, but if it's run in an “all tests” run, the test throws the following exception:

```
java.lang.IllegalStateException: Another strategy was already registered.

	at com.netflix.hystrix.strategy.HystrixPlugins.registerCommandExecutionHook(HystrixPlugins.java:328)
```

Calling `HystrixPlugins.reset()` before and after the test fixes this.