### PR TITLE
Remove cancelled work from the threadpool queue.

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
@@ -119,6 +119,7 @@ public class HystrixTimer {
         @Override
         public void clear() {
             super.clear();
+            INSTANCE.executor.get().getThreadPool().remove((Runnable) f);
             // stop this ScheduledFuture from any further executions
             f.cancel(false);
         }

--- a/hystrix-core/src/test/java/com/netflix/hystrix/util/HystrixTimerTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/util/HystrixTimerTest.java
@@ -207,6 +207,22 @@ public class HystrixTimerTest {
 
     }
 
+    @Test
+    public void testCancelledTasksInQueueGetRemoved() {
+        HystrixTimer timer = HystrixTimer.getInstance();
+        TestListener l1 = new TestListener(1000, "A");
+        Reference<TimerListener> l1ref = timer.addTimerListener(l1);
+
+        assertTrue(timer.executor.get().getThreadPool().getQueue().size() > 0);
+
+        l1ref.clear();
+
+        System.out.println("l1 ticks: " + l1.tickCount.get());
+        assertTrue(l1.tickCount.get() == 0);
+
+        assertTrue(timer.executor.get().getThreadPool().getQueue().size() == 0);
+    }
+
     private static class TestListener implements TimerListener {
 
         private final int interval;


### PR DESCRIPTION
when the ```ScheduledFuture``` is canceled, but the task is has not removed from the threadpool queue. there are very many instance in memory until fullgc.

![image](https://user-images.githubusercontent.com/5037807/39250680-f87052f2-48d3-11e8-8491-72e79cbb518d.png)
![image](https://user-images.githubusercontent.com/5037807/39250710-0ae273de-48d4-11e8-81d6-73478aab2a4d.png)
![image](https://user-images.githubusercontent.com/5037807/39250747-24ba3576-48d4-11e8-9981-5c960f05a2cf.png)

