### PR TITLE
hystrixtimer add removeOnCancelPolicy for ScheduledThreadPoolExecutor to void memory leak

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/util/HystrixTimer.java
@@ -170,6 +170,7 @@ public class HystrixTimer {
             }
 
             executor = new ScheduledThreadPoolExecutor(coreSize, threadFactory);
+            this.executor.setRemoveOnCancelPolicy(true);
             initialized = true;
         }
 


### PR DESCRIPTION
fix https://github.com/Netflix/Hystrix/issues/1998