### PR TITLE
fix thread pool error

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPool.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixThreadPool.java
@@ -227,8 +227,8 @@ public interface HystrixThreadPool {
                             dynamicCoreSize + " and maximumSize = " + configuredMaximumSize + ".  Maximum size will be set to " +
                             dynamicMaximumSize + ", the coreSize value, since it must be equal to or greater than the coreSize value");
                 }
-                threadPool.setCorePoolSize(dynamicCoreSize);
                 threadPool.setMaximumPoolSize(dynamicMaximumSize);
+                threadPool.setCorePoolSize(dynamicCoreSize);
             }
 
             threadPool.setKeepAliveTime(properties.keepAliveTimeMinutes().get(), TimeUnit.MINUTES);


### PR DESCRIPTION
 When the thread pool is dynamically expanded, and current thread pool maximum size < dynamicCoreSize , will throw exception and stop the current process.  
So first need expand maximum size , then expand core size.