### PR TITLE
percentage shouldn't go beyond 100 to keep the circuits closed on 100% error rate

### DIFF
--- a/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
+++ b/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java
@@ -183,7 +183,7 @@ public interface HystrixCircuitBreaker {
                                 // if it was half-open, we need to wait for a successful command execution
                                 // if it was open, we need to wait for sleep window to elapse
                             } else {
-                                if (hc.getErrorPercentage() < properties.circuitBreakerErrorThresholdPercentage().get()) {
+                                if (hc.getErrorPercentage() <= properties.circuitBreakerErrorThresholdPercentage().get()) {
                                     //we are not past the minimum error threshold for the stat window,
                                     // so no change to circuit status.
                                     // if it was CLOSED, it stays CLOSED


### PR DESCRIPTION
circuitBreakerErrorThresholdPercentage is a number but as per the name it should be treated like a percentage. Defining a percentage over 100 doesn't make sense. 
So if someone is defining this property as 100, that person would be expecting circuits to not open at all. We do have other properties with which we can keep the circuit forcefully closed/open but many teams write wrapper over hystrix to only let devs access the basic ones and it is expected the basic properties will suffice for all different scenarios.

We were trying to keep the circuits closed at 100% failure rate using `circuitBreakerErrorThresholdPercentage` and we failed. We didn't want to make circuitBreakerErrorThresholdPercentage 101 and then check for the circuit remaining closed as a percentage over 100 didn't sound about right.
Can we please see if this change makes sense?