### PR TITLE
update org.ow2.asm:asm to version 6.2

### DIFF
--- a/hystrix-contrib/hystrix-javanica/build.gradle
+++ b/hystrix-contrib/hystrix-javanica/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     compileApi 'com.google.guava:guava:15.0'
     compile 'org.apache.commons:commons-lang3:3.1'
     compileApi 'com.google.code.findbugs:jsr305:2.0.0'
-    compile 'org.ow2.asm:asm:5.0.4'
+    compile 'org.ow2.asm:asm:6.2'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile 'pl.pragmatists:JUnitParams:1.0.5'
     testCompile project(':hystrix-junit')


### PR DESCRIPTION
useful for using librairy under springboot 2