### PR TITLE
Add Failsafe as alternative for Hystrix users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 # Hystrix Status
 Hystrix is no longer in active development, and is currently in maintenance mode.
 
-Hystrix (at version 1.5.18) is stable enough to meet the needs of Netflix for our existing applications. Meanwhile, our focus has shifted towards more adaptive implementations that react to an application’s real time performance rather than pre-configured settings (for example, through [adaptive concurrency limits](https://medium.com/@NetflixTechBlog/performance-under-load-3e6fa9a60581)). For the cases where something like Hystrix makes sense, we intend to continue using Hystrix for existing applications, and to leverage open and active projects like [resilience4j](https://github.com/resilience4j/resilience4j) for new internal projects. We are beginning to recommend others do the same.
+Hystrix (at version 1.5.18) is stable enough to meet the needs of Netflix for our existing applications. Meanwhile, our focus has shifted towards more adaptive implementations that react to an application’s real time performance rather than pre-configured settings (for example, through [adaptive concurrency limits](https://medium.com/@NetflixTechBlog/performance-under-load-3e6fa9a60581)). For the cases where something like Hystrix makes sense, we intend to continue using Hystrix for existing applications, and to leverage open and active projects like [resilience4j](https://github.com/resilience4j/resilience4j) or [Failsafe](https://github.com/jhalterman/failsafe) for new internal projects. We are beginning to recommend others do the same.
 
 Netflix Hystrix is now officially in maintenance mode, with the following expectations to the greater community: 
 Netflix will no longer actively review issues, merge pull-requests, and release new versions of Hystrix. 


### PR DESCRIPTION
Since Hystrix is in maintenance mode, it would be great and appreciated if you'd mention Failsafe as another alternative for existing Failsafe users. 👍 