### PR TITLE
2017 | Upgrade of jackson from 2.7.5 to 2.10.5

### DIFF
--- a/hystrix-serialization/build.gradle
+++ b/hystrix-serialization/build.gradle
@@ -9,11 +9,10 @@ targetCompatibility = JavaVersion.VERSION_1_6
 dependencies {
     compileApi project(':hystrix-core')
 
-	//if we bump into the the 2.8.0 series, we are forced to use Java7
-    compileApi 'com.fasterxml.jackson.core:jackson-core:2.7.5'
-    compileApi 'com.fasterxml.jackson.core:jackson-databind:2.7.5'
-    compileApi 'com.fasterxml.jackson.core:jackson-annotations:2.7.5'
-    compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.7.5'
+    compileApi 'com.fasterxml.jackson.core:jackson-core:2.10.5'
+    compileApi 'com.fasterxml.jackson.core:jackson-databind:2.10.5'
+    compileApi 'com.fasterxml.jackson.core:jackson-annotations:2.10.5'
+    compile 'com.fasterxml.jackson.module:jackson-module-afterburner:2.10.5'
 	
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-all:1.9.5'


### PR DESCRIPTION
This resolves issue https://github.com/Netflix/Hystrix/issues/2017