### PR TITLE
Fix the CommandThatFailsSilently sample

### DIFF
--- a/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandThatFailsSilently.java
+++ b/hystrix-examples/src/main/java/com/netflix/hystrix/examples/basic/CommandThatFailsSilently.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2012 Netflix, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,7 +44,7 @@ public class CommandThatFailsSilently extends HystrixCommand<List<String>> {
     @Override
     protected List<String> run() {
         if (throwException) {
-            throw new RuntimeException("failure from CommandThatFailsFast");
+            return getFallback();
         } else {
             ArrayList<String> values = new ArrayList<String>();
             values.add("success");


### PR DESCRIPTION
The CommandThatFailsSilently is supposed to return an empty list as a
fallback strategy, rather than throwing a RuntimeException.