### PR TITLE
Fixed possible memory leak in ScheduledThreadPoolExecutor (HystrixTimer.java)

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
@@ -170,6 +170,7 @@ public class HystrixTimer {
             }
 
             executor = new ScheduledThreadPoolExecutor(coreSize, threadFactory);
+            executor.setRemoveOnCancelPolicy(true);
             initialized = true;
         }
 


### PR DESCRIPTION
Found what seems to be a possible memory leak inside HystrixTimer.java caused by **cancel** operations called on tasks inside a ScheduledThreadPoolExecutor.
The fix helped us and solved the leakage.
Tasks that were canceled due to timeouts were not removed from the scheduler queues unless **setRemoveOnCancelPolicy(true)** was called on that scheduler on initialization.
