### PR TITLE
fix typo 'HystrixContextSchedulerAction' class name

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextScheduler.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextScheduler.java
@@ -27,7 +27,7 @@ import com.netflix.hystrix.HystrixThreadPool;
 import com.netflix.hystrix.strategy.HystrixPlugins;
 
 /**
- * Wrap a {@link Scheduler} so that scheduled actions are wrapped with {@link HystrixContexSchedulerAction} so that
+ * Wrap a {@link Scheduler} so that scheduled actions are wrapped with {@link HystrixContextSchedulerAction} so that
  * the {@link HystrixRequestContext} is properly copied across threads (if they are used by the {@link Scheduler}).
  */
 public class HystrixContextScheduler extends Scheduler {
@@ -93,7 +93,7 @@ public class HystrixContextScheduler extends Scheduler {
                     throw new RejectedExecutionException("Rejected command because thread-pool queueSize is at rejection threshold.");
                 }
             }
-            return worker.schedule(new HystrixContexSchedulerAction(concurrencyStrategy, action), delayTime, unit);
+            return worker.schedule(new HystrixContextSchedulerAction(concurrencyStrategy, action), delayTime, unit);
         }
 
         @Override
@@ -103,7 +103,7 @@ public class HystrixContextScheduler extends Scheduler {
                     throw new RejectedExecutionException("Rejected command because thread-pool queueSize is at rejection threshold.");
                 }
             }
-            return worker.schedule(new HystrixContexSchedulerAction(concurrencyStrategy, action));
+            return worker.schedule(new HystrixContextSchedulerAction(concurrencyStrategy, action));
         }
 
     }

--- a/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextSchedulerAction.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/strategy/concurrency/HystrixContextSchedulerAction.java
@@ -30,17 +30,17 @@ import com.netflix.hystrix.strategy.HystrixPlugins;
  * 
  * @ExcludeFromJavadoc
  */
-public class HystrixContexSchedulerAction implements Action0 {
+public class HystrixContextSchedulerAction implements Action0 {
 
     private final Action0 actual;
     private final HystrixRequestContext parentThreadState;
     private final Callable<Void> c;
 
-    public HystrixContexSchedulerAction(Action0 action) {
+    public HystrixContextSchedulerAction(Action0 action) {
         this(HystrixPlugins.getInstance().getConcurrencyStrategy(), action);
     }
 
-    public HystrixContexSchedulerAction(final HystrixConcurrencyStrategy concurrencyStrategy, Action0 action) {
+    public HystrixContextSchedulerAction(final HystrixConcurrencyStrategy concurrencyStrategy, Action0 action) {
         this.actual = action;
         this.parentThreadState = HystrixRequestContext.getContextForCurrentThread();
 


### PR DESCRIPTION
I was looking at the Hystrix code and found a missing alphabet

HystrixContexSchedulerAction -> HystrixContextSchedulerAction

thank you