### PR TITLE
Implement the default constructor

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/exception/HystrixBadRequestException.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/exception/HystrixBadRequestException.java
@@ -28,6 +28,10 @@ public class HystrixBadRequestException extends RuntimeException {
 
     private static final long serialVersionUID = -8341452103561805856L;
 
+    public HystrixBadRequestException() {
+        super();
+    }
+
     public HystrixBadRequestException(String message) {
         super(message);
     }


### PR DESCRIPTION
There's not always a message, so implement the default constructor (just like RuntimeException does).