### PR TITLE
Hystrix Configuration Stream Fix

### DIFF
--- a/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/sample/stream/HystrixConfigurationJsonStream.java
+++ b/hystrix-contrib/hystrix-metrics-event-stream/src/main/java/com/netflix/hystrix/contrib/sample/stream/HystrixConfigurationJsonStream.java
@@ -105,7 +105,8 @@ public class HystrixConfigurationJsonStream {
         HystrixCommandConfiguration.HystrixCommandCircuitBreakerConfig circuitBreakerConfig = commandConfig.getCircuitBreakerConfig();
         json.writeBooleanField("enabled", circuitBreakerConfig.isEnabled());
         json.writeBooleanField("isForcedOpen", circuitBreakerConfig.isForceOpen());
-        json.writeBooleanField("isForcedClosed", circuitBreakerConfig.isForceOpen());
+        json.writeBooleanField("isForcedClosed", circuitBreakerConfig.
+                isForceClosed());
         json.writeNumberField("requestVolumeThreshold", circuitBreakerConfig.getRequestVolumeThreshold());
         json.writeNumberField("errorPercentageThreshold", circuitBreakerConfig.getErrorThresholdPercentage());
         json.writeNumberField("sleepInMilliseconds", circuitBreakerConfig.getSleepWindowInMilliseconds());


### PR DESCRIPTION
Match the json stream output for the circuitBreakConfig isForcedClosed to the correct internal state.

It had been erroneously matching isForcedClosed to the internal state of isForceOpen.