### PR TITLE
Update settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name='hystrix'
+rootProject.name='Hystrix'
 include 'hystrix-core', \
 'hystrix-examples', \
 'hystrix-examples-webapp', \


### PR DESCRIPTION
When I cloned this repo, the gradle is not able to build and gives an error that 'did not find the the module hystrix' due to case sensitivity.

Changing that to match the repo name.