### PR TITLE
Stabilize yet another test

### DIFF
--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -2493,6 +2493,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                         .withExecutionIsolationStrategy(ExecutionIsolationStrategy.THREAD)
                         .withExecutionTimeoutInMilliseconds(50));
 
+        final AtomicBoolean startedExecution = new AtomicBoolean();
         HystrixObservableCommand<String> command = new HystrixObservableCommand<String>(properties) {
             @Override
             protected Observable<String> construct() {
@@ -2500,6 +2501,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
                     @Override
                     public void call(Subscriber<? super String> t1) {
+                        startedExecution.set(true);
                         try {
                             Thread.sleep(2000);
                         } catch (InterruptedException e) {
@@ -2527,7 +2529,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals("expected fallback value", "timed-out", value);
 
         // Thread isolated
-        assertTrue(command.isExecutedInThread());
+        assertTrue(!startedExecution.get() || command.isExecutedInThread());
         assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());

--- a/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
+++ b/hystrix-core/src/test/java/com/netflix/hystrix/HystrixObservableCommandTest.java
@@ -2440,6 +2440,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
 
         System.out.println(">>>>> Begin: " + System.currentTimeMillis());
 
+        final AtomicBoolean startedExecution = new AtomicBoolean();
         HystrixObservableCommand<String> command = new HystrixObservableCommand<String>(properties) {
             @Override
             protected Observable<String> construct() {
@@ -2449,6 +2450,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
                     @Override
                     public void call(Subscriber<? super String> t1) {
                         try {
+                            startedExecution.set(true);
                             Thread.sleep(2000);
                         } catch (InterruptedException e) {
                             e.printStackTrace();
@@ -2477,7 +2479,7 @@ public class HystrixObservableCommandTest extends CommonHystrixCommandTests<Test
         assertEquals("expected fallback value", "timed-out", value);
 
         // Thread isolated
-        assertTrue(command.isExecutedInThread());
+        assertTrue(!startedExecution.get() || command.isExecutedInThread());
         assertNotNull(command.getExecutionException());
 
         assertEquals(0, command.metrics.getCurrentConcurrentExecutionCount());


### PR DESCRIPTION
This fix addresses the build failure that occurred in https://travis-ci.org/Netflix/Hystrix/builds/370693316

The test assumed that the command actually had time to start executing. However, there's some code being executed before the `executedInThread` property is set to `true` in `AbstractCommand`. The timeout can occur during that phase, so it's possible for the test to fail under high load.

The fix adds a check to see whether the command had a chance to run, and only then asserts that it was executed on a thread.

I verified the fix by stopping the executing thread via a breakpoint just before the call to `executionResult.setExecutedInThread()`. The test fails without the fix under these circumstances, but succeeds with the fix in place.

@timbozo I hope this is the one that will get the master build green, but of course there may be more flaky tests.