### PR TITLE
fix  HystrixTimer when it  initialize ScheduledThreadPoolExecutor does not set RemoveOnCancelPolicy for true

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
@@ -170,6 +170,7 @@ public class HystrixTimer {
             }
 
             executor = new ScheduledThreadPoolExecutor(coreSize, threadFactory);
+            this.executor.setRemoveOnCancelPolicy(true);
             initialized = true;
         }
 


### PR DESCRIPTION
set follow configurations for some command key:

hystrix.command.fallbackcmd.execution.isolation.thread.timeoutInMilliseconds = 1000000000
hystrix.command.fallbackcmd.execution.isolation.strategy = SEMAPHORE
hystrix.command.fallbackcmd.execution.isolation.semaphore.maxConcurrentRequests = 1000
hystrix.command.fallbackcmd.fallback.enabled = true
hystrix.command.fallbackcmd.circuitBreaker.enabled = true

when it  invoke TimerReference.clear(), it does not remove this thread from the queue in ScheduledThreadPoolExecutor,In the case of a large number of requests for long time under this hystrix command key will cause memory leak ,we encounter this problem at our production environment,it Influences service performance


